### PR TITLE
fix color block background overflow

### DIFF
--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -483,7 +483,7 @@ const styles = css`
         text-align: center;
         position: relative;
         transition: opacity 0.1s linear;
-        height: 100%;
+        height: max-content;
         min-height: 100%;
         background-color: ${fillColor};
         color: ${neutralForegroundRest};


### PR DESCRIPTION
When the screen size is small enough to cause the explorer to scroll vertically, the color blocks' content would break out causing the background to not extend with the overflowing content.