### PR TITLE
WIP: Initial work on Adaptive UI style modules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
     },
     "[typescript]": {
         "editor.defaultFormatter": "vscode.typescript-language-features"
-    }
+    },
+    "cSpell.words": [
+        "kebabinate"
+    ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2031,6 +2031,22 @@
                 "node": ">=0.1.95"
             }
         },
+        "node_modules/@cobalt-ui/core": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@cobalt-ui/core/-/core-0.7.4.tgz",
+            "integrity": "sha512-DJbSYwMHoACPYLLNSBsoZwopuS7ggTKcO4NJToxvLwsykzVmUEqNQwLcGrxUq23CD4Nx8L3LvHN1nVd/vCr9yQ==",
+            "dependencies": {
+                "@cobalt-ui/utils": "^0.5.3",
+                "@types/csso": "^5.0.0",
+                "better-color-tools": "^0.10.0",
+                "svgo": "^3.0.2"
+            }
+        },
+        "node_modules/@cobalt-ui/utils": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@cobalt-ui/utils/-/utils-0.5.3.tgz",
+            "integrity": "sha512-yCCeB6VhrLJDz0ogvKKgCOliZQWodlcBcRztmiycm+w4HzFmWAkI2o6l26uAKiPerIZeEra0dVr3QTFYSuCvTw=="
+        },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -6860,11 +6876,32 @@
                 "lodash": "^4.17.15"
             }
         },
+        "node_modules/@trysound/sax": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
+        },
+        "node_modules/@types/css-tree": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.0.tgz",
+            "integrity": "sha512-waFpSayOepEo9vI68r5K/hAgxloFDkUTqXvYduSnwzS5n+tdmvouIWBJy+kOq5xwh0paoJw7NnNXiM8O/O9jRg=="
+        },
+        "node_modules/@types/csso": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/csso/-/csso-5.0.0.tgz",
+            "integrity": "sha512-EMrCTGpXRUsbFfZBzn2jcW6Sqg8kxWXkJcpvAGYSEzFqAJ2THDJSwiMeS2fPUw+0p6RQNT/n8F/skEc9hUBc0g==",
+            "dependencies": {
+                "@types/css-tree": "*"
+            }
         },
         "node_modules/@types/debug": {
             "version": "4.1.7",
@@ -8593,6 +8630,11 @@
                 }
             ]
         },
+        "node_modules/better-color-tools": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/better-color-tools/-/better-color-tools-0.10.0.tgz",
+            "integrity": "sha512-Val/kKqyKK43YYZuMxSPG2lgJL7P7kTm/wSrxPz3y/wXAbx4zrTTBR4A8pi10H9KFPCNcNyLBGsgZPIrnP9Yig=="
+        },
         "node_modules/better-opn": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-2.1.1.tgz",
@@ -8722,8 +8764,7 @@
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
         "node_modules/boxen": {
             "version": "5.1.2",
@@ -10447,11 +10488,22 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "dependencies": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-            "dev": true,
             "engines": {
                 "node": ">= 6"
             },
@@ -10470,6 +10522,36 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "dependencies": {
+                "css-tree": "~2.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
         },
         "node_modules/csstype": {
             "version": "3.1.1",
@@ -10835,7 +10917,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -15493,6 +15574,11 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+        },
         "node_modules/mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -17089,7 +17175,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0"
             },
@@ -20283,7 +20368,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
             "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -20947,6 +21031,108 @@
             "engines": {
                 "node": ">=4.0.0"
             }
+        },
+        "node_modules/svgo": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+            "dependencies": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^2.2.1",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
+            }
+        },
+        "node_modules/svgo/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/svgo/node_modules/css-select": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/svgo/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/svgo/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/svgo/node_modules/domutils": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/svgo/node_modules/entities": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/svgo/node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
         "node_modules/symbol.prototype.description": {
             "version": "1.0.5",
@@ -23414,6 +23600,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
+                "@cobalt-ui/core": "^0.7.4",
                 "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-foundation": "3.0.0-alpha.25"
             },
@@ -23724,6 +23911,7 @@
         "@adaptive-web/adaptive-ui": {
             "version": "file:packages/adaptive-ui",
             "requires": {
+                "@cobalt-ui/core": "^0.7.4",
                 "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-foundation": "3.0.0-alpha.25",
                 "@types/chai": "^4.3.4",
@@ -25250,6 +25438,22 @@
                 "exec-sh": "^0.3.2",
                 "minimist": "^1.2.0"
             }
+        },
+        "@cobalt-ui/core": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@cobalt-ui/core/-/core-0.7.4.tgz",
+            "integrity": "sha512-DJbSYwMHoACPYLLNSBsoZwopuS7ggTKcO4NJToxvLwsykzVmUEqNQwLcGrxUq23CD4Nx8L3LvHN1nVd/vCr9yQ==",
+            "requires": {
+                "@cobalt-ui/utils": "^0.5.3",
+                "@types/csso": "^5.0.0",
+                "better-color-tools": "^0.10.0",
+                "svgo": "^3.0.2"
+            }
+        },
+        "@cobalt-ui/utils": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@cobalt-ui/utils/-/utils-0.5.3.tgz",
+            "integrity": "sha512-yCCeB6VhrLJDz0ogvKKgCOliZQWodlcBcRztmiycm+w4HzFmWAkI2o6l26uAKiPerIZeEra0dVr3QTFYSuCvTw=="
         },
         "@colors/colors": {
             "version": "1.5.0",
@@ -28748,11 +28952,29 @@
                 }
             }
         },
+        "@trysound/sax": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+        },
         "@types/chai": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
+        },
+        "@types/css-tree": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@types/css-tree/-/css-tree-2.3.0.tgz",
+            "integrity": "sha512-waFpSayOepEo9vI68r5K/hAgxloFDkUTqXvYduSnwzS5n+tdmvouIWBJy+kOq5xwh0paoJw7NnNXiM8O/O9jRg=="
+        },
+        "@types/csso": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/csso/-/csso-5.0.0.tgz",
+            "integrity": "sha512-EMrCTGpXRUsbFfZBzn2jcW6Sqg8kxWXkJcpvAGYSEzFqAJ2THDJSwiMeS2fPUw+0p6RQNT/n8F/skEc9hUBc0g==",
+            "requires": {
+                "@types/css-tree": "*"
+            }
         },
         "@types/debug": {
             "version": "4.1.7",
@@ -30144,6 +30366,11 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
         },
+        "better-color-tools": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/better-color-tools/-/better-color-tools-0.10.0.tgz",
+            "integrity": "sha512-Val/kKqyKK43YYZuMxSPG2lgJL7P7kTm/wSrxPz3y/wXAbx4zrTTBR4A8pi10H9KFPCNcNyLBGsgZPIrnP9Yig=="
+        },
         "better-opn": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-2.1.1.tgz",
@@ -30252,8 +30479,7 @@
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-            "dev": true
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
         "boxen": {
             "version": "5.1.2",
@@ -31639,17 +31865,49 @@
                 "nth-check": "^2.0.1"
             }
         },
+        "css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "requires": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            }
+        },
         "css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-            "dev": true
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
         },
         "cssesc": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
+        },
+        "csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "requires": {
+                "css-tree": "~2.2.0"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+                    "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+                    "requires": {
+                        "mdn-data": "2.0.28",
+                        "source-map-js": "^1.0.1"
+                    }
+                },
+                "mdn-data": {
+                    "version": "2.0.28",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+                    "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+                }
+            }
         },
         "csstype": {
             "version": "3.1.1",
@@ -31929,8 +32187,7 @@
         "domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "dev": true
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
         },
         "domhandler": {
             "version": "4.3.1",
@@ -35505,6 +35762,11 @@
             "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
             "dev": true
         },
+        "mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+        },
         "mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -36661,7 +36923,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
             "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dev": true,
             "requires": {
                 "boolbase": "^1.0.0"
             }
@@ -39137,8 +39398,7 @@
         "source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-            "dev": true
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
         },
         "source-map-loader": {
             "version": "0.2.4",
@@ -39673,6 +39933,76 @@
                         "emojis-list": "^3.0.0",
                         "json5": "^1.0.1"
                     }
+                }
+            }
+        },
+        "svgo": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
+            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+            "requires": {
+                "@trysound/sax": "0.2.0",
+                "commander": "^7.2.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^2.2.1",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+                },
+                "css-select": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+                    "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+                    "requires": {
+                        "boolbase": "^1.0.0",
+                        "css-what": "^6.1.0",
+                        "domhandler": "^5.0.2",
+                        "domutils": "^3.0.1",
+                        "nth-check": "^2.0.1"
+                    }
+                },
+                "dom-serializer": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+                    "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+                    "requires": {
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.2",
+                        "entities": "^4.2.0"
+                    }
+                },
+                "domhandler": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+                    "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+                    "requires": {
+                        "domelementtype": "^2.3.0"
+                    }
+                },
+                "domutils": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+                    "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+                    "requires": {
+                        "dom-serializer": "^2.0.0",
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.1"
+                    }
+                },
+                "entities": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+                    "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+                },
+                "picocolors": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+                    "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
                 }
             }
         },

--- a/packages/adaptive-ui-explorer/index.html
+++ b/packages/adaptive-ui-explorer/index.html
@@ -16,6 +16,7 @@
             display: flex;
         }
     </style>
+    <script type="module" src="/src/load-tokens.ts"></script>
     <script type="module" src="/src/app.ts"></script>
 </head>
 

--- a/packages/adaptive-ui-explorer/package.json
+++ b/packages/adaptive-ui-explorer/package.json
@@ -23,7 +23,7 @@
         "clean": "rimraf dist",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
-        "start": "vite --open",
+        "start": "vite --force --open",
         "test": "npm run lint && npm run build"
     },
     "dependencies": {

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -1,5 +1,6 @@
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { ModuleStyles, Swatch } from "@adaptive-web/adaptive-ui";
 import {
+    attr,
     css,
     customElement,
     ElementViewTemplate,
@@ -28,7 +29,9 @@ function template<T extends AdaptiveComponent>(): ElementViewTemplate<T> {
                 --ac-foreground-focus: ${x => x.foregroundFocus?.createCSS()};
             "
         >
-            <slot></slot>
+            <span class="content" part="content">
+                <slot></slot>
+            </span>
         </template>
     `;
 }
@@ -71,12 +74,19 @@ const styles = css`
     }
 `;
 
+const testModularStyles = ModuleStyles.get("app-adaptive-component") || [];
+console.log("Loading app-adaptive-component", testModularStyles);
+
 @customElement({
     name: "app-adaptive-component",
     template: template(),
-    styles,
+    styles: [styles, ...testModularStyles],
 })
 export class AdaptiveComponent extends FASTElement {
+    // Temp for testing attribute selection
+    @attr({attribute: "layer", mode: "boolean"})
+    public layer: boolean;
+    
     @observable
     public fillRest?: CSSDesignToken<Swatch>;
 

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -118,6 +118,7 @@ const backplateComponents = html<ColorBlock>`
 
         <div class="example">
             <app-adaptive-component
+                layer
                 :fillRest="${x => neutralFillRest}"
                 :fillHover="${x => neutralFillHover}"
                 :fillActive="${x => neutralFillActive}"

--- a/packages/adaptive-ui-explorer/src/load-tokens.ts
+++ b/packages/adaptive-ui-explorer/src/load-tokens.ts
@@ -1,0 +1,8 @@
+import { parse } from "@adaptive-web/adaptive-ui";
+import { DesignToken } from "@microsoft/fast-foundation";
+
+// console.log("Importing tokens.json");
+import tokens from "./test.tokens.json";
+parse(tokens);
+
+DesignToken.registerDefaultStyleTarget();

--- a/packages/adaptive-ui-explorer/src/test.tokens.json
+++ b/packages/adaptive-ui-explorer/src/test.tokens.json
@@ -1,0 +1,49 @@
+{
+    "$name": "Token Test",
+    "$description": "The top part can be whatever tokens needed following the DTCG spec plus extensions and custom types.",
+    "cornerRadius": {
+        "$type": "dimension",
+        "$description": "Corner radius values",
+        "control": {
+            "$description": "Corner radius for controls",
+            "$value": "4px",
+            "$extensions": {
+                "mode": {
+                    "hover": "8px",
+                    "active": "0px"
+                }
+            }
+        },
+        "layer": {
+            "$description": "Corner radius for layers",
+            "$value": "8px"
+        }
+    },
+    "_styles": {
+        "$description": "This section applies tokens above to components, following the allowed formats.",
+        "app-adaptive-component": {
+            "$description": "Test component styles",
+            "border-radius": {
+                "$value": "{cornerRadius.control}"
+            },
+            "[layer]": {
+                "border-radius": {
+                    "$value": "{cornerRadius.layer}"
+                }
+            },
+            "content": {
+                "color": {
+                    "$type": "color",
+                    "$value": "#00FF00"
+                },
+                ":hover": {
+                    "$description": "NOTE: This is not the best example, but tests part conditions.",
+                    "color": {
+                        "$type": "color",
+                        "$value": "#FF0000"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -19,8 +19,9 @@
         "directory": "packages/adaptive-ui"
     },
     "scripts": {
-        "build": "tsc -p ./tsconfig.json",
+        "build": "tsc",
         "clean": "rimraf dist",
+        "dev": "tsc --watch",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
         "test": "npm run lint && npm run build && npm run unit-tests",
@@ -28,6 +29,7 @@
         "unit-tests:watch": "mocha --watch"
     },
     "dependencies": {
+        "@cobalt-ui/core": "^0.7.4",
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-foundation": "3.0.0-alpha.25"
     },

--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./color/index.js";
 export * from "./design-tokens/index.js";
 export * from "./elevation/index.js";
+export * from "./modules/index.js";
+export * from "./tokens/index.js";
 export * from "./type/index.js";

--- a/packages/adaptive-ui/src/modules/attribute.ts
+++ b/packages/adaptive-ui/src/modules/attribute.ts
@@ -1,0 +1,41 @@
+import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
+import { CSSDesignToken } from "@microsoft/fast-foundation";
+import { makeSelector } from "./selector.js";
+import type { FocusSelector, StyleModuleEvaluate, StyleModuleEvaluateParameters } from "./types.js";
+
+export function attribute(
+    attribute: string,
+    value: string | CSSDesignToken<any>,
+): StyleModuleEvaluate {
+    return (params: StyleModuleEvaluateParameters): ElementStyles =>
+        css`${makeSelector(params)} { ${attribute}: ${value}; }`;
+}
+
+export function attributeInteractive(
+    attribute: string,
+    rest: string | CSSDesignToken<any>,
+    hover?: string | CSSDesignToken<any>,
+    active?: string | CSSDesignToken<any>,
+    focus?: string | CSSDesignToken<any>,
+    focusSelector: FocusSelector = "focus-visible",
+): StyleModuleEvaluate {
+    return (params: StyleModuleEvaluateParameters): ElementStyles => css`
+        ${makeSelector(params)} { ${attribute}: ${rest}; }
+        ${
+            hover
+                ? css.partial`${makeSelector(params, "hover")} { ${attribute}: ${hover}; }`
+                : ``
+        }
+        ${
+            active
+                ? css.partial`${makeSelector(params, "active")} { ${attribute}: ${active}; }`
+                : ``
+        }
+        ${
+            focus
+                ? css.partial`${makeSelector(params, focusSelector)} { ${attribute}: ${focus}; }`
+                : ``
+        }
+    `;
+}

--- a/packages/adaptive-ui/src/modules/base-style.ts
+++ b/packages/adaptive-ui/src/modules/base-style.ts
@@ -1,0 +1,5 @@
+export const componentBaseStyles = /* css */`
+    :host([hidden]) {
+        display: none !important;
+    }
+`;

--- a/packages/adaptive-ui/src/modules/index.ts
+++ b/packages/adaptive-ui/src/modules/index.ts
@@ -1,0 +1,4 @@
+export * from "./attribute.js";
+export * from "./base-style.js";
+export * from "./selector.js";
+export * from "./types.js";

--- a/packages/adaptive-ui/src/modules/selector.ts
+++ b/packages/adaptive-ui/src/modules/selector.ts
@@ -1,0 +1,32 @@
+import type { StateSelector, StyleModuleEvaluateParameters } from "./types.js";
+
+export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string {
+    const selectors: string[] = [];
+
+    if (params.hostCondition || (state && params.interactivitySelector)) {
+        // Use any base host condition like `[appearance='accent']`.
+        let hostCondition = params.hostCondition || "";
+
+        // Add any interactive condition like `:not([disabled])`.
+        hostCondition += (params.interactivitySelector || "");
+
+        // If this is not targeting a part, apply the state at the `:host`.
+        if (!params.part && state) {
+            hostCondition += ":" + state;
+        }
+
+        if (hostCondition !== "") {
+            selectors.push(`:host(${hostCondition})`);
+        }
+    } else if (!params.part) {
+        selectors.push(":host");
+    }
+
+    if (params.part) {
+        // Using class selector notation for now.
+        selectors.push(`.${params.part}${params.partCondition || ""}${state ? ":" + state : ""}`);
+    }
+    const ret = selectors.join(" ");
+    // console.log("makeSelector", ret);
+    return ret;
+}

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -1,0 +1,15 @@
+import type { ElementStyles } from "@microsoft/fast-element";
+
+export type FocusSelector = "focus" | "focus-visible" | "focus-within";
+
+export type StateSelector = FocusSelector | "hover" | "active";
+
+export interface StyleModuleEvaluateParameters {
+    hostCondition?: string;
+    part?: string;
+    partCondition?: string;
+    interactivitySelector?: string;
+    nonInteractivitySelector?: string;
+}
+
+export type StyleModuleEvaluate = (params: StyleModuleEvaluateParameters) => ElementStyles;

--- a/packages/adaptive-ui/src/tokens/index.ts
+++ b/packages/adaptive-ui/src/tokens/index.ts
@@ -1,0 +1,1 @@
+export * from "./parse.js";

--- a/packages/adaptive-ui/src/tokens/parse.ts
+++ b/packages/adaptive-ui/src/tokens/parse.ts
@@ -1,0 +1,94 @@
+import co from "@cobalt-ui/core";
+import type { ParseResult } from "@cobalt-ui/core";
+import { isAlias, kebabinate } from "@cobalt-ui/utils";
+import type { ElementStyles } from "@microsoft/fast-element";
+import { CSSDesignToken, DesignToken } from "@microsoft/fast-foundation";
+import { attribute } from "../modules/attribute.js";
+import { StyleModuleEvaluateParameters } from "../modules/types.js";
+
+export const DesignTokens: Map<string, CSSDesignToken<any>> = new Map();
+export const ModuleStyles: Map<string, ElementStyles[]> = new Map();
+
+function aliasToTokenId(alias: string): string {
+    if (alias.startsWith("{") && alias.endsWith("}")) {
+        alias = alias.substring(1, alias.length - 1);
+    }
+    return kebabinate(alias);
+}
+
+function createDesignToken(tokenId: string, tokenValue: any) {
+    const dt = DesignToken.create(tokenId).withDefault(tokenValue);
+    // console.log("Creating DesignToken", tokenId, tokenValue);
+    DesignTokens.set(tokenId, dt);
+}
+
+function isCondition(selector: string): boolean {
+    return /[:[(]/.test(selector);
+}
+
+function addModule(component: string, module: ElementStyles) {
+    const modules = ModuleStyles.get(component) || [];
+    modules.push(module);
+    ModuleStyles.set(component, modules);
+}
+
+const stylesKey = "_styles";
+
+export const parse = (designTokens: any): void => {
+    const result: ParseResult = co.parse(designTokens);
+
+    // console.log("Token parsing result", result);
+    result.result.tokens.forEach((token) => {
+        if (!token.id.startsWith(stylesKey)) {
+            // Create a DesignToken for flattened standard tokens.
+            const tokenId = kebabinate(token.id);
+            createDesignToken(tokenId, token.$value);
+
+            // Use `mode` feature for interactive states.
+            if (token.$extensions && token.$extensions.mode) {
+                for (const [k, v] of Object.entries(token.$extensions.mode || {})) {
+                    createDesignToken(`${tokenId}-${k.toLowerCase()}`, v);
+                }
+            }
+        } else {
+            // Apply modular styles. Examples:
+            //   component.attribute => badge.border-radius
+            //   component.part.attribute => badge.content.color
+            //   component.part.[condition].attribute => badge.content.[disabled].color
+            //   component.[condition].attribute => badge.[circular].border-radius
+            //   component.[condition].part.attribute => badge.[appearance=accent].content.color
+            //   component.[condition].part.[condition].attribute => horizontal-scroll.[fit=wide].scroll-next.[disabled].opacity
+            const [/* stylesKey */, component, ...selectors] = token.id.split(".");
+            if (selectors.length > 0) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const attr = selectors.pop()!;
+
+                const params: StyleModuleEvaluateParameters = {};
+                const first = selectors.shift();
+                if (first) {
+                    if (isCondition(first)) {
+                        params.hostCondition = first;
+                        params.part = selectors.shift();
+                    } else {
+                        params.part = first;
+                    }
+                    params.partCondition = selectors.shift();
+                }
+
+                // console.log("Modular style selector", token.id.replace(stylesKey, ""), "=>", component, params, attr);
+
+                const tokenValue = isAlias(token._original.$value)
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    ? DesignTokens.get(aliasToTokenId(token._original.$value as string))!
+                    : (token.$value as string);
+                // const tokenValueDesc = isAlias(token._original.$value)
+                //    ? "DT: " + aliasToTokenId(token._original.$value as string)
+                //    : token.$value as string;
+                // console.log("Adding module", component, tokenValueDesc);
+                const module = attribute(attr, tokenValue)(params);
+
+                addModule(component, module);
+            }
+        }
+    });
+}

--- a/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
@@ -1,6 +1,7 @@
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { DesignSystem } from "../../design-system.js";
 import { AdaptiveAnchor } from "./anchor.js";
-import { styles } from "./anchor.styles.js";
+import { aestheticStyles, moduleStyles, templateStyles } from "./anchor.styles.js";
 import { template } from "./anchor.template.js";
 
 /**
@@ -16,7 +17,12 @@ export const definition = (ds: DesignSystem) =>
         name: `${ds.prefix}-anchor`,
         registry: ds.registry,
         template: template(ds),
-        styles,
+        styles: [
+            componentBaseStyles,
+            templateStyles,
+            aestheticStyles,
+            ...moduleStyles
+        ],
         shadowOptions: {
             delegatesFocus: true,
         },

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -1,26 +1,30 @@
 import {
+    attributeInteractive,
     controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     neutralFillActive,
+    neutralFillFocus,
     neutralFillHover,
     neutralFillRest,
     neutralForegroundRest,
+    neutralStrokeActive,
+    neutralStrokeFocus,
+    neutralStrokeHover,
+    neutralStrokeRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
-import { css, ElementStyles } from "@microsoft/fast-element";
+import type { StyleModuleEvaluateParameters } from "@adaptive-web/adaptive-ui";
+import { css } from "@microsoft/fast-element";
+import type { ComposableStyles, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
     }
@@ -53,7 +57,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
         ${typeRampBase}
     }
 
@@ -61,8 +64,7 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         gap: 10px;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
-        border-radius: inherit;
-        background-color: ${neutralFillRest};
+        border-radius: calc(${controlCornerRadius} * 1px);
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
@@ -72,24 +74,33 @@ export const aestheticStyles: ElementStyles = css`
         line-height: 0;
     }
 
-    :host([href]:hover) .control {
-        background-color: ${neutralFillHover};
-    }
-
-    :host([href]:active) .control {
-        background-color: ${neutralFillActive};
-    }
-
     .control:focus-visible {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
 `;
 
-/**
- * Default Adaptive UI Anchor styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
+const moduleParams: StyleModuleEvaluateParameters = {
+    part: "control",
+    interactivitySelector: "[href]",
+    nonInteractivitySelector: ":not([href])",
+};
 
-    ${aestheticStyles}
-`;
+/**
+ * Visual styles composed by modules.
+ */
+export const moduleStyles: ComposableStyles[] = [
+    attributeInteractive(
+        "background-color",
+        neutralFillRest,
+        neutralFillHover,
+        neutralFillActive,
+        neutralFillFocus
+    )(moduleParams),
+    attributeInteractive(
+        "border-color",
+        neutralStrokeRest,
+        neutralStrokeHover,
+        neutralStrokeActive,
+        neutralStrokeFocus
+    )(moduleParams),
+];


### PR DESCRIPTION
## Description

Adds an evolution of an old idea to build styles as a modular set of design decisions.

This work also adds parsing the DTCG tokens file format, turning that into DesignTokens, and building modular styles for components.

## Reviewer Notes

If you want to build and play with this, you'll need the latest unpublished @cobalt-ui/utils package. I submitted a patch but it's not published yet. If you pull down, build, and npm link into this project the error should go away.

For the full process, start by running `adaptive-ui-explorer` and looking in `load-tokens.ts`.

For a manual example of the interactive color module, look at `anchor.styles.ts`.

## Next Steps

Tighten up the code.

The `StyleModuleEvaluateParameters` isn't quite right yet. There are attributes that should come from the components and some from the style registration. The `interactivity` support is intended to be provided by the component. For instance, an Anchor is interactive if `[href]` and a Button is interactive if `:not([disabled])`. Both should be able to have the same style module applied but generate valid styles.

Perhaps the object registered in `ModuleStyles` should not be an evaluated `ElementStyles` but instead an object representing the modular function and the registration portions of the style. The component portions would be mixed in when the component is defined and the styles are needed.

A better pipeline between the `parse` call and getting the styles out of `ModuleStyles`.

Error handling.