### PR TITLE
Add Card component

### DIFF
--- a/packages/adaptive-web-components/.storybook/preview.js
+++ b/packages/adaptive-web-components/.storybook/preview.js
@@ -1,5 +1,6 @@
 import { DesignToken } from "@microsoft/fast-foundation";
 
+import "../src/components/card/define";
 import "../src/components/toolbar/define";
 
 DesignToken.registerDefaultStyleTarget();

--- a/packages/adaptive-web-components/src/components/card/card.definition.ts
+++ b/packages/adaptive-web-components/src/components/card/card.definition.ts
@@ -1,0 +1,20 @@
+import { FASTCard } from "@microsoft/fast-foundation";
+import type { DesignSystem } from "../../design-system.js";
+import { styles } from "./card.styles.js";
+import { template } from "./card.template.js";
+
+/**
+ * The Card custom element definition. Implements {@link @microsoft/fast-foundation#FASTCard}.
+ *
+ * @remarks
+ * HTML Element: \<adaptive-card\>
+ *
+ * @public
+ */
+export const definition = (ds: DesignSystem) =>
+    FASTCard.compose({
+        name: `${ds.prefix}-card`,
+        registry: ds.registry,
+        template: template(ds),
+        styles,
+    });

--- a/packages/adaptive-web-components/src/components/card/card.stories.ts
+++ b/packages/adaptive-web-components/src/components/card/card.stories.ts
@@ -1,0 +1,30 @@
+import { html } from "@microsoft/fast-element";
+import type { FASTCard } from "@microsoft/fast-foundation";
+import { renderComponent } from "../../utilities/storybook-helpers.js";
+import type { Meta, Story, StoryArgs } from "../../utilities/storybook-helpers.js";
+
+const storyTemplate = html<StoryArgs<FASTCard>>`
+    <adaptive-card>
+        ${(x) => x?.content}
+    </adaptive-card>
+`;
+
+export default {
+    title: "Components/Card",
+    args: {
+        content: "Pick a card",
+    },
+} as Meta<FASTCard>;
+
+export const Card: Story<FASTCard> = renderComponent(storyTemplate).bind({});
+
+export const CardWithCustomDimensions = renderComponent(storyTemplate).bind({});
+CardWithCustomDimensions.decorators = [
+    (Story: () => FASTCard) => {
+        const renderedStory = Story() as FASTCard;
+        renderedStory.style.setProperty("--card-height", "400px");
+        renderedStory.style.setProperty("--card-width", "500px");
+        renderedStory.style.setProperty("padding", "20px");
+        return renderedStory;
+    },
+];

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -1,0 +1,56 @@
+import {
+    elevationCardFocus,
+    elevationCardHover,
+    elevationCardRest,
+    fillColor,
+    layerCornerRadius,
+    neutralForegroundRest,
+} from "@adaptive-web/adaptive-ui";
+import { css, ElementStyles } from "@microsoft/fast-element";
+
+/**
+ * Basic layout styling associated with the anatomy of the template.
+ */
+export const templateStyles: ElementStyles = css`
+    :host([hidden]) {
+        display: none;
+    }
+
+    :host {
+        display: block;
+        contain: content;
+        content-visibility: auto;
+    }
+`;
+
+/**
+ * Visual styles including Adaptive UI tokens.
+ */
+export const aestheticStyles: ElementStyles = css`
+    :host {
+        height: var(--card-height, 100%);
+        width: var(--card-width, 100%);
+        box-sizing: border-box;
+        background: ${fillColor};
+        color: ${neutralForegroundRest};
+        border-radius: calc(${layerCornerRadius} * 1px);
+        box-shadow: ${elevationCardRest}
+    }
+
+    :host(:hover) {
+        box-shadow: ${elevationCardHover}
+    }
+
+    :host(:focus-within) {
+        box-shadow: ${elevationCardFocus}
+    }
+`;
+
+/**
+ * Default Adaptive UI Card styles.
+ */
+export const styles: ElementStyles = css`
+    ${templateStyles}
+
+    ${aestheticStyles}
+`;

--- a/packages/adaptive-web-components/src/components/card/card.template.ts
+++ b/packages/adaptive-web-components/src/components/card/card.template.ts
@@ -1,0 +1,10 @@
+import { ElementViewTemplate } from "@microsoft/fast-element";
+import { cardTemplate, FASTCard } from "@microsoft/fast-foundation";
+import { DesignSystem } from "../../design-system.js";
+
+/**
+ * Default Card template, {@link @microsoft/fast-foundation#cardTemplate}.
+ */
+export const template: (ds: DesignSystem) => ElementViewTemplate<FASTCard> =
+    (ds: DesignSystem) =>
+        cardTemplate();

--- a/packages/adaptive-web-components/src/components/card/define.ts
+++ b/packages/adaptive-web-components/src/components/card/define.ts
@@ -1,0 +1,4 @@
+import { DefaultDesignSystem } from "../../design-system.js";
+import { definition } from "./card.definition.js";
+
+definition(DefaultDesignSystem).define();

--- a/packages/adaptive-web-components/src/components/card/index.ts
+++ b/packages/adaptive-web-components/src/components/card/index.ts
@@ -1,0 +1,7 @@
+export { definition as CardDefinition } from "./card.definition.js";
+export {
+    templateStyles as CardTemplateStyles,
+    aestheticStyles as CardAestheticStyles,
+    styles as CardStyles,
+} from "./card.styles.js";
+export { template as CardTemplate } from "./card.template.js";

--- a/packages/adaptive-web-components/src/components/index.ts
+++ b/packages/adaptive-web-components/src/components/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Export all custom element definitions.
+ */
+export * from "./card/index.js";
 export * from "./toolbar/index.js";

--- a/packages/adaptive-web-components/src/components/toolbar/index.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/index.ts
@@ -1,3 +1,7 @@
-export { template as ToolbarTemplate } from "./toolbar.template.js";
-export { styles as ToolbarStyles } from "./toolbar.styles.js";
 export { definition as ToolbarDefinition } from "./toolbar.definition.js";
+export {
+    templateStyles as ToolbarTemplateStyles,
+    aestheticStyles as ToolbarAestheticStyles,
+    styles as ToolbarStyles,
+} from "./toolbar.styles.js";
+export { template as ToolbarTemplate } from "./toolbar.template.js";

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.definition.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.definition.ts
@@ -4,7 +4,7 @@ import { styles } from "./toolbar.styles.js";
 import { template } from "./toolbar.template.js";
 
 /**
- * The Toolbar Custom Element. Implements {@link @microsoft/fast-foundation#FASTToolbar}.
+ * The Toolbar custom element definition. Implements {@link @microsoft/fast-foundation#FASTToolbar}.
  *
  * @remarks
  * HTML Element: \<adaptive-toolbar\>
@@ -15,8 +15,8 @@ export const definition = (ds: DesignSystem) =>
     FASTToolbar.compose({
         name: `${ds.prefix}-toolbar`,
         registry: ds.registry,
+        template: template(ds),
         styles,
-        template,
         shadowOptions: {
             delegatesFocus: true,
         },

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.stories.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.stories.ts
@@ -1,19 +1,23 @@
 import { html } from "@microsoft/fast-element";
 import type { FASTToolbar } from "@microsoft/fast-foundation";
 import { Orientation } from "@microsoft/fast-web-utilities";
-import { Meta, renderComponent, StoryArgs } from "../../utilities/storybook-helpers.js";
+import { renderComponent } from "../../utilities/storybook-helpers.js";
+import type { Meta, StoryArgs } from "../../utilities/storybook-helpers.js";
 
 const componentTemplate = html<StoryArgs<FASTToolbar>>`
-    <adaptive-toolbar orientation="${(x) => x.orientation}">${(x) => x.content}</adaptive-toolbar>
+    <adaptive-toolbar
+        orientation="${(x) => x.orientation}"
+    >
+        ${(x) => x.content}
+    </adaptive-toolbar>
 `;
 
 export default {
     title: "Components/Toolbar",
     args: {
         content: html`
-            <button>Button</button>
-            <button slot="end">End Slot Button</button>
             <button slot="start">Start Slot Button</button>
+            <button>Button</button>
             <select>
                 <option>Option 1</option>
                 <option>Second option</option>
@@ -32,6 +36,7 @@ export default {
                 Checkbox 3
             </label>
             <input type="text" name="text" id="text-input" />
+            <button slot="end">End Slot Button</button>
         `,
         orientation: Orientation.horizontal,
     },

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -1,33 +1,29 @@
-import { designUnit, focusStrokeWidth, neutralStrokeFocus } from "@adaptive-web/adaptive-ui";
+import { focusStrokeWidth, neutralForegroundRest, neutralStrokeFocus } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
- * Default Adaptive UI Toolbar styles.
+ * Basic layout styling associated with the anatomy of the template.
  */
-export const styles: ElementStyles = css`
+export const templateStyles: ElementStyles = css`
     :host([hidden]) {
         display: none;
     }
 
     :host {
-        --toolbar-item-gap: calc(${designUnit} * 1px);
         display: inline-flex;
-        fill: currentcolor;
-        padding: var(--toolbar-item-gap);
-        box-sizing: border-box;
         align-items: center;
     }
 
-    :host(:focus-visible) {
-        outline: calc(${focusStrokeWidth} * 1px) solid ${neutralStrokeFocus};
+    :host([orientation="vertical"]) {
+        flex-direction: column;
     }
 
     .positioning-region {
-        align-items: center;
         display: inline-flex;
-        flex-flow: row wrap;
-        justify-content: flex-start;
         flex-grow: 1;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-start;
     }
 
     :host([orientation="vertical"]) .positioning-region {
@@ -35,27 +31,36 @@ export const styles: ElementStyles = css`
         align-items: start;
     }
 
-    ::slotted(:not([slot])) {
-        flex: 0 0 auto;
-        margin: 0 var(--toolbar-item-gap);
-    }
-
-    :host([orientation="vertical"]) ::slotted(:not([slot])) {
-        margin: var(--toolbar-item-gap) 0;
-    }
-
-    :host([orientation="vertical"]) {
-        display: inline-flex;
-        flex-direction: column;
-    }
-
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
         display: flex;
-        align-items: center;
+    }
+`;
+
+/**
+ * Visual styles including Adaptive UI tokens.
+ */
+export const aestheticStyles: ElementStyles = css`
+    :host {
+        gap: 8px;
+        color: ${neutralForegroundRest};
+        fill: currentcolor;
     }
 
-    ::slotted([slot="end"]) {
-        margin-inline-start: auto;
+    :host(:focus-visible) {
+        outline: calc(${focusStrokeWidth} * 1px) solid ${neutralStrokeFocus};
     }
+
+    .positioning-region {
+        gap: 8px;
+    }
+`;
+
+/**
+ * Default Adaptive UI Toolbar styles.
+ */
+export const styles: ElementStyles = css`
+    ${templateStyles}
+
+    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
@@ -1,7 +1,10 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTToolbar, toolbarTemplate } from "@microsoft/fast-foundation";
+import { DesignSystem } from "../../design-system.js";
 
 /**
  * Default Toolbar template, {@link @microsoft/fast-foundation#toolbarTemplate}.
  */
-export const template: ElementViewTemplate<FASTToolbar> = toolbarTemplate();
+export const template: (ds: DesignSystem) => ElementViewTemplate<FASTToolbar> =
+    (ds: DesignSystem) =>
+        toolbarTemplate();


### PR DESCRIPTION
Added the Card component and cleaned up style pattern. The idea of separating out the template structure from the visual decisions is the basis for the next phase of Adaptive UI. Over time the `aesthetic` styles will be migrated to a declarative model and generated.

Wanted to get initial thoughts on this, even though I realize the full vision isn't clear from this PR. After this I'll do a large batch of most components, not individually.