### PR TITLE
Add initial cem config and scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,6 +1897,124 @@
                 "node": ">=0.1.90"
             }
         },
+        "node_modules/@custom-elements-manifest/analyzer": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.6.8.tgz",
+            "integrity": "sha512-Wy5CiMUq9njT6vbeEPi7Zjm7OcVmL+5zyJXUam5TZe13QVnsn/m3VaJx8aqMecTp1m/pFNCL4QGJpYV/oZYIkg==",
+            "dev": true,
+            "dependencies": {
+                "@custom-elements-manifest/find-dependencies": "^0.0.5",
+                "@github/catalyst": "^1.6.0",
+                "@web/config-loader": "0.1.3",
+                "chokidar": "3.5.2",
+                "command-line-args": "5.1.2",
+                "comment-parser": "1.2.4",
+                "custom-elements-manifest": "1.0.0",
+                "debounce": "1.2.1",
+                "globby": "11.0.4",
+                "typescript": "~4.3.2"
+            },
+            "bin": {
+                "cem": "cem.js",
+                "custom-elements-manifest": "cem.js"
+            }
+        },
+        "node_modules/@custom-elements-manifest/analyzer/node_modules/chokidar": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "dev": true,
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/@custom-elements-manifest/analyzer/node_modules/globby": {
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+            "dev": true,
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@custom-elements-manifest/analyzer/node_modules/typescript": {
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/@custom-elements-manifest/find-dependencies": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/find-dependencies/-/find-dependencies-0.0.5.tgz",
+            "integrity": "sha512-fKIMMZCDFSoL2ySUoz8knWgpV4jpb0lUXgLOvdZQMQFHxgxz1PqOJpUIypwvEVyKk3nEHRY4f10gNol02HjeCg==",
+            "dev": true,
+            "dependencies": {
+                "es-module-lexer": "^0.9.3"
+            }
+        },
+        "node_modules/@custom-elements-manifest/to-markdown": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/to-markdown/-/to-markdown-0.1.0.tgz",
+            "integrity": "sha512-Bq7ppygs7H0Mbrhuj23cfwWC4krw+ZWQAmIvOYBSbt0xQVWpkDxxXlX1xdgvEEHE2vDxThPELW2VvlUYf0DKjw==",
+            "dev": true,
+            "dependencies": {
+                "mdast-builder": "^1.1.1",
+                "mdast-util-from-markdown": "^1.0.4",
+                "mdast-util-gfm": "^1.0.0",
+                "mdast-util-to-markdown": "^1.0.1",
+                "remark-gfm": "^1.0.0",
+                "remark-stringify": "^9.0.1",
+                "unified": "^9.2.1"
+            }
+        },
+        "node_modules/@custom-elements-manifest/to-markdown/node_modules/unified": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+            "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+            "dev": true,
+            "dependencies": {
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^2.0.0",
+                "trough": "^1.0.0",
+                "vfile": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1984,6 +2102,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+            "dev": true
+        },
+        "node_modules/@github/catalyst": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
+            "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
             "dev": true
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -6246,6 +6370,15 @@
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
+        "node_modules/@types/debug": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "dev": true,
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.4.10",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -6373,6 +6506,12 @@
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
             "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+            "dev": true
+        },
+        "node_modules/@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -6843,6 +6982,51 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@web/config-loader": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
+            "integrity": "sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==",
+            "dev": true,
+            "dependencies": {
+                "semver": "^7.3.4"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@web/config-loader/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@web/config-loader/node_modules/semver": {
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@web/config-loader/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.9.0",
@@ -7316,6 +7500,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/array-back": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.17"
             }
         },
         "node_modules/array-find-index": {
@@ -8948,6 +9141,21 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/command-line-args": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
+            "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
+            "dev": true,
+            "dependencies": {
+                "array-back": "^6.1.2",
+                "find-replace": "^3.0.0",
+                "lodash.camelcase": "^4.3.0",
+                "typical": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/commander": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -8955,6 +9163,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/comment-parser": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+            "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/commondir": {
@@ -9777,10 +9994,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/custom-elements-manifest": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz",
+            "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
+            "dev": true
+        },
         "node_modules/cyclist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
             "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
+            "dev": true
+        },
+        "node_modules/debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
             "dev": true
         },
         "node_modules/debug": {
@@ -9808,6 +10037,29 @@
             "optional": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "dev": true,
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/decode-named-character-reference/node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/decode-uri-component": {
@@ -9924,6 +10176,15 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/des.js": {
@@ -11548,6 +11809,27 @@
             "dependencies": {
                 "find-up": "^3.0.0"
             },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/find-replace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "dev": true,
+            "dependencies": {
+                "array-back": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/find-replace/node_modules/array-back": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14035,6 +14317,12 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true
+        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14137,6 +14425,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/loose-envify": {
@@ -14282,6 +14580,16 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/markdown-table": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -14291,6 +14599,15 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/mdast-builder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-builder/-/mdast-builder-1.1.1.tgz",
+            "integrity": "sha512-a3KBk/LmYD6wKsWi8WJrGU/rXR4yuF4Men0JO0z6dSZCm5FrXXWTRDjqK0vGSqa+1M6p9edeuypZAZAzSehTUw==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.3"
             }
         },
         "node_modules/mdast-squeeze-paragraphs": {
@@ -14319,6 +14636,218 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+            "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/unist-util-is": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+            "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/unist-util-visit-parents": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
+            "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "mdast-util-to-string": "^3.1.0",
+                "micromark": "^3.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "uvu": "^0.5.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
+            "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-1.0.0.tgz",
+            "integrity": "sha512-JY4qImsTqivQ0Gl3qvdaizCpomFaNrHnjEhNjNNKeNEA5jZHAJDYu1+yO4V9jn4/ti8GrKdAScaT4F71knoxsA==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-gfm-autolink-literal": "^1.0.0",
+                "mdast-util-gfm-strikethrough": "^1.0.0",
+                "mdast-util-gfm-table": "^1.0.0",
+                "mdast-util-gfm-task-list-item": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+            "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "ccount": "^2.0.0",
+                "mdast-util-find-and-replace": "^2.0.0",
+                "micromark-util-character": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal/node_modules/ccount": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+            "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+            "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^1.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+            "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+            "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "unist-util-is": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+            "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/mdast-util-to-hast": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz",
@@ -14337,6 +14866,88 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+            "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^3.0.0",
+                "mdast-util-to-string": "^3.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "unist-util-visit": "^4.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
+            "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
+            "dev": true,
+            "dependencies": {
+                "@types/mdast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown/node_modules/unist-util-is": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+            "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+            "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.1.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit-parents": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown/node_modules/zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/mdast-util-to-string": {
@@ -14588,6 +15199,629 @@
             "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
             "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
             "dev": true
+        },
+        "node_modules/micromark": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
+            "integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-core-commonmark": "^1.0.1",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-combine-extensions": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-sanitize-uri": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
+            "integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-factory-destination": "^1.0.0",
+                "micromark-factory-label": "^1.0.0",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-factory-title": "^1.0.0",
+                "micromark-factory-whitespace": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-classify-character": "^1.0.0",
+                "micromark-util-html-tag-name": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+            "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+            "dev": true,
+            "dependencies": {
+                "micromark": "~2.11.0",
+                "micromark-extension-gfm-autolink-literal": "~0.5.0",
+                "micromark-extension-gfm-strikethrough": "~0.6.5",
+                "micromark-extension-gfm-table": "~0.4.0",
+                "micromark-extension-gfm-tagfilter": "~0.3.0",
+                "micromark-extension-gfm-task-list-item": "~0.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+            "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+            "dev": true,
+            "dependencies": {
+                "micromark": "~2.11.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+            "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+            "dev": true,
+            "dependencies": {
+                "micromark": "~2.11.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+            "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+            "dev": true,
+            "dependencies": {
+                "micromark": "~2.11.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+            "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+            "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+            "dev": true,
+            "dependencies": {
+                "micromark": "~2.11.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+            "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+            "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+            "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+            "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+            "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+            "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+            "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+            "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+            "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+            "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+            "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
+            "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
+            "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+            "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+            "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
+            "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+            "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+            "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
+        },
+        "node_modules/micromark-util-types": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
+            "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ]
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
@@ -15049,6 +16283,15 @@
             },
             "bin": {
                 "rimraf": "bin.js"
+            }
+        },
+        "node_modules/mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/ms": {
@@ -17024,6 +18267,190 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/remark-gfm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+            "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-gfm": "^0.1.0",
+                "micromark-extension-gfm": "^0.3.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/longest-streak": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+            "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/markdown-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+            "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+            "dev": true,
+            "dependencies": {
+                "repeat-string": "^1.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-find-and-replace": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+            "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+            "dev": true,
+            "dependencies": {
+                "escape-string-regexp": "^4.0.0",
+                "unist-util-is": "^4.0.0",
+                "unist-util-visit-parents": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-gfm": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+            "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-gfm-autolink-literal": "^0.1.0",
+                "mdast-util-gfm-strikethrough": "^0.2.0",
+                "mdast-util-gfm-table": "^0.1.0",
+                "mdast-util-gfm-task-list-item": "^0.1.0",
+                "mdast-util-to-markdown": "^0.6.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+            "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+            "dev": true,
+            "dependencies": {
+                "ccount": "^1.0.0",
+                "mdast-util-find-and-replace": "^1.1.0",
+                "micromark": "^2.11.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-gfm-strikethrough": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+            "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-to-markdown": "^0.6.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-gfm-table": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+            "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+            "dev": true,
+            "dependencies": {
+                "markdown-table": "^2.0.0",
+                "mdast-util-to-markdown": "~0.6.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-gfm-task-list-item": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+            "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-to-markdown": "~0.6.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-to-markdown": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+            "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "longest-streak": "^2.0.0",
+                "mdast-util-to-string": "^2.0.0",
+                "parse-entities": "^2.0.0",
+                "repeat-string": "^1.0.0",
+                "zwitch": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/mdast-util-to-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-gfm/node_modules/micromark": {
+            "version": "2.11.4",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "dependencies": {
+                "debug": "^4.0.0",
+                "parse-entities": "^2.0.0"
+            }
+        },
         "node_modules/remark-mdx": {
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.22.tgz",
@@ -17176,6 +18603,57 @@
             "dependencies": {
                 "mdast-squeeze-paragraphs": "^4.0.0"
             },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+            "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+            "dev": true,
+            "dependencies": {
+                "mdast-util-to-markdown": "^0.6.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify/node_modules/longest-streak": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+            "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/remark-stringify/node_modules/mdast-util-to-markdown": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+            "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "longest-streak": "^2.0.0",
+                "mdast-util-to-string": "^2.0.0",
+                "parse-entities": "^2.0.0",
+                "repeat-string": "^1.0.0",
+                "zwitch": "^1.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify/node_modules/mdast-util-to-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+            "dev": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
@@ -17405,6 +18883,18 @@
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
             "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
             "dev": true
+        },
+        "node_modules/sade": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+            "dev": true,
+            "dependencies": {
+                "mri": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -19615,6 +21105,15 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/typical": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+            "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/uglify-js": {
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -20146,6 +21645,33 @@
             "resolved": "https://registry.npmjs.org/uuid-browser/-/uuid-browser-3.1.0.tgz",
             "integrity": "sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==",
             "dev": true
+        },
+        "node_modules/uvu": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+            "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+            "dev": true,
+            "dependencies": {
+                "dequal": "^2.0.0",
+                "diff": "^5.0.0",
+                "kleur": "^4.0.3",
+                "sade": "^1.7.3"
+            },
+            "bin": {
+                "uvu": "bin.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/uvu/node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -21364,6 +22890,8 @@
             },
             "devDependencies": {
                 "@babel/core": "^7.20.12",
+                "@custom-elements-manifest/analyzer": "^0.6.8",
+                "@custom-elements-manifest/to-markdown": "^0.1.0",
                 "@storybook/addon-actions": "^6.5.15",
                 "@storybook/addon-essentials": "^6.5.15",
                 "@storybook/addon-links": "^6.5.15",
@@ -21403,6 +22931,8 @@
             "requires": {
                 "@adaptive-web/adaptive-ui": "^0.0.1",
                 "@babel/core": "^7.20.12",
+                "@custom-elements-manifest/analyzer": "^0.6.8",
+                "@custom-elements-manifest/to-markdown": "*",
                 "@fluentui/svg-icons": "^1.1.192",
                 "@microsoft/fast-element": "2.0.0-beta.20",
                 "@microsoft/fast-foundation": "3.0.0-alpha.24",
@@ -22712,6 +24242,102 @@
             "dev": true,
             "optional": true
         },
+        "@custom-elements-manifest/analyzer": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.6.8.tgz",
+            "integrity": "sha512-Wy5CiMUq9njT6vbeEPi7Zjm7OcVmL+5zyJXUam5TZe13QVnsn/m3VaJx8aqMecTp1m/pFNCL4QGJpYV/oZYIkg==",
+            "dev": true,
+            "requires": {
+                "@custom-elements-manifest/find-dependencies": "^0.0.5",
+                "@github/catalyst": "^1.6.0",
+                "@web/config-loader": "0.1.3",
+                "chokidar": "3.5.2",
+                "command-line-args": "5.1.2",
+                "comment-parser": "1.2.4",
+                "custom-elements-manifest": "1.0.0",
+                "debounce": "1.2.1",
+                "globby": "11.0.4",
+                "typescript": "~4.3.2"
+            },
+            "dependencies": {
+                "chokidar": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+                    "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "~3.1.2",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.2",
+                        "glob-parent": "~5.1.2",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.6.0"
+                    }
+                },
+                "globby": {
+                    "version": "11.0.4",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+                    "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^2.1.0",
+                        "dir-glob": "^3.0.1",
+                        "fast-glob": "^3.1.1",
+                        "ignore": "^5.1.4",
+                        "merge2": "^1.3.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "typescript": {
+                    "version": "4.3.5",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+                    "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+                    "dev": true
+                }
+            }
+        },
+        "@custom-elements-manifest/find-dependencies": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/find-dependencies/-/find-dependencies-0.0.5.tgz",
+            "integrity": "sha512-fKIMMZCDFSoL2ySUoz8knWgpV4jpb0lUXgLOvdZQMQFHxgxz1PqOJpUIypwvEVyKk3nEHRY4f10gNol02HjeCg==",
+            "dev": true,
+            "requires": {
+                "es-module-lexer": "^0.9.3"
+            }
+        },
+        "@custom-elements-manifest/to-markdown": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@custom-elements-manifest/to-markdown/-/to-markdown-0.1.0.tgz",
+            "integrity": "sha512-Bq7ppygs7H0Mbrhuj23cfwWC4krw+ZWQAmIvOYBSbt0xQVWpkDxxXlX1xdgvEEHE2vDxThPELW2VvlUYf0DKjw==",
+            "dev": true,
+            "requires": {
+                "mdast-builder": "^1.1.1",
+                "mdast-util-from-markdown": "^1.0.4",
+                "mdast-util-gfm": "^1.0.0",
+                "mdast-util-to-markdown": "^1.0.1",
+                "remark-gfm": "^1.0.0",
+                "remark-stringify": "^9.0.1",
+                "unified": "^9.2.1"
+            },
+            "dependencies": {
+                "unified": {
+                    "version": "9.2.2",
+                    "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
+                    "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+                    "dev": true,
+                    "requires": {
+                        "bail": "^1.0.0",
+                        "extend": "^3.0.0",
+                        "is-buffer": "^2.0.0",
+                        "is-plain-obj": "^2.0.0",
+                        "trough": "^1.0.0",
+                        "vfile": "^4.0.0"
+                    }
+                }
+            }
+        },
         "@discoveryjs/json-ext": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -22783,6 +24409,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
             "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+            "dev": true
+        },
+        "@github/catalyst": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
+            "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
             "dev": true
         },
         "@humanwhocodes/config-array": {
@@ -25952,6 +27584,15 @@
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
+        "@types/debug": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "dev": true,
+            "requires": {
+                "@types/ms": "*"
+            }
+        },
         "@types/eslint": {
             "version": "8.4.10",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -26079,6 +27720,12 @@
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
             "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+            "dev": true
+        },
+        "@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
             "dev": true
         },
         "@types/node": {
@@ -26434,6 +28081,41 @@
             "requires": {
                 "@typescript-eslint/types": "5.50.0",
                 "eslint-visitor-keys": "^3.3.0"
+            }
+        },
+        "@web/config-loader": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.1.3.tgz",
+            "integrity": "sha512-XVKH79pk4d3EHRhofete8eAnqto1e8mCRAqPV00KLNFzCWSe8sWmLnqKCqkPNARC6nksMaGrATnA5sPDRllMpQ==",
+            "dev": true,
+            "requires": {
+                "semver": "^7.3.4"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.8",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+                    "dev": true
+                }
             }
         },
         "@webassemblyjs/ast": {
@@ -26847,6 +28529,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+            "dev": true
+        },
+        "array-back": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
             "dev": true
         },
         "array-find-index": {
@@ -28107,10 +29795,28 @@
             "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
             "dev": true
         },
+        "command-line-args": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
+            "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
+            "dev": true,
+            "requires": {
+                "array-back": "^6.1.2",
+                "find-replace": "^3.0.0",
+                "lodash.camelcase": "^4.3.0",
+                "typical": "^4.0.0"
+            }
+        },
         "commander": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
             "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "dev": true
+        },
+        "comment-parser": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
+            "integrity": "sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==",
             "dev": true
         },
         "commondir": {
@@ -28791,10 +30497,22 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "custom-elements-manifest": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/custom-elements-manifest/-/custom-elements-manifest-1.0.0.tgz",
+            "integrity": "sha512-j59k0ExGCKA8T6Mzaq+7axc+KVHwpEphEERU7VZ99260npu/p/9kd+Db+I3cGKxHkM5y6q5gnlXn00mzRQkX2A==",
+            "dev": true
+        },
         "cyclist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
             "integrity": "sha512-NJGVKPS81XejHcLhaLJS7plab0fK3slPh11mESeeDq2W4ZI5kUKK/LRRdVDvjJseojbPB7ZwjnyOybg3Igea/A==",
+            "dev": true
+        },
+        "debounce": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+            "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
             "dev": true
         },
         "debug": {
@@ -28812,6 +30530,23 @@
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
             "dev": true,
             "optional": true
+        },
+        "decode-named-character-reference": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "dev": true,
+            "requires": {
+                "character-entities": "^2.0.0"
+            },
+            "dependencies": {
+                "character-entities": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+                    "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+                    "dev": true
+                }
+            }
         },
         "decode-uri-component": {
             "version": "0.2.2",
@@ -28894,6 +30629,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true
+        },
+        "dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
             "dev": true
         },
         "des.js": {
@@ -30214,6 +31955,23 @@
                     "requires": {
                         "find-up": "^3.0.0"
                     }
+                }
+            }
+        },
+        "find-replace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "dev": true,
+            "requires": {
+                "array-back": "^3.0.1"
+            },
+            "dependencies": {
+                "array-back": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+                    "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+                    "dev": true
                 }
             }
         },
@@ -32055,6 +33813,12 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true
+        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -32133,6 +33897,12 @@
                     }
                 }
             }
+        },
+        "longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "dev": true
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -32251,6 +34021,12 @@
             "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
             "dev": true
         },
+        "markdown-table": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
+            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "dev": true
+        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -32260,6 +34036,15 @@
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "mdast-builder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/mdast-builder/-/mdast-builder-1.1.1.tgz",
+            "integrity": "sha512-a3KBk/LmYD6wKsWi8WJrGU/rXR4yuF4Men0JO0z6dSZCm5FrXXWTRDjqK0vGSqa+1M6p9edeuypZAZAzSehTUw==",
+            "dev": true,
+            "requires": {
+                "@types/unist": "^2.0.3"
             }
         },
         "mdast-squeeze-paragraphs": {
@@ -32280,6 +34065,164 @@
                 "unist-util-visit": "^2.0.0"
             }
         },
+        "mdast-util-find-and-replace": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+            "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+                    "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+                    "dev": true
+                },
+                "unist-util-is": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+                    "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+                    "dev": true
+                },
+                "unist-util-visit-parents": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+                    "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-is": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "mdast-util-from-markdown": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
+            "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "mdast-util-to-string": "^3.1.0",
+                "micromark": "^3.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "unist-util-stringify-position": "^3.0.0",
+                "uvu": "^0.5.0"
+            },
+            "dependencies": {
+                "mdast-util-to-string": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
+                    "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/mdast": "^3.0.0"
+                    }
+                },
+                "unist-util-stringify-position": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+                    "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "mdast-util-gfm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-1.0.0.tgz",
+            "integrity": "sha512-JY4qImsTqivQ0Gl3qvdaizCpomFaNrHnjEhNjNNKeNEA5jZHAJDYu1+yO4V9jn4/ti8GrKdAScaT4F71knoxsA==",
+            "dev": true,
+            "requires": {
+                "mdast-util-gfm-autolink-literal": "^1.0.0",
+                "mdast-util-gfm-strikethrough": "^1.0.0",
+                "mdast-util-gfm-table": "^1.0.0",
+                "mdast-util-gfm-task-list-item": "^1.0.0"
+            }
+        },
+        "mdast-util-gfm-autolink-literal": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+            "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "ccount": "^2.0.0",
+                "mdast-util-find-and-replace": "^2.0.0",
+                "micromark-util-character": "^1.0.0"
+            },
+            "dependencies": {
+                "ccount": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+                    "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+                    "dev": true
+                }
+            }
+        },
+        "mdast-util-gfm-strikethrough": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+            "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            }
+        },
+        "mdast-util-gfm-table": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+            "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^1.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            }
+        },
+        "mdast-util-gfm-task-list-item": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+            "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-markdown": "^1.3.0"
+            }
+        },
+        "mdast-util-phrasing": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+            "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "unist-util-is": "^5.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+                    "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+                    "dev": true
+                }
+            }
+        },
         "mdast-util-to-hast": {
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz",
@@ -32294,6 +34237,66 @@
                 "unist-util-generated": "^1.0.0",
                 "unist-util-position": "^3.0.0",
                 "unist-util-visit": "^2.0.0"
+            }
+        },
+        "mdast-util-to-markdown": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+            "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+            "dev": true,
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^3.0.0",
+                "mdast-util-to-string": "^3.0.0",
+                "micromark-util-decode-string": "^1.0.0",
+                "unist-util-visit": "^4.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "dependencies": {
+                "mdast-util-to-string": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.1.tgz",
+                    "integrity": "sha512-tGvhT94e+cVnQt8JWE9/b3cUQZWS732TJxXHktvP+BYo62PpYD53Ls/6cC60rW21dW+txxiM4zMdc6abASvZKA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/mdast": "^3.0.0"
+                    }
+                },
+                "unist-util-is": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.0.tgz",
+                    "integrity": "sha512-Glt17jWwZeyqrFqOK0pF1Ded5U3yzJnFr8CG1GMjCWTp9zDo2p+cmD6pWbZU8AgM5WU3IzRv6+rBwhzsGh6hBQ==",
+                    "dev": true
+                },
+                "unist-util-visit": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+                    "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-is": "^5.0.0",
+                        "unist-util-visit-parents": "^5.1.1"
+                    }
+                },
+                "unist-util-visit-parents": {
+                    "version": "5.1.3",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+                    "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-is": "^5.0.0"
+                    }
+                },
+                "zwitch": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+                    "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+                    "dev": true
+                }
             }
         },
         "mdast-util-to-string": {
@@ -32504,6 +34507,355 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
             "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
+            "dev": true
+        },
+        "micromark": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
+            "integrity": "sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==",
+            "dev": true,
+            "requires": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-core-commonmark": "^1.0.1",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-combine-extensions": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-sanitize-uri": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-core-commonmark": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.6.tgz",
+            "integrity": "sha512-K+PkJTxqjFfSNkfAhp4GB+cZPfQd6dxtTXnf+RjZOV7T4EEXnvgzOcnp+eSTmpGk9d1S9sL6/lqrgSNn/s0HZA==",
+            "dev": true,
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-factory-destination": "^1.0.0",
+                "micromark-factory-label": "^1.0.0",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-factory-title": "^1.0.0",
+                "micromark-factory-whitespace": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-classify-character": "^1.0.0",
+                "micromark-util-html-tag-name": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-extension-gfm": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz",
+            "integrity": "sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==",
+            "dev": true,
+            "requires": {
+                "micromark": "~2.11.0",
+                "micromark-extension-gfm-autolink-literal": "~0.5.0",
+                "micromark-extension-gfm-strikethrough": "~0.6.5",
+                "micromark-extension-gfm-table": "~0.4.0",
+                "micromark-extension-gfm-tagfilter": "~0.3.0",
+                "micromark-extension-gfm-task-list-item": "~0.3.0"
+            },
+            "dependencies": {
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-extension-gfm-autolink-literal": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz",
+            "integrity": "sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==",
+            "dev": true,
+            "requires": {
+                "micromark": "~2.11.3"
+            },
+            "dependencies": {
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-extension-gfm-strikethrough": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz",
+            "integrity": "sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==",
+            "dev": true,
+            "requires": {
+                "micromark": "~2.11.0"
+            },
+            "dependencies": {
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-extension-gfm-table": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz",
+            "integrity": "sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==",
+            "dev": true,
+            "requires": {
+                "micromark": "~2.11.0"
+            },
+            "dependencies": {
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-extension-gfm-tagfilter": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz",
+            "integrity": "sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==",
+            "dev": true
+        },
+        "micromark-extension-gfm-task-list-item": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz",
+            "integrity": "sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==",
+            "dev": true,
+            "requires": {
+                "micromark": "~2.11.0"
+            },
+            "dependencies": {
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-factory-destination": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+            "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+            "dev": true,
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-label": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+            "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+            "dev": true,
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-space": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+            "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+            "dev": true,
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-title": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+            "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+            "dev": true,
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-whitespace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+            "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+            "dev": true,
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-character": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+            "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+            "dev": true,
+            "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-chunked": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+            "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+            "dev": true,
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-classify-character": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+            "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+            "dev": true,
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-combine-extensions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+            "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+            "dev": true,
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-numeric-character-reference": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+            "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+            "dev": true,
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-string": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.2.tgz",
+            "integrity": "sha512-DLT5Ho02qr6QWVNYbRZ3RYOSSWWFuH3tJexd3dgN1odEuPNxCngTCXJum7+ViRAd9BbdxCvMToPOD/IvVhzG6Q==",
+            "dev": true,
+            "requires": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-encode": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.1.tgz",
+            "integrity": "sha512-U2s5YdnAYexjKDel31SVMPbfi+eF8y1U4pfiRW/Y8EFVCy/vgxk/2wWTxzcqE71LHtCuCzlBDRU2a5CQ5j+mQA==",
+            "dev": true
+        },
+        "micromark-util-html-tag-name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.1.0.tgz",
+            "integrity": "sha512-BKlClMmYROy9UiV03SwNmckkjn8QHVaWkqoAqzivabvdGcwNGMMMH/5szAnywmsTBUzDsU57/mFi0sp4BQO6dA==",
+            "dev": true
+        },
+        "micromark-util-normalize-identifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+            "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+            "dev": true,
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-resolve-all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+            "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+            "dev": true,
+            "requires": {
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-sanitize-uri": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz",
+            "integrity": "sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==",
+            "dev": true,
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-subtokenize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+            "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+            "dev": true,
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-util-symbol": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz",
+            "integrity": "sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==",
+            "dev": true
+        },
+        "micromark-util-types": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.2.tgz",
+            "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w==",
             "dev": true
         },
         "micromatch": {
@@ -32871,6 +35223,12 @@
                     }
                 }
             }
+        },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+            "dev": true
         },
         "ms": {
             "version": "2.1.2",
@@ -34408,6 +36766,132 @@
             "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==",
             "dev": true
         },
+        "remark-gfm": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-1.0.0.tgz",
+            "integrity": "sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==",
+            "dev": true,
+            "requires": {
+                "mdast-util-gfm": "^0.1.0",
+                "micromark-extension-gfm": "^0.3.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "longest-streak": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+                    "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+                    "dev": true
+                },
+                "markdown-table": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+                    "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+                    "dev": true,
+                    "requires": {
+                        "repeat-string": "^1.0.0"
+                    }
+                },
+                "mdast-util-find-and-replace": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz",
+                    "integrity": "sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^4.0.0",
+                        "unist-util-is": "^4.0.0",
+                        "unist-util-visit-parents": "^3.0.0"
+                    }
+                },
+                "mdast-util-gfm": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz",
+                    "integrity": "sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==",
+                    "dev": true,
+                    "requires": {
+                        "mdast-util-gfm-autolink-literal": "^0.1.0",
+                        "mdast-util-gfm-strikethrough": "^0.2.0",
+                        "mdast-util-gfm-table": "^0.1.0",
+                        "mdast-util-gfm-task-list-item": "^0.1.0",
+                        "mdast-util-to-markdown": "^0.6.1"
+                    }
+                },
+                "mdast-util-gfm-autolink-literal": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz",
+                    "integrity": "sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==",
+                    "dev": true,
+                    "requires": {
+                        "ccount": "^1.0.0",
+                        "mdast-util-find-and-replace": "^1.1.0",
+                        "micromark": "^2.11.3"
+                    }
+                },
+                "mdast-util-gfm-strikethrough": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz",
+                    "integrity": "sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==",
+                    "dev": true,
+                    "requires": {
+                        "mdast-util-to-markdown": "^0.6.0"
+                    }
+                },
+                "mdast-util-gfm-table": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz",
+                    "integrity": "sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==",
+                    "dev": true,
+                    "requires": {
+                        "markdown-table": "^2.0.0",
+                        "mdast-util-to-markdown": "~0.6.0"
+                    }
+                },
+                "mdast-util-gfm-task-list-item": {
+                    "version": "0.1.6",
+                    "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz",
+                    "integrity": "sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==",
+                    "dev": true,
+                    "requires": {
+                        "mdast-util-to-markdown": "~0.6.0"
+                    }
+                },
+                "mdast-util-to-markdown": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+                    "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "longest-streak": "^2.0.0",
+                        "mdast-util-to-string": "^2.0.0",
+                        "parse-entities": "^2.0.0",
+                        "repeat-string": "^1.0.0",
+                        "zwitch": "^1.0.0"
+                    }
+                },
+                "mdast-util-to-string": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+                    "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+                    "dev": true
+                },
+                "micromark": {
+                    "version": "2.11.4",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+                    "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.0.0",
+                        "parse-entities": "^2.0.0"
+                    }
+                }
+            }
+        },
         "remark-mdx": {
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.22.tgz",
@@ -34530,6 +37014,43 @@
             "dev": true,
             "requires": {
                 "mdast-squeeze-paragraphs": "^4.0.0"
+            }
+        },
+        "remark-stringify": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
+            "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
+            "dev": true,
+            "requires": {
+                "mdast-util-to-markdown": "^0.6.0"
+            },
+            "dependencies": {
+                "longest-streak": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+                    "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+                    "dev": true
+                },
+                "mdast-util-to-markdown": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+                    "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "longest-streak": "^2.0.0",
+                        "mdast-util-to-string": "^2.0.0",
+                        "parse-entities": "^2.0.0",
+                        "repeat-string": "^1.0.0",
+                        "zwitch": "^1.0.0"
+                    }
+                },
+                "mdast-util-to-string": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+                    "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+                    "dev": true
+                }
             }
         },
         "remove-trailing-separator": {
@@ -34697,6 +37218,15 @@
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
                     "dev": true
                 }
+            }
+        },
+        "sade": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+            "dev": true,
+            "requires": {
+                "mri": "^1.1.0"
             }
         },
         "safe-buffer": {
@@ -36488,6 +39018,12 @@
             "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
             "dev": true
         },
+        "typical": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+            "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+            "dev": true
+        },
         "uglify-js": {
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -36887,6 +39423,26 @@
             "resolved": "https://registry.npmjs.org/uuid-browser/-/uuid-browser-3.1.0.tgz",
             "integrity": "sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==",
             "dev": true
+        },
+        "uvu": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+            "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+            "dev": true,
+            "requires": {
+                "dequal": "^2.0.0",
+                "diff": "^5.0.0",
+                "kleur": "^4.0.3",
+                "sade": "^1.7.3"
+            },
+            "dependencies": {
+                "kleur": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+                    "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+                    "dev": true
+                }
+            }
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/packages/adaptive-web-components/cem.config.mjs
+++ b/packages/adaptive-web-components/cem.config.mjs
@@ -1,0 +1,14 @@
+export default {
+	globs: [
+		"src/components/**/*.ts"
+	],
+	exclude: [
+		"src/*.ts",
+		"src/**/*.md",
+		"src/**/index.ts",
+		"src/**/*.stories.*"
+	],
+	outdir: "dist",
+	dev: false,
+	fast: true
+};

--- a/packages/adaptive-web-components/cem.plugins.mjs
+++ b/packages/adaptive-web-components/cem.plugins.mjs
@@ -1,0 +1,3 @@
+export function fast() {
+	return void 0;
+}

--- a/packages/adaptive-web-components/package.json
+++ b/packages/adaptive-web-components/package.json
@@ -22,6 +22,7 @@
         "build": "tsc -p ./tsconfig.build.json",
         "build:storybook": "build-storybook",
         "clean": "rimraf dist storybook-static",
+        "cem:analyze": "cem analyze --config ./cem.config.mjs",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
         "start": "start-storybook -p 6006"
@@ -35,6 +36,8 @@
     },
     "devDependencies": {
         "@babel/core": "^7.20.12",
+        "@custom-elements-manifest/analyzer": "^0.6.8",
+        "@custom-elements-manifest/to-markdown": "^0.1.0",
         "@storybook/addon-actions": "^6.5.15",
         "@storybook/addon-essentials": "^6.5.15",
         "@storybook/addon-links": "^6.5.15",
@@ -53,7 +56,10 @@
         "ts-loader": "^7.0.2",
         "typescript": "^4.7.0"
     },
+    "customElements": "dist/custom-elements.json",
     "exports": {
+        "./custom-elements.json": "./dist/custom-elements.json",
+        "./package.json": "./package.json",
         ".": {
             "types": "./dist/dts/index.d.ts",
             "default": "./dist/esm/index.js"


### PR DESCRIPTION
This PR sets up the initial configuration and scripts for CEM. I did a test run and it couldn't identify where the custom elements were being defined so I will be creating a plugin that can accomplish this.

Next steps after I finish the plugin for fast definitions are to bring over the jsdoc link fix plugin and markdown generation from FAST as needed depending on how we plan to document things.