### PR TITLE
Removing `style` exports

### DIFF
--- a/packages/adaptive-web-components/src/components/accordion-item/index.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/index.ts
@@ -2,6 +2,5 @@ export { definition as AccordionItemDefinition } from "./accordion-item.definiti
 export {
     templateStyles as AccordionItemTemplateStyles,
     aestheticStyles as AccordionItemAestheticStyles,
-    styles as AccordionItemStyles,
 } from "./accordion-item.styles.js";
 export { template as AccordionItemTemplate } from "./accordion-item.template.js";

--- a/packages/adaptive-web-components/src/components/accordion/index.ts
+++ b/packages/adaptive-web-components/src/components/accordion/index.ts
@@ -2,6 +2,5 @@ export { definition as AccordionDefinition } from "./accordion.definition.js";
 export {
     templateStyles as AccordionTemplateStyles,
     aestheticStyles as AccordionAestheticStyles,
-    styles as AccordionStyles,
 } from "./accordion.styles.js";
 export { template as AccordionTemplate } from "./accordion.template.js";

--- a/packages/adaptive-web-components/src/components/anchor/index.ts
+++ b/packages/adaptive-web-components/src/components/anchor/index.ts
@@ -2,7 +2,6 @@ export { definition as AnchorDefinition } from "./anchor.definition.js";
 export {
     templateStyles as AnchorTemplateStyles,
     aestheticStyles as AnchorAestheticStyles,
-    styles as AnchorStyles,
 } from "./anchor.styles.js";
 export { template as AnchorTemplate } from "./anchor.template.js";
 export { AdaptiveAnchor } from "./anchor.js";

--- a/packages/adaptive-web-components/src/components/anchored-region/index.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/index.ts
@@ -2,6 +2,5 @@ export { definition as AnchoredRegionDefinition } from "./anchored-region.defini
 export {
     templateStyles as AnchoredRegionTemplateStyles,
     aestheticStyles as AnchoredRegionAestheticStyles,
-    styles as AnchoredRegionStyles,
 } from "./anchored-region.styles.js";
 export { template as AnchoredRegionTemplate } from "./anchored-region.template.js";

--- a/packages/adaptive-web-components/src/components/avatar/index.ts
+++ b/packages/adaptive-web-components/src/components/avatar/index.ts
@@ -2,6 +2,5 @@ export { definition as AvatarDefinition } from "./avatar.definition.js";
 export {
     templateStyles as AvatarTemplateStyles,
     aestheticStyles as AvatarAestheticStyles,
-    styles as AvatarStyles,
 } from "./avatar.styles.js";
 export { template as AvatarTemplate } from "./avatar.template.js";

--- a/packages/adaptive-web-components/src/components/badge/index.ts
+++ b/packages/adaptive-web-components/src/components/badge/index.ts
@@ -2,6 +2,5 @@ export { definition as BadgeDefinition } from "./badge.definition.js";
 export {
     templateStyles as BadgeTemplateStyles,
     aestheticStyles as BadgeAestheticStyles,
-    styles as BadgeStyles,
 } from "./badge.styles.js";
 export { template as BadgeTemplate } from "./badge.template.js";

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/index.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/index.ts
@@ -2,6 +2,5 @@ export { definition as BreadcrumbItemDefinition } from "./breadcrumb-item.defini
 export {
     templateStyles as BreadcrumbItemTemplateStyles,
     aestheticStyles as BreadcrumbItemAestheticStyles,
-    styles as BreadcrumbItemStyles,
 } from "./breadcrumb-item.styles.js";
 export { template as BreadcrumbItemTemplate } from "./breadcrumb-item.template.js";

--- a/packages/adaptive-web-components/src/components/breadcrumb/index.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/index.ts
@@ -2,6 +2,5 @@ export { definition as BreadcrumbDefinition } from "./breadcrumb.definition.js";
 export {
     templateStyles as BreadcrumbTemplateStyles,
     aestheticStyles as BreadcrumbAestheticStyles,
-    styles as BreadcrumbStyles,
 } from "./breadcrumb.styles.js";
 export { template as BreadcrumbTemplate } from "./breadcrumb.template.js";

--- a/packages/adaptive-web-components/src/components/button/index.ts
+++ b/packages/adaptive-web-components/src/components/button/index.ts
@@ -2,7 +2,6 @@ export { definition as ButtonDefinition } from "./button.definition.js";
 export {
     templateStyles as ButtonTemplateStyles,
     aestheticStyles as ButtonAestheticStyles,
-    styles as ButtonStyles,
 } from "./button.styles.js";
 export { template as ButtonTemplate } from "./button.template.js";
 export { AdaptiveButton } from "./button.js";

--- a/packages/adaptive-web-components/src/components/calendar/index.ts
+++ b/packages/adaptive-web-components/src/components/calendar/index.ts
@@ -2,6 +2,5 @@ export { definition as CalendarDefinition } from "./calendar.definition.js";
 export {
     templateStyles as CalendarTemplateStyles,
     aestheticStyles as CalendarAestheticStyles,
-    styles as CalendarStyles
 } from "./calendar.styles.js";
 export { template as CalendarTemplate } from "./calendar.template.js";

--- a/packages/adaptive-web-components/src/components/card/index.ts
+++ b/packages/adaptive-web-components/src/components/card/index.ts
@@ -2,6 +2,5 @@ export { definition as CardDefinition } from "./card.definition.js";
 export {
     templateStyles as CardTemplateStyles,
     aestheticStyles as CardAestheticStyles,
-    styles as CardStyles,
 } from "./card.styles.js";
 export { template as CardTemplate } from "./card.template.js";

--- a/packages/adaptive-web-components/src/components/checkbox/index.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/index.ts
@@ -2,6 +2,5 @@ export { definition as CheckboxDefinition } from "./checkbox.definition.js";
 export {
     templateStyles as CheckboxTemplateStyles,
     aestheticStyles as CheckboxAestheticStyles,
-    styles as CheckboxStyles,
 } from "./checkbox.styles.js";
 export { template as CheckboxTemplate } from "./checkbox.template.js";

--- a/packages/adaptive-web-components/src/components/combobox/index.ts
+++ b/packages/adaptive-web-components/src/components/combobox/index.ts
@@ -2,6 +2,5 @@ export { definition as ComboboxDefinition } from "./combobox.definition.js";
 export {
     templateStyles as ComboboxTemplateStyles,
     aestheticStyles as ComboboxAestheticStyles,
-    styles as ComboboxStyles,
 } from "./combobox.styles.js";
 export { template as ComboboxTemplate } from "./combobox.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
@@ -2,6 +2,5 @@ export { definition as DataGridCellDefinition } from "./data-grid-cell.definitio
 export {
     templateStyles as DataGridCellTemplateStyles,
     aestheticStyles as DataGridCellAestheticStyles,
-    styles as DataGridCellStyles,
 } from "./data-grid-cell.styles.js";
 export { template as DataGridCellTemplate } from "./data-grid-cell.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-row/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/index.ts
@@ -2,6 +2,5 @@ export { definition as DataGridRowDefinition } from "./data-grid-row.definition.
 export {
     templateStyles as DataGridRowTemplateStyles,
     aestheticStyles as DataGridRowAestheticStyles,
-    styles as DataGridRowStyles,
 } from "./data-grid-row.styles.js";
 export { template as DataGridRowTemplate } from "./data-grid-row.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/index.ts
@@ -2,6 +2,5 @@ export { definition as DataGridDefinition } from "./data-grid.definition.js";
 export {
     templateStyles as DataGridTemplateStyles,
     aestheticStyles as DataGridAestheticStyles,
-    styles as DataGridStyles,
 } from "./data-grid.styles.js";
 export { template as DataGridTemplate } from "./data-grid.template.js";

--- a/packages/adaptive-web-components/src/components/dialog/index.ts
+++ b/packages/adaptive-web-components/src/components/dialog/index.ts
@@ -2,6 +2,5 @@ export { definition as DialogDefinition } from "./dialog.definition.js";
 export {
     templateStyles as DialogTemplateStyles,
     aestheticStyles as DialogAestheticStyles,
-    styles as DialogStyles,
 } from "./dialog.styles.js";
 export { template as DialogTemplate } from "./dialog.template.js";

--- a/packages/adaptive-web-components/src/components/disclosure/index.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/index.ts
@@ -2,6 +2,5 @@ export { definition as DisclosureDefinition } from "./disclosure.definition.js";
 export {
     templateStyles as DisclosureTemplateStyles,
     aestheticStyles as DisclosureAestheticStyles,
-    styles as DisclosureStyles,
 } from "./disclosure.styles.js";
 export { template as DisclosureTemplate } from "./disclosure.template.js";

--- a/packages/adaptive-web-components/src/components/divider/index.ts
+++ b/packages/adaptive-web-components/src/components/divider/index.ts
@@ -2,6 +2,5 @@ export { definition as DividerDefinition } from "./divider.definition.js";
 export {
     templateStyles as DividerTemplateStyles,
     aestheticStyles as DividerAestheticStyles,
-    styles as DividerStyles,
 } from "./divider.styles.js";
 export { template as DividerTemplate } from "./divider.template.js";

--- a/packages/adaptive-web-components/src/components/flipper/index.ts
+++ b/packages/adaptive-web-components/src/components/flipper/index.ts
@@ -2,6 +2,5 @@ export { definition as FlipperDefinition } from "./flipper.definition.js";
 export {
     templateStyles as FlipperTemplateStyles,
     aestheticStyles as FlipperAestheticStyles,
-    styles as FlipperStyles,
 } from "./flipper.styles.js";
 export { template as FlipperTemplate } from "./flipper.template.js";

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
@@ -2,7 +2,6 @@ export { definition as HorizontalScrollDefinition } from "./horizontal-scroll.de
 export {
     templateStyles as HorizontalScrollTemplateStyles,
     aestheticStyles as HorizontalScrollAestheticStyles,
-    styles as HorizontalScrollStyles,
 } from "./horizontal-scroll.styles.js";
 export { template as HorizontalScrollTemplate } from "./horizontal-scroll.template.js";
 export { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";

--- a/packages/adaptive-web-components/src/components/listbox-option/index.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/index.ts
@@ -2,6 +2,5 @@ export { definition as ListboxOptionDefinition } from "./listbox-option.definiti
 export {
     templateStyles as ListboxOptionTemplateStyles,
     aestheticStyles as ListboxOptionAestheticStyles,
-    styles as ListboxOptionStyles,
 } from "./listbox-option.styles.js";
 export { template as ListboxOptionTemplate } from "./listbox-option.template.js";

--- a/packages/adaptive-web-components/src/components/listbox/index.ts
+++ b/packages/adaptive-web-components/src/components/listbox/index.ts
@@ -2,6 +2,5 @@ export { definition as ListboxDefinition } from "./listbox.definition.js";
 export {
     templateStyles as ListboxTemplateStyles,
     aestheticStyles as ListboxAestheticStyles,
-    styles as ListboxStyles,
 } from "./listbox.styles.js";
 export { template as ListboxTemplate } from "./listbox.template.js";

--- a/packages/adaptive-web-components/src/components/menu-item/index.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/index.ts
@@ -2,7 +2,6 @@ export { definition as MenuItemDefinition } from "./menu-item.definition.js";
 export {
     templateStyles as MenuItemTemplateStyles,
     aestheticStyles as MenuItemAestheticStyles,
-    styles as MenuItemStyles
 } from "./menu-item.styles.js";
 export { template as MenuItemTemplate } from "./menu-item.template.js";
 export { AdaptiveMenuItem } from "./menu-item.js";

--- a/packages/adaptive-web-components/src/components/menu/index.ts
+++ b/packages/adaptive-web-components/src/components/menu/index.ts
@@ -2,7 +2,6 @@ export { definition as MenuDefinition } from "./menu.definition.js";
 export {
     templateStyles as MenuTemplateStyles,
     aestheticStyles as MenuAestheticStyles,
-    styles as MenuStyles
 } from "./menu.styles.js";
 export { template as MenuTemplate } from "./menu.template.js";
 export { AdaptiveMenu } from "./menu.js";

--- a/packages/adaptive-web-components/src/components/number-field/index.ts
+++ b/packages/adaptive-web-components/src/components/number-field/index.ts
@@ -2,6 +2,5 @@ export { definition as NumberFieldDefinition } from "./number-field.definition.j
 export {
     templateStyles as NumberFieldTemplateStyles,
     aestheticStyles as NumberFieldAestheticStyles,
-    styles as NumberFieldStyles,
 } from "./number-field.styles.js";
 export { template as NumberFieldTemplate } from "./number-field.template.js";

--- a/packages/adaptive-web-components/src/components/picker-list-item/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/index.ts
@@ -2,6 +2,5 @@ export { definition as PickerListItemDefinition } from "./picker-list-item.defin
 export {
     templateStyles as PickerListItemTemplateStyles,
     aestheticStyles as PickerListItemAestheticStyles,
-    styles as PickerListItemStyles,
 } from "./picker-list-item.styles.js";
 export { template as PickerListItemTemplate } from "./picker-list-item.template.js";

--- a/packages/adaptive-web-components/src/components/picker-list/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/index.ts
@@ -2,6 +2,5 @@ export { definition as PickerListDefinition } from "./picker-list.definition.js"
 export {
     templateStyles as PickerListTemplateStyles,
     aestheticStyles as PickerListAestheticStyles,
-    styles as PickerListStyles,
 } from "./picker-list.styles.js";
 export { template as PickerListTemplate } from "./picker-list.template.js";

--- a/packages/adaptive-web-components/src/components/picker-menu-option/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/index.ts
@@ -2,6 +2,5 @@ export { definition as PickerMenuOptionDefinition } from "./picker-menu-option.d
 export {
     templateStyles as PickerMenuOptionTemplateStyles,
     aestheticStyles as PickerMenuOptionAestheticStyles,
-    styles as PickerMenuOptionStyles,
 } from "./picker-menu-option.styles.js";
 export { template as PickerMenuOptionTemplate } from "./picker-menu-option.template.js";

--- a/packages/adaptive-web-components/src/components/picker-menu/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/index.ts
@@ -2,6 +2,5 @@ export { definition as PickerMenuDefinition } from "./picker-menu.definition.js"
 export {
     templateStyles as PickerMenuTemplateStyles,
     aestheticStyles as PickerMenuAestheticStyles,
-    styles as PickerMenuStyles,
 } from "./picker-menu.styles.js";
 export { template as PickerMenuTemplate } from "./picker-menu.template.js";

--- a/packages/adaptive-web-components/src/components/picker/index.ts
+++ b/packages/adaptive-web-components/src/components/picker/index.ts
@@ -2,6 +2,5 @@ export { definition as PickerDefinition } from "./picker.definition.js";
 export {
     templateStyles as PickerTemplateStyles,
     aestheticStyles as PickerAestheticStyles,
-    styles as PickerStyles,
 } from "./picker.styles.js";
 export { template as PickerTemplate } from "./picker.template.js";

--- a/packages/adaptive-web-components/src/components/progress-ring/index.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/index.ts
@@ -2,6 +2,5 @@ export { definition as ProgressRingDefinition } from "./progress-ring.definition
 export {
     templateStyles as ProgressRingTemplateStyles,
     aestheticStyles as ProgressRingAestheticStyles,
-    styles as ProgressRingStyles,
 } from "./progress-ring.styles.js";
 export { template as ProgressRingTemplate } from "./progress-ring.template.js";

--- a/packages/adaptive-web-components/src/components/progress/index.ts
+++ b/packages/adaptive-web-components/src/components/progress/index.ts
@@ -2,6 +2,5 @@ export { definition as ProgressDefinition } from "./progress.definition.js";
 export {
     templateStyles as ProgressTemplateStyles,
     aestheticStyles as ProgressAestheticStyles,
-    styles as ProgressStyles,
 } from "./progress.styles.js";
 export { template as ProgressTemplate } from "./progress.template.js";

--- a/packages/adaptive-web-components/src/components/radio-group/index.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/index.ts
@@ -2,6 +2,5 @@ export { definition as RadioGroupDefinition } from "./radio-group.definition.js"
 export {
     templateStyles as RadioGroupTemplateStyles,
     aestheticStyles as RadioGroupAestheticStyles,
-    styles as RadioGroupStyles,
 } from "./radio-group.styles.js";
 export { template as RadioGroupTemplate } from "./radio-group.template.js";

--- a/packages/adaptive-web-components/src/components/radio/index.ts
+++ b/packages/adaptive-web-components/src/components/radio/index.ts
@@ -2,6 +2,5 @@ export { definition as RadioDefinition } from "./radio.definition.js";
 export {
     templateStyles as RadioTemplateStyles,
     aestheticStyles as RadioAestheticStyles,
-    styles as RadioStyles,
 } from "./radio.styles.js";
 export { template as RadioTemplate } from "./radio.template.js";

--- a/packages/adaptive-web-components/src/components/search/index.ts
+++ b/packages/adaptive-web-components/src/components/search/index.ts
@@ -2,6 +2,5 @@ export { definition as SearchDefinition } from "./search.definition.js";
 export {
     templateStyles as SearchTemplateStyles,
     aestheticStyles as SearchAestheticStyles,
-    styles as SearchStyles,
 } from "./search.styles.js";
 export { template as SearchTemplate } from "./search.template.js";

--- a/packages/adaptive-web-components/src/components/select/index.ts
+++ b/packages/adaptive-web-components/src/components/select/index.ts
@@ -2,6 +2,5 @@ export { definition as SelectDefinition } from "./select.definition.js";
 export {
     templateStyles as SelectTemplateStyles,
     aestheticStyles as SelectAestheticStyles,
-    styles as SelectStyles,
 } from "./select.styles.js";
 export { template as SelectTemplate } from "./select.template.js";

--- a/packages/adaptive-web-components/src/components/skeleton/index.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/index.ts
@@ -2,6 +2,5 @@ export { definition as SkeletonDefinition } from "./skeleton.definition.js";
 export {
     templateStyles as SkeletonTemplateStyles,
     aestheticStyles as SkeletonAestheticStyles,
-    styles as SkeletonStyles
 } from "./skeleton.styles.js";
 export { template as SkeletonTemplate } from "./skeleton.template.js";

--- a/packages/adaptive-web-components/src/components/slider-label/index.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/index.ts
@@ -2,6 +2,5 @@ export { definition as SliderLabelDefinition } from "./slider-label.definition.j
 export {
     templateStyles as SliderLabelTemplateStyles,
     aestheticStyles as SliderLabelAestheticStyles,
-    styles as SliderLabelStyles
 } from "./slider-label.styles.js";
 export { template as SliderLabelTemplate } from "./slider-label.template.js";

--- a/packages/adaptive-web-components/src/components/slider/index.ts
+++ b/packages/adaptive-web-components/src/components/slider/index.ts
@@ -2,6 +2,5 @@ export { definition as SliderDefinition } from "./slider.definition.js";
 export {
     templateStyles as SliderTemplateStyles,
     aestheticStyles as SliderAestheticStyles,
-    styles as SliderStyles
 } from "./slider.styles.js";
 export { template as SliderTemplate } from "./slider.template.js";

--- a/packages/adaptive-web-components/src/components/switch/index.ts
+++ b/packages/adaptive-web-components/src/components/switch/index.ts
@@ -2,6 +2,5 @@ export { definition as SwitchDefinition } from "./switch.definition.js";
 export {
     templateStyles as SwitchTemplateStyles,
     aestheticStyles as SwitchAestheticStyles,
-    styles as SwitchStyles,
 } from "./switch.styles.js";
 export { template as SwitchTemplate } from "./switch.template.js";

--- a/packages/adaptive-web-components/src/components/tab-panel/index.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/index.ts
@@ -2,6 +2,5 @@ export { definition as TabPanelDefinition } from "./tab-panel.definition.js";
 export {
     templateStyles as TabPanelTemplateStyles,
     aestheticStyles as TabPanelAestheticStyles,
-    styles as TabPanelStyles,
 } from "./tab-panel.styles.js";
 export { template as TabPanelTemplate } from "./tab-panel.template.js";

--- a/packages/adaptive-web-components/src/components/tab/index.ts
+++ b/packages/adaptive-web-components/src/components/tab/index.ts
@@ -2,6 +2,5 @@ export { definition as TabDefinition } from "./tab.definition.js";
 export {
     templateStyles as TabTemplateStyles,
     aestheticStyles as TabAestheticStyles,
-    styles as TabStyles,
 } from "./tab.styles.js";
 export { template as TabTemplate } from "./tab.template.js";

--- a/packages/adaptive-web-components/src/components/tabs/index.ts
+++ b/packages/adaptive-web-components/src/components/tabs/index.ts
@@ -2,6 +2,5 @@ export { definition as TabsDefinition } from "./tabs.definition.js";
 export {
     templateStyles as TabsTemplateStyles,
     aestheticStyles as TabsAestheticStyles,
-    styles as TabsStyles,
 } from "./tabs.styles.js";
 export { template as TabsTemplate } from "./tabs.template.js";

--- a/packages/adaptive-web-components/src/components/text-area/index.ts
+++ b/packages/adaptive-web-components/src/components/text-area/index.ts
@@ -2,6 +2,5 @@ export { definition as TextAreaDefinition } from "./text-area.definition.js";
 export {
     templateStyles as TextAreaTemplateStyles,
     aestheticStyles as TextAreaAestheticStyles,
-    styles as TextAreaStyles,
 } from "./text-area.styles.js";
 export { template as TextAreaTemplate } from "./text-area.template.js";

--- a/packages/adaptive-web-components/src/components/text-field/index.ts
+++ b/packages/adaptive-web-components/src/components/text-field/index.ts
@@ -2,6 +2,5 @@ export { definition as TextFieldDefinition } from "./text-field.definition.js";
 export {
     templateStyles as TextFieldTemplateStyles,
     aestheticStyles as TextFieldAestheticStyles,
-    styles as TextFieldStyles,
 } from "./text-field.styles.js";
 export { template as TextFieldTemplate } from "./text-field.template.js";

--- a/packages/adaptive-web-components/src/components/toolbar/index.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/index.ts
@@ -2,6 +2,5 @@ export { definition as ToolbarDefinition } from "./toolbar.definition.js";
 export {
     templateStyles as ToolbarTemplateStyles,
     aestheticStyles as ToolbarAestheticStyles,
-    styles as ToolbarStyles,
 } from "./toolbar.styles.js";
 export { template as ToolbarTemplate } from "./toolbar.template.js";

--- a/packages/adaptive-web-components/src/components/tooltip/index.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/index.ts
@@ -2,6 +2,5 @@ export { definition as TooltipDefinition } from "./tooltip.definition.js";
 export {
     templateStyles as TooltipTemplateStyles,
     aestheticStyles as TooltipAestheticStyles,
-    styles as TooltipStyles,
 } from "./tooltip.styles.js";
 export { template as TooltipTemplate } from "./tooltip.template.js";

--- a/packages/adaptive-web-components/src/components/tree-item/index.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/index.ts
@@ -2,6 +2,5 @@ export { definition as TreeItemDefinition } from "./tree-item.definition.js";
 export {
     templateStyles as TreeItemTemplateStyles,
     aestheticStyles as TreeItemAestheticStyles,
-    styles as TreeItemStyles
 } from "./tree-item.styles.js";
 export { template as TreeItemTemplate } from "./tree-item.template.js";

--- a/packages/adaptive-web-components/src/components/tree-view/index.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/index.ts
@@ -2,6 +2,5 @@ export { definition as TreeViewDefinition } from "./tree-view.definition.js";
 export {
     templateStyles as TreeViewTemplateStyles,
     aestheticStyles as TreeViewAestheticStyles,
-    styles as TreeViewStyles
 } from "./tree-view.styles.js";
 export { template as TreeViewTemplate } from "./tree-view.template.js";


### PR DESCRIPTION
## Description

Component `style` exports will go away with migration to modular styling. Removing them now so they are not part of the API.