### PR TITLE
Fixes for NPM publish

### DIFF
--- a/packages/adaptive-ui/.npmignore
+++ b/packages/adaptive-ui/.npmignore
@@ -1,0 +1,23 @@
+# Tests
+dist/dts/__test__/
+dist/esm/__test__/
+*.spec.*
+coverage/
+
+# Source files
+src/
+
+# config files
+.eslintignore
+.eslintrc.cjs
+.eslintrc.json
+.mocharc.json
+.prettierignore
+api-extractor.json
+karma.conf.js
+rollup.config.js
+tsconfig.json
+
+# cache
+.rollupcache
+temp

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -18,9 +18,9 @@
         "url": "https://github.com/adaptive-web-community/adaptive-web-components.git",
         "directory": "packages/adaptive-ui"
     },
-    "main": "./dist/esm/index.js",
-    "module": "./dist/esm/index.js",
-    "types": "./dist/dts/index.d.ts",
+    "main": "dist/esm/index.js",
+    "module": "dist/esm/index.js",
+    "types": "dist/dts/index.d.ts",
     "scripts": {
         "build": "tsc",
         "clean": "rimraf dist",

--- a/packages/adaptive-web-components/.npmignore
+++ b/packages/adaptive-web-components/.npmignore
@@ -1,0 +1,30 @@
+# Tests
+dist/dts/__test__/
+dist/esm/__test__/
+*.spec.*
+coverage/
+
+# Source files
+src/
+
+# config files
+.eslintignore
+.eslintrc.cjs
+.eslintrc.json
+.mocharc.json
+.prettierignore
+api-extractor.json
+karma.conf.js
+rollup.config.js
+tsconfig.json
+tsconfig.build.json
+vite.config.js
+cem.config.mjs
+cem.plugins.mjs
+
+# cache
+.rollupcache
+temp
+
+# storybook
+.storybook/**

--- a/packages/adaptive-web-components/package.json
+++ b/packages/adaptive-web-components/package.json
@@ -18,9 +18,9 @@
         "url": "https://github.com/adaptive-web-community/adaptive-web-components.git",
         "directory": "packages/adaptive-web-components"
     },
-    "main": "./dist/adaptive-web-components.min.js",
-    "module": "./dist/esm/index.js",
-    "types": "./dist/dts/index.d.ts",
+    "main": "dist/esm/index.js",
+    "module": "dist/esm/index.js",
+    "types": "dist/dts/index.d.ts",
     "scripts": {
         "build:tsc": "tsc -p ./tsconfig.build.json",
         "build:bundle": "vite build",


### PR DESCRIPTION
Just some small things I noticed when publishing the packages. We were missing npm ignore files and the package entry points weren't being recognized using relative paths.