### PR TITLE
Remove unnecessary css variables for Card size

### DIFF
--- a/packages/adaptive-web-components/src/components/card/card.stories.ts
+++ b/packages/adaptive-web-components/src/components/card/card.stories.ts
@@ -1,4 +1,4 @@
-import { css, html } from "@microsoft/fast-element";
+import { html } from "@microsoft/fast-element";
 import type { FASTCard } from "@microsoft/fast-foundation";
 import { renderComponent } from "../../utilities/storybook-helpers.js";
 import type { Meta, Story, StoryArgs } from "../../utilities/storybook-helpers.js";
@@ -22,8 +22,8 @@ export const CardWithCustomDimensions = renderComponent(storyTemplate).bind({});
 CardWithCustomDimensions.decorators = [
     (Story: () => FASTCard) => {
         const renderedStory = Story() as FASTCard;
-        renderedStory.style.setProperty("--card-height", "400px");
-        renderedStory.style.setProperty("--card-width", "500px");
+        renderedStory.style.setProperty("height", "400px");
+        renderedStory.style.setProperty("width", "500px");
         renderedStory.style.setProperty("padding", "20px");
         return renderedStory;
     },
@@ -38,17 +38,11 @@ CardWithControls.args = {
 CardWithControls.decorators = [
     (Story: () => FASTCard) => {
         const renderedStory = Story() as FASTCard;
-        const style = css`
-            :host {
-                --card-height: 400px;
-                --card-width: 500px;
-                display: flex;
-                flex-direction: column;
-                padding: 20px;
-            }
-        `;
-
-        renderedStory.$fastController.addStyles(style);
+        renderedStory.style.setProperty("height", "400px");
+        renderedStory.style.setProperty("width", "500px");
+        renderedStory.style.setProperty("display", "flex");
+        renderedStory.style.setProperty("flex-direction", "column");
+        renderedStory.style.setProperty("padding", "20px");
         return renderedStory;
     },
 ];

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -26,9 +26,9 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        height: var(--card-height, 100%);
-        width: var(--card-width, 100%);
         box-sizing: border-box;
+        height: 100%;
+        width: 100%;
         background: ${fillColor};
         color: ${neutralForegroundRest};
         border-radius: calc(${layerCornerRadius} * 1px);


### PR DESCRIPTION
Favoring setting css attributes directly on light dom where applicable.