### PR TITLE
Migrate components styles to compose with an array.

### DIFF
--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -2,3 +2,4 @@ export * from "./color/index.js";
 export * from "./design-tokens/index.js";
 export * from "./elevation/index.js";
 export * from "./type/index.js";
+export * from "./styles.js";

--- a/packages/adaptive-ui/src/styles.ts
+++ b/packages/adaptive-ui/src/styles.ts
@@ -1,0 +1,11 @@
+/**
+ * Recommended base styles for a component.
+ * 
+ * @remarks
+ * Adds support for `[hidden]` custom elements.
+ */
+export const componentBaseStyles = /* css */`
+    :host([hidden]) {
+        display: none !important;
+    }
+`;

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
@@ -1,8 +1,11 @@
 import { FASTAccordionItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./accordion-item.styles.js";
+import { aestheticStyles, templateStyles } from "./accordion-item.styles.js";
 import { AccordionItemStatics, template } from "./accordion-item.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAccordionItem(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -17,10 +17,6 @@ import { density, heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         flex-direction: column;
@@ -148,13 +144,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Accordion Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/accordion-item/index.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/index.ts
@@ -1,6 +1,6 @@
 export { composeAccordionItem } from "./accordion-item.compose.js";
 export {
-    templateStyles as AccordionItemTemplateStyles,
-    aestheticStyles as AccordionItemAestheticStyles,
+    templateStyles as accordionItemTemplateStyles,
+    aestheticStyles as accordionItemAestheticStyles,
 } from "./accordion-item.styles.js";
-export { template as AccordionItemTemplate, AccordionItemStatics } from "./accordion-item.template.js";
+export { template as accordionItemTemplate, AccordionItemStatics } from "./accordion-item.template.js";

--- a/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
@@ -1,8 +1,11 @@
 import { FASTAccordion } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./accordion.styles.js";
+import { aestheticStyles, templateStyles } from "./accordion.styles.js";
 import { template } from "./accordion.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAccordion(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
@@ -5,10 +5,6 @@ import { neutralForegroundRest, neutralStrokeDividerRest, strokeWidth, typeRampB
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         flex-direction: column;
@@ -24,13 +20,4 @@ export const aestheticStyles: ElementStyles = css`
         color: ${neutralForegroundRest};
         ${typeRampBase}
     }
-`;
-
-/**
- * Default Adaptive UI Accordion styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/accordion/index.ts
+++ b/packages/adaptive-web-components/src/components/accordion/index.ts
@@ -1,6 +1,6 @@
 export { composeAccordion } from "./accordion.compose.js";
 export {
-    templateStyles as AccordionTemplateStyles,
-    aestheticStyles as AccordionAestheticStyles,
+    templateStyles as accordionTemplateStyles,
+    aestheticStyles as accordionAestheticStyles,
 } from "./accordion.styles.js";
-export { template as AccordionTemplate } from "./accordion.template.js";
+export { template as accordionTemplate } from "./accordion.template.js";

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveAnchor } from "./anchor.js";
-import { styles } from "./anchor.styles.js";
+import { aestheticStyles, templateStyles } from "./anchor.styles.js";
 import { template } from "./anchor.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAnchor(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
@@ -1,4 +1,3 @@
-import { FASTAnchor } from '@microsoft/fast-foundation';
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeAnchor } from "./anchor.compose.js";
 

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -17,10 +17,6 @@ import { density, heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
     }
@@ -83,13 +79,4 @@ export const aestheticStyles: ElementStyles = css`
     .control:focus-visible {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Anchor styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/anchor/index.ts
+++ b/packages/adaptive-web-components/src/components/anchor/index.ts
@@ -1,7 +1,7 @@
 export { composeAnchor } from "./anchor.compose.js";
 export {
-    templateStyles as AnchorTemplateStyles,
-    aestheticStyles as AnchorAestheticStyles,
+    templateStyles as anchorTemplateStyles,
+    aestheticStyles as anchorAestheticStyles,
 } from "./anchor.styles.js";
-export { template as AnchorTemplate } from "./anchor.template.js";
+export { template as anchorTemplate } from "./anchor.template.js";
 export { AdaptiveAnchor } from "./anchor.js";

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -1,8 +1,11 @@
 import { FASTAnchoredRegion } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./anchored-region.styles.js";
+import { aestheticStyles, templateStyles } from "./anchored-region.styles.js";
 import { template } from "./anchored-region.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAnchoredRegion(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
         contain: layout;
@@ -18,12 +14,3 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css``;
-
-/**
- * Default Adaptive UI Anchored Region styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
-`;

--- a/packages/adaptive-web-components/src/components/anchored-region/index.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/index.ts
@@ -1,6 +1,6 @@
 export { composeAnchoredRegion } from "./anchored-region.compose.js";
 export {
-    templateStyles as AnchoredRegionTemplateStyles,
-    aestheticStyles as AnchoredRegionAestheticStyles,
+    templateStyles as anchoredRegionTemplateStyles,
+    aestheticStyles as anchoredRegionAestheticStyles,
 } from "./anchored-region.styles.js";
-export { template as AnchoredRegionTemplate } from "./anchored-region.template.js";
+export { template as anchoredRegionTemplate } from "./anchored-region.template.js";

--- a/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
@@ -1,8 +1,11 @@
 import { FASTAvatar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./avatar.styles.js";
+import { aestheticStyles, templateStyles } from "./avatar.styles.js";
 import { template } from "./avatar.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAvatar(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -6,10 +6,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: flex;
@@ -62,13 +58,4 @@ export const aestheticStyles: ElementStyles = css`
         bottom: 0;
         right: 0;
     }
-`;
-
-/**
- * Default Adaptive UI Card styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/avatar/index.ts
+++ b/packages/adaptive-web-components/src/components/avatar/index.ts
@@ -1,6 +1,6 @@
 export { composeAvatar } from "./avatar.compose.js";
 export {
-    templateStyles as AvatarTemplateStyles,
-    aestheticStyles as AvatarAestheticStyles,
+    templateStyles as avatarTemplateStyles,
+    aestheticStyles as avatarAestheticStyles,
 } from "./avatar.styles.js";
-export { template as AvatarTemplate } from "./avatar.template.js";
+export { template as avatarTemplate } from "./avatar.template.js";

--- a/packages/adaptive-web-components/src/components/badge/badge.compose.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.compose.ts
@@ -1,8 +1,11 @@
 import { FASTBadge } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./badge.styles.js";
+import { aestheticStyles, templateStyles } from "./badge.styles.js";
 import { template } from "./badge.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeBadge(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -12,10 +12,6 @@ import {
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
     }
@@ -39,13 +35,4 @@ export const aestheticStyles: ElementStyles = css`
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
-`;
-
-/**
- * Default Adaptive UI Badge styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/badge/index.ts
+++ b/packages/adaptive-web-components/src/components/badge/index.ts
@@ -1,6 +1,6 @@
 export { composeBadge } from "./badge.compose.js";
 export {
-    templateStyles as BadgeTemplateStyles,
-    aestheticStyles as BadgeAestheticStyles,
+    templateStyles as badgeTemplateStyles,
+    aestheticStyles as badgeAestheticStyles,
 } from "./badge.styles.js";
-export { template as BadgeTemplate } from "./badge.template.js";
+export { template as badgeTemplate } from "./badge.template.js";

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -1,8 +1,11 @@
 import { FASTBreadcrumbItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./breadcrumb-item.styles.js";
+import { aestheticStyles, templateStyles } from "./breadcrumb-item.styles.js";
 import { BreadcrumbItemStatics, template } from "./breadcrumb-item.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeBreadcrumbItem(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -14,10 +14,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
     }
@@ -113,13 +109,4 @@ export const aestheticStyles: ElementStyles = css`
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
-`;
-
-/**
- * Default Adaptive UI Breadcrumb Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/index.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/index.ts
@@ -1,6 +1,6 @@
 export { composeBreadcrumbItem } from "./breadcrumb-item.compose.js";
 export {
-    templateStyles as BreadcrumbItemTemplateStyles,
-    aestheticStyles as BreadcrumbItemAestheticStyles,
+    templateStyles as breadcrumbItemTemplateStyles,
+    aestheticStyles as breadcrumbItemAestheticStyles,
 } from "./breadcrumb-item.styles.js";
-export { template as BreadcrumbItemTemplate, BreadcrumbItemStatics } from "./breadcrumb-item.template.js";
+export { template as breadcrumbItemTemplate, BreadcrumbItemStatics } from "./breadcrumb-item.template.js";

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -1,8 +1,11 @@
 import { FASTBreadcrumb } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./breadcrumb.styles.js";
+import { aestheticStyles, templateStyles } from "./breadcrumb.styles.js";
 import { template } from "./breadcrumb.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeBreadcrumb(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
     }
@@ -25,13 +21,4 @@ export const aestheticStyles: ElementStyles = css`
     .list {
         gap: 8px;
     }
-`;
-
-/**
- * Default Adaptive UI Breadcrumb styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/breadcrumb/index.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/index.ts
@@ -1,6 +1,6 @@
 export { composeBreadcrumb } from "./breadcrumb.compose.js";
 export {
-    templateStyles as BreadcrumbTemplateStyles,
-    aestheticStyles as BreadcrumbAestheticStyles,
+    templateStyles as breadcrumbTemplateStyles,
+    aestheticStyles as breadcrumbAestheticStyles,
 } from "./breadcrumb.styles.js";
-export { template as BreadcrumbTemplate } from "./breadcrumb.template.js";
+export { template as breadcrumbTemplate } from "./breadcrumb.template.js";

--- a/packages/adaptive-web-components/src/components/button/button.compose.ts
+++ b/packages/adaptive-web-components/src/components/button/button.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveButton } from "./button.js";
-import { styles } from "./button.styles.js";
+import { aestheticStyles, templateStyles } from "./button.styles.js";
 import { template } from "./button.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeButton(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -17,10 +17,6 @@ import { density, heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
     }
@@ -91,13 +87,4 @@ export const aestheticStyles: ElementStyles = css`
     .control:focus-visible {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Button styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/button/index.ts
+++ b/packages/adaptive-web-components/src/components/button/index.ts
@@ -1,7 +1,7 @@
 export { composeButton } from "./button.compose.js";
 export {
-    templateStyles as ButtonTemplateStyles,
-    aestheticStyles as ButtonAestheticStyles,
+    templateStyles as buttonTemplateStyles,
+    aestheticStyles as buttonAestheticStyles,
 } from "./button.styles.js";
-export { template as ButtonTemplate } from "./button.template.js";
+export { template as buttonTemplate } from "./button.template.js";
 export { AdaptiveButton } from "./button.js";

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -1,8 +1,11 @@
 import { FASTCalendar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./calendar.styles.js";
+import { aestheticStyles, templateStyles } from "./calendar.styles.js";
 import { template } from "./calendar.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCalendar(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -16,10 +16,6 @@ import { baseHeightMultiplier, density } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
     }
@@ -127,13 +123,4 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: 50%;
         position: relative;
     }
-`;
-
-/**
- * Default Adaptive UI Calendar styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/calendar/index.ts
+++ b/packages/adaptive-web-components/src/components/calendar/index.ts
@@ -1,6 +1,6 @@
 export { composeCalendar} from "./calendar.compose.js";
 export {
-    templateStyles as CalendarTemplateStyles,
-    aestheticStyles as CalendarAestheticStyles,
+    templateStyles as calendarTemplateStyles,
+    aestheticStyles as calendarAestheticStyles,
 } from "./calendar.styles.js";
-export { template as CalendarTemplate } from "./calendar.template.js";
+export { template as calendarTemplate } from "./calendar.template.js";

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -1,8 +1,11 @@
 import { FASTCard } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./card.styles.js";
+import { aestheticStyles, templateStyles } from "./card.styles.js";
 import { template } from "./card.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCard(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -14,10 +14,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
     }
@@ -46,13 +42,4 @@ export const aestheticStyles: ElementStyles = css`
         background: ${layerFillInteractiveActive};
         box-shadow: ${elevationCardFocus}
     }
-`;
-
-/**
- * Default Adaptive UI Card styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/card/index.ts
+++ b/packages/adaptive-web-components/src/components/card/index.ts
@@ -1,6 +1,6 @@
 export { composeCard } from "./card.compose.js";
 export {
-    templateStyles as CardTemplateStyles,
-    aestheticStyles as CardAestheticStyles,
+    templateStyles as cardTemplateStyles,
+    aestheticStyles as cardAestheticStyles,
 } from "./card.styles.js";
-export { template as CardTemplate } from "./card.template.js";
+export { template as cardTemplate } from "./card.template.js";

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -1,8 +1,11 @@
 import { FASTCheckbox } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./checkbox.styles.js";
+import { aestheticStyles, templateStyles } from "./checkbox.styles.js";
 import { CheckboxStatics, template } from "./checkbox.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCheckbox(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -24,10 +24,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -134,13 +130,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Checkbox styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/checkbox/index.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/index.ts
@@ -1,6 +1,6 @@
 export { composeCheckbox } from "./checkbox.compose.js";
 export {
-    templateStyles as CheckboxTemplateStyles,
-    aestheticStyles as CheckboxAestheticStyles,
+    templateStyles as checkboxTemplateStyles,
+    aestheticStyles as checkboxAestheticStyles,
 } from "./checkbox.styles.js";
-export { template as CheckboxTemplate, CheckboxStatics } from "./checkbox.template.js";
+export { template as checkboxTemplate, CheckboxStatics } from "./checkbox.template.js";

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -1,8 +1,11 @@
 import { FASTCombobox } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./combobox.styles.js";
+import { aestheticStyles, templateStyles } from "./combobox.styles.js";
 import { ComboboxStatics, template } from "./combobox.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCombobox(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -22,10 +22,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         position: relative;
@@ -142,13 +138,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Combobox styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/combobox/index.ts
+++ b/packages/adaptive-web-components/src/components/combobox/index.ts
@@ -1,6 +1,6 @@
 export { composeCombobox } from "./combobox.compose.js";
 export {
-    templateStyles as ComboboxTemplateStyles,
-    aestheticStyles as ComboboxAestheticStyles,
+    templateStyles as comboboxTemplateStyles,
+    aestheticStyles as comboboxAestheticStyles,
 } from "./combobox.styles.js";
-export { template as ComboboxTemplate, ComboboxStatics } from "./combobox.template.js";
+export { template as comboboxTemplate, ComboboxStatics } from "./combobox.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDataGridCell } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./data-grid-cell.styles.js";
+import { aestheticStyles, templateStyles } from "./data-grid-cell.styles.js";
 import { template } from "./data-grid-cell.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGridCell(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -13,10 +13,6 @@ import {
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         overflow: hidden;
     }
@@ -43,13 +39,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:focus-visible) {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Data Grid Cell styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
@@ -1,6 +1,6 @@
 export { composeDataGridCell } from "./data-grid-cell.compose.js";
 export {
-    templateStyles as DataGridCellTemplateStyles,
-    aestheticStyles as DataGridCellAestheticStyles,
+    templateStyles as dataGridCellTemplateStyles,
+    aestheticStyles as dataGridCellAestheticStyles,
 } from "./data-grid-cell.styles.js";
-export { template as DataGridCellTemplate } from "./data-grid-cell.template.js";
+export { template as dataGridCellTemplate } from "./data-grid-cell.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDataGridRow } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./data-grid-row.styles.js";
+import { aestheticStyles, templateStyles } from "./data-grid-row.styles.js";
 import { template } from "./data-grid-row.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGridRow(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -5,10 +5,6 @@ import { neutralFillRest, neutralStrokeDividerRest, strokeWidth } from "@adaptiv
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: grid;
         box-sizing: border-box;
@@ -33,13 +29,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([cell-type="sticky-header"]) {
         background: ${neutralFillRest};
     }
-`;
-
-/**
- * Default Adaptive UI Data Grid Row styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/data-grid-row/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/index.ts
@@ -1,6 +1,6 @@
 export { composeDataGridRow } from "./data-grid-row.compose.js";
 export {
-    templateStyles as DataGridRowTemplateStyles,
-    aestheticStyles as DataGridRowAestheticStyles,
+    templateStyles as dataGridRowTemplateStyles,
+    aestheticStyles as dataGridRowAestheticStyles,
 } from "./data-grid-row.styles.js";
-export { template as DataGridRowTemplate } from "./data-grid-row.template.js";
+export { template as dataGridRowTemplate } from "./data-grid-row.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDataGrid } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./data-grid.styles.js";
+import { aestheticStyles, templateStyles } from "./data-grid.styles.js";
 import { template } from "./data-grid.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGrid(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         position: relative;
@@ -19,12 +15,3 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css``;
-
-/**
- * Default Adaptive UI Data Grid styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
-`;

--- a/packages/adaptive-web-components/src/components/data-grid/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/index.ts
@@ -1,6 +1,6 @@
 export { composeDataGrid } from "./data-grid.compose.js";
 export {
-    templateStyles as DataGridTemplateStyles,
-    aestheticStyles as DataGridAestheticStyles,
+    templateStyles as dataGridTemplateStyles,
+    aestheticStyles as dataGridAestheticStyles,
 } from "./data-grid.styles.js";
-export { template as DataGridTemplate } from "./data-grid.template.js";
+export { template as dataGridTemplate } from "./data-grid.template.js";

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDialog } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./dialog.styles.js";
+import { aestheticStyles, templateStyles } from "./dialog.styles.js";
 import { template } from "./dialog.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDialog(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
@@ -5,10 +5,6 @@ import { elevationDialog, fillColor, layerCornerRadius, strokeWidth } from "@ada
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         align-items: center;
@@ -59,13 +55,4 @@ export const aestheticStyles: ElementStyles = css`
         background: ${fillColor};
         box-shadow: ${elevationDialog};
     }
-`;
-
-/**
- * Default Adaptive UI Dialog styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/dialog/index.ts
+++ b/packages/adaptive-web-components/src/components/dialog/index.ts
@@ -1,6 +1,6 @@
 export { composeDialog } from "./dialog.compose.js";
 export {
-    templateStyles as DialogTemplateStyles,
-    aestheticStyles as DialogAestheticStyles,
+    templateStyles as dialogTemplateStyles,
+    aestheticStyles as dialogAestheticStyles,
 } from "./dialog.styles.js";
-export { template as DialogTemplate } from "./dialog.template.js";
+export { template as dialogTemplate } from "./dialog.template.js";

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDisclosure } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./disclosure.styles.js";
+import { aestheticStyles, templateStyles } from "./disclosure.styles.js";
 import { template } from "./disclosure.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDisclosure(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -13,10 +13,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
     }
@@ -69,13 +65,4 @@ export const aestheticStyles: ElementStyles = css`
         background: ${accentFillActive};
         color: ${foregroundOnAccentActive};
     }
-`;
-
-/**
- * Default Adaptive UI Disclosure styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/disclosure/index.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/index.ts
@@ -1,6 +1,6 @@
 export { composeDisclosure } from "./disclosure.compose.js";
 export {
-    templateStyles as DisclosureTemplateStyles,
-    aestheticStyles as DisclosureAestheticStyles,
+    templateStyles as disclosureTemplateStyles,
+    aestheticStyles as disclosureAestheticStyles,
 } from "./disclosure.styles.js";
-export { template as DisclosureTemplate } from "./disclosure.template.js";
+export { template as disclosureTemplate } from "./disclosure.template.js";

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -1,8 +1,11 @@
 import { FASTDivider } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./divider.styles.js";
+import { aestheticStyles, templateStyles } from "./divider.styles.js";
 import { template } from "./divider.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDivider(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.ts
@@ -5,10 +5,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
     }
@@ -28,13 +24,4 @@ export const aestheticStyles: ElementStyles = css`
         height: 100%;
         border-left: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
     }
-`;
-
-/**
- * Default Adaptive UI Divider styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/divider/index.ts
+++ b/packages/adaptive-web-components/src/components/divider/index.ts
@@ -1,6 +1,6 @@
 export { composeDivider } from "./divider.compose.js";
 export {
-    templateStyles as DividerTemplateStyles,
-    aestheticStyles as DividerAestheticStyles,
+    templateStyles as dividerTemplateStyles,
+    aestheticStyles as dividerAestheticStyles,
 } from "./divider.styles.js";
-export { template as DividerTemplate } from "./divider.template.js";
+export { template as dividerTemplate } from "./divider.template.js";

--- a/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
@@ -1,8 +1,11 @@
 import { FASTFlipper } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./flipper.styles.js";
+import { aestheticStyles, templateStyles } from "./flipper.styles.js";
 import { FlipperStatics, template } from "./flipper.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeFlipper(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -17,10 +17,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         justify-content: center;
@@ -73,13 +69,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Flipper styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/flipper/index.ts
+++ b/packages/adaptive-web-components/src/components/flipper/index.ts
@@ -1,6 +1,6 @@
 export { composeFlipper } from "./flipper.compose.js";
 export {
-    templateStyles as FlipperTemplateStyles,
-    aestheticStyles as FlipperAestheticStyles,
+    templateStyles as flipperTemplateStyles,
+    aestheticStyles as flipperAestheticStyles,
 } from "./flipper.styles.js";
-export { template as FlipperTemplate, FlipperStatics } from "./flipper.template.js";
+export { template as flipperTemplate, FlipperStatics } from "./flipper.template.js";

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./horizontal-scroll.styles.js";
+import { aestheticStyles, templateStyles } from "./horizontal-scroll.styles.js";
 import { template } from "./horizontal-scroll.template.js";
 import { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeHorizontalScroll(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: block;
@@ -42,15 +38,6 @@ export const aestheticStyles: ElementStyles = css`
     .content {
         gap: 8px;
     }
-`;
-
-/**
- * Default Adaptive UI Horizontal Scroll styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;
 
 /**

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
@@ -1,7 +1,7 @@
 export { composeHorizontalScroll } from "./horizontal-scroll.compose.js";
 export {
-    templateStyles as HorizontalScrollTemplateStyles,
-    aestheticStyles as HorizontalScrollAestheticStyles,
+    templateStyles as horizontalScrollTemplateStyles,
+    aestheticStyles as horizontalScrollAestheticStyles,
 } from "./horizontal-scroll.styles.js";
-export { template as HorizontalScrollTemplate } from "./horizontal-scroll.template.js";
+export { template as horizontalScrollTemplate } from "./horizontal-scroll.template.js";
 export { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";

--- a/packages/adaptive-web-components/src/components/listbox-option/index.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/index.ts
@@ -1,6 +1,6 @@
 export { composeListboxOption } from "./listbox-option.compose.js";
 export {
-    templateStyles as ListboxOptionTemplateStyles,
-    aestheticStyles as ListboxOptionAestheticStyles,
+    templateStyles as listboxOptionTemplateStyles,
+    aestheticStyles as listboxOptionAestheticStyles,
 } from "./listbox-option.styles.js";
-export { template as ListboxOptionTemplate } from "./listbox-option.template.js";
+export { template as listboxOptionTemplate } from "./listbox-option.template.js";

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
@@ -1,8 +1,11 @@
 import { FASTListboxOption } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./listbox-option.styles.js";
+import { aestheticStyles, templateStyles } from "./listbox-option.styles.js";
 import { template } from "./listbox-option.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeListboxOption(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -23,10 +23,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -100,13 +96,4 @@ export const aestheticStyles: ElementStyles = css`
     ::slotted([slot="end"]) {
         display: flex;
     }
-`;
-
-/**
- * Default Adaptive UI Listbox Option styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/listbox/index.ts
+++ b/packages/adaptive-web-components/src/components/listbox/index.ts
@@ -1,6 +1,6 @@
 export { composeListbox } from "./listbox.compose.js";
 export {
-    templateStyles as ListboxTemplateStyles,
-    aestheticStyles as ListboxAestheticStyles,
+    templateStyles as listboxTemplateStyles,
+    aestheticStyles as listboxAestheticStyles,
 } from "./listbox.styles.js";
-export { template as ListboxTemplate } from "./listbox.template.js";
+export { template as listboxTemplate } from "./listbox.template.js";

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -1,8 +1,11 @@
 import { FASTListboxElement } from "@microsoft/fast-foundation";
 import { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./listbox.styles.js";
+import { aestheticStyles, templateStyles } from "./listbox.styles.js";
 import { template } from "./listbox.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeListbox(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -13,10 +13,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         flex-direction: column;
@@ -38,13 +34,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:not([disabled]):focus-within) {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Listbox styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/menu-item/index.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/index.ts
@@ -1,7 +1,7 @@
 export { composeMenuItem } from "./menu-item.compose.js";
 export {
-    templateStyles as MenuItemTemplateStyles,
-    aestheticStyles as MenuItemAestheticStyles,
+    templateStyles as menuItemTemplateStyles,
+    aestheticStyles as menuItemAestheticStyles,
 } from "./menu-item.styles.js";
-export { template as MenuItemTemplate, MenuItemStatics } from "./menu-item.template.js";
+export { template as menuItemTemplate, MenuItemStatics } from "./menu-item.template.js";
 export { AdaptiveMenuItem } from "./menu-item.js";

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveMenuItem } from "./menu-item.js";
-import { styles } from "./menu-item.styles.js";
+import { aestheticStyles, templateStyles } from "./menu-item.styles.js";
 import { MenuItemStatics, template } from "./menu-item.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeMenuItem(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -18,10 +18,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: grid;
         align-items: center;
@@ -169,13 +165,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Menu Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/menu/index.ts
+++ b/packages/adaptive-web-components/src/components/menu/index.ts
@@ -1,7 +1,7 @@
 export { composeMenu } from "./menu.compose.js";
 export {
-    templateStyles as MenuTemplateStyles,
-    aestheticStyles as MenuAestheticStyles,
+    templateStyles as menuTemplateStyles,
+    aestheticStyles as menuAestheticStyles,
 } from "./menu.styles.js";
-export { template as MenuTemplate } from "./menu.template.js";
+export { template as menuTemplate } from "./menu.template.js";
 export { AdaptiveMenu } from "./menu.js";

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveMenu } from "./menu.js";
-import { styles } from "./menu.styles.js";
+import { aestheticStyles, templateStyles } from "./menu.styles.js";
 import { template } from "./menu.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeMenu(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.ts
@@ -11,10 +11,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
     }
@@ -45,13 +41,4 @@ export const aestheticStyles: ElementStyles = css`
     ::slotted(adaptive-divider) {
         margin: 4px 0;
     }
-`;
-
-/**
- * Default Adaptive UI Menu styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/number-field/index.ts
+++ b/packages/adaptive-web-components/src/components/number-field/index.ts
@@ -1,6 +1,6 @@
 export { composeNumberField } from "./number-field.compose.js";
 export {
-    templateStyles as NumberFieldTemplateStyles,
-    aestheticStyles as NumberFieldAestheticStyles,
+    templateStyles as numberFieldTemplateStyles,
+    aestheticStyles as numberFieldAestheticStyles,
 } from "./number-field.styles.js";
-export { template as NumberFieldTemplate, NumberFieldStatics } from "./number-field.template.js";
+export { template as numberFieldTemplate, NumberFieldStatics } from "./number-field.template.js";

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -1,8 +1,11 @@
 import { FASTNumberField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./number-field.styles.js";
+import { aestheticStyles, templateStyles } from "./number-field.styles.js";
 import { NumberFieldStatics, template } from "./number-field.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeNumberField(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -20,10 +20,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
         user-select: none;
@@ -137,13 +133,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Number Field styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/picker-list-item/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/index.ts
@@ -1,6 +1,6 @@
 export { composePickerListItem } from "./picker-list-item.compose.js";
 export {
-    templateStyles as PickerListItemTemplateStyles,
-    aestheticStyles as PickerListItemAestheticStyles,
+    templateStyles as pickerListItemTemplateStyles,
+    aestheticStyles as pickerListItemAestheticStyles,
 } from "./picker-list-item.styles.js";
-export { template as PickerListItemTemplate } from "./picker-list-item.template.js";
+export { template as pickerListItemTemplate } from "./picker-list-item.template.js";

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
@@ -1,8 +1,11 @@
 import { FASTPickerListItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./picker-list-item.styles.js";
+import { aestheticStyles, templateStyles } from "./picker-list-item.styles.js";
 import { template } from "./picker-list-item.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePickerListItem(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -17,10 +17,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         align-items: center;
@@ -59,13 +55,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:focus-visible) {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Picker List Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/picker-list/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/index.ts
@@ -1,6 +1,6 @@
 export { composePickerList } from "./picker-list.compose.js";
 export {
-    templateStyles as PickerListTemplateStyles,
-    aestheticStyles as PickerListAestheticStyles,
+    templateStyles as pickerListTemplateStyles,
+    aestheticStyles as pickerListAestheticStyles,
 } from "./picker-list.styles.js";
-export { template as PickerListTemplate } from "./picker-list.template.js";
+export { template as pickerListTemplate } from "./picker-list.template.js";

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -1,8 +1,11 @@
 import { FASTPickerList } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./picker-list.styles.js";
+import { aestheticStyles, templateStyles } from "./picker-list.styles.js";
 import { template } from "./picker-list.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePickerList(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -20,10 +20,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         flex-wrap: wrap;
@@ -77,13 +73,4 @@ export const aestheticStyles: ElementStyles = css`
         height: calc(${heightNumber} * 1px);
         padding: 0 calc(${designUnit} * 2px + 1px);
     }
-`;
-
-/**
- * Default Adaptive UI Picker List Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/picker-menu-option/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/index.ts
@@ -1,6 +1,6 @@
 export { composePickerMenuOption } from "./picker-menu-option.compose.js";
 export {
-    templateStyles as PickerMenuOptionTemplateStyles,
-    aestheticStyles as PickerMenuOptionAestheticStyles,
+    templateStyles as pickerMenuOptionTemplateStyles,
+    aestheticStyles as pickerMenuOptionAestheticStyles,
 } from "./picker-menu-option.styles.js";
-export { template as PickerMenuOptionTemplate } from "./picker-menu-option.template.js";
+export { template as pickerMenuOptionTemplate } from "./picker-menu-option.template.js";

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
@@ -1,8 +1,11 @@
 import { FASTPickerMenuOption } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./picker-menu-option.styles.js";
+import { aestheticStyles, templateStyles } from "./picker-menu-option.styles.js";
 import { template } from "./picker-menu-option.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePickerMenuOption(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -19,10 +19,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         align-items: center;
@@ -66,13 +62,4 @@ export const aestheticStyles: ElementStyles = css`
         background: ${accentFillRest};
         color: ${foregroundOnAccentRest};
     }
-`;
-
-/**
- * Default Adaptive UI Picker Menu Option styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/picker-menu/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/index.ts
@@ -1,6 +1,6 @@
 export { composePickerMenu } from "./picker-menu.compose.js";
 export {
-    templateStyles as PickerMenuTemplateStyles,
-    aestheticStyles as PickerMenuAestheticStyles,
+    templateStyles as pickerMenuTemplateStyles,
+    aestheticStyles as pickerMenuAestheticStyles,
 } from "./picker-menu.styles.js";
-export { template as PickerMenuTemplate } from "./picker-menu.template.js";
+export { template as pickerMenuTemplate } from "./picker-menu.template.js";

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -1,8 +1,11 @@
 import { FASTPickerMenu } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./picker-menu.styles.js";
+import { aestheticStyles, templateStyles } from "./picker-menu.styles.js";
 import { template } from "./picker-menu.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePickerMenu(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
@@ -5,10 +5,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         box-sizing: border-box;
         width: 100%;
@@ -38,13 +34,4 @@ export const aestheticStyles: ElementStyles = css`
         background: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};
     }
-`;
-
-/**
- * Default Adaptive UI Picker Menu styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/picker/index.ts
+++ b/packages/adaptive-web-components/src/components/picker/index.ts
@@ -1,6 +1,6 @@
 export { composePicker } from "./picker.compose.js";
 export {
-    templateStyles as PickerTemplateStyles,
-    aestheticStyles as PickerAestheticStyles,
+    templateStyles as pickerTemplateStyles,
+    aestheticStyles as pickerAestheticStyles,
 } from "./picker.styles.js";
-export { template as PickerTemplate } from "./picker.template.js";
+export { template as pickerTemplate } from "./picker.template.js";

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -1,8 +1,11 @@
 import { FASTPicker } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./picker.styles.js";
+import { aestheticStyles, templateStyles } from "./picker.styles.js";
 import { template } from "./picker.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePicker(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
     }
@@ -44,12 +40,3 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css``;
-
-/**
- * Default Adaptive UI Picker styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
-`;

--- a/packages/adaptive-web-components/src/components/progress-ring/index.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/index.ts
@@ -1,6 +1,6 @@
 export { composeProgressRing } from "./progress-ring.compose.js";
 export {
-    templateStyles as ProgressRingTemplateStyles,
-    aestheticStyles as ProgressRingAestheticStyles,
+    templateStyles as progressRingTemplateStyles,
+    aestheticStyles as progressRingAestheticStyles,
 } from "./progress-ring.styles.js";
-export { template as ProgressRingTemplate } from "./progress-ring.template.js";
+export { template as progressRingTemplate } from "./progress-ring.template.js";

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -1,8 +1,11 @@
 import { FASTProgressRing } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./progress-ring.styles.js";
+import { aestheticStyles, templateStyles } from "./progress-ring.styles.js";
 import { template } from "./progress-ring.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeProgressRing(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
@@ -6,10 +6,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: flex;
@@ -73,13 +69,4 @@ export const aestheticStyles: ElementStyles = css`
             transform: rotate(1080deg);
         }
     }
-`;
-
-/**
- * Default Adaptive UI Progress styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/progress/index.ts
+++ b/packages/adaptive-web-components/src/components/progress/index.ts
@@ -1,6 +1,6 @@
 export { composeProgress } from "./progress.compose.js";
 export {
-    templateStyles as ProgressTemplateStyles,
-    aestheticStyles as ProgressAestheticStyles,
+    templateStyles as progressTemplateStyles,
+    aestheticStyles as progressAestheticStyles,
 } from "./progress.styles.js";
-export { template as ProgressTemplate } from "./progress.template.js";
+export { template as progressTemplate } from "./progress.template.js";

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -1,8 +1,11 @@
 import { FASTProgress } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./progress.styles.js";
+import { aestheticStyles, templateStyles } from "./progress.styles.js";
 import { template } from "./progress.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeProgress(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.ts
@@ -5,10 +5,6 @@ import { accentForegroundRest, designUnit, neutralFillSecondaryRest } from "@ada
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: flex;
@@ -81,13 +77,4 @@ export const aestheticStyles: ElementStyles = css`
             transform: translateX(300%);
         }
     }
-`;
-
-/**
- * Default Adaptive UI Progress styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/radio-group/index.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/index.ts
@@ -1,6 +1,6 @@
 export { composeRadioGroup } from "./radio-group.compose.js";
 export {
-    templateStyles as RadioGroupTemplateStyles,
-    aestheticStyles as RadioGroupAestheticStyles,
+    templateStyles as radioGroupTemplateStyles,
+    aestheticStyles as radioGroupAestheticStyles,
 } from "./radio-group.styles.js";
-export { template as RadioGroupTemplate } from "./radio-group.template.js";
+export { template as radioGroupTemplate } from "./radio-group.template.js";

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -1,8 +1,11 @@
 import { FASTRadioGroup } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./radio-group.styles.js";
+import { aestheticStyles, templateStyles } from "./radio-group.styles.js";
 import { template } from "./radio-group.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeRadioGroup(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
     }
@@ -34,13 +30,4 @@ export const aestheticStyles: ElementStyles = css`
     .positioning-region {
         gap: 8px;
     }
-`;
-
-/**
- * Default Adaptive UI Radio Group styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/radio/index.ts
+++ b/packages/adaptive-web-components/src/components/radio/index.ts
@@ -1,6 +1,6 @@
 export { composeRadio } from "./radio.compose.js";
 export {
-    templateStyles as RadioTemplateStyles,
-    aestheticStyles as RadioAestheticStyles,
+    templateStyles as radioTemplateStyles,
+    aestheticStyles as radioAestheticStyles,
 } from "./radio.styles.js";
-export { template as RadioTemplate, RadioStatics } from "./radio.template.js";
+export { template as radioTemplate, RadioStatics } from "./radio.template.js";

--- a/packages/adaptive-web-components/src/components/radio/radio.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.compose.ts
@@ -1,8 +1,11 @@
 import { FASTRadio } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./radio.styles.js";
+import { aestheticStyles, templateStyles } from "./radio.styles.js";
 import { RadioStatics, template } from "./radio.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeRadio(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -23,10 +23,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -131,13 +127,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Radio styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/search/index.ts
+++ b/packages/adaptive-web-components/src/components/search/index.ts
@@ -1,6 +1,6 @@
 export { composeSearch } from "./search.compose.js";
 export {
-    templateStyles as SearchTemplateStyles,
-    aestheticStyles as SearchAestheticStyles,
+    templateStyles as searchTemplateStyles,
+    aestheticStyles as searchAestheticStyles,
 } from "./search.styles.js";
-export { template as SearchTemplate } from "./search.template.js";
+export { template as searchTemplate } from "./search.template.js";

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -1,8 +1,11 @@
 import { FASTSearch } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./search.styles.js";
+import { aestheticStyles, templateStyles } from "./search.styles.js";
 import { template } from "./search.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSearch(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -21,10 +21,6 @@ import { density, heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
         user-select: none;
@@ -158,13 +154,4 @@ export const aestheticStyles: ElementStyles = css`
     .clear-button:active {
         background: ${neutralFillStealthActive}
     }
-`;
-
-/**
- * Default Adaptive UI Search Field styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/select/index.ts
+++ b/packages/adaptive-web-components/src/components/select/index.ts
@@ -1,6 +1,6 @@
 export { composeSelect } from "./select.compose.js";
 export {
-    templateStyles as SelectTemplateStyles,
-    aestheticStyles as SelectAestheticStyles,
+    templateStyles as selectTemplateStyles,
+    aestheticStyles as selectAestheticStyles,
 } from "./select.styles.js";
-export { template as SelectTemplate, SelectStatics } from "./select.template.js";
+export { template as selectTemplate, SelectStatics } from "./select.template.js";

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -1,8 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveSelect } from "./select.js";
-import { styles } from "./select.styles.js";
+import { aestheticStyles, templateStyles } from "./select.styles.js";
 import { SelectStatics, template } from "./select.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSelect(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -22,10 +22,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         position: relative;
@@ -140,13 +136,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Select styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/skeleton/index.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/index.ts
@@ -1,6 +1,6 @@
 export { composeSkeleton } from "./skeleton.compose.js";
 export {
-    templateStyles as SkeletonTemplateStyles,
-    aestheticStyles as SkeletonAestheticStyles,
+    templateStyles as skeletonTemplateStyles,
+    aestheticStyles as skeletonAestheticStyles,
 } from "./skeleton.styles.js";
-export { template as SkeletonTemplate } from "./skeleton.template.js";
+export { template as skeletonTemplate } from "./skeleton.template.js";

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -1,8 +1,11 @@
 import { FASTSkeleton } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./skeleton.styles.js";
+import { aestheticStyles, templateStyles } from "./skeleton.styles.js";
 import { template } from "./skeleton.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSkeleton(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
@@ -5,10 +5,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: block;
@@ -85,13 +81,4 @@ export const aestheticStyles: ElementStyles = css`
             transform: translateX(100%);
         }
     }
-`;
-
-/**
- * Default Adaptive UI Skeleton styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/slider-label/index.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/index.ts
@@ -1,6 +1,6 @@
 export { composeSliderLabel } from "./slider-label.compose.js";
 export {
-    templateStyles as SliderLabelTemplateStyles,
-    aestheticStyles as SliderLabelAestheticStyles,
+    templateStyles as sliderLabelTemplateStyles,
+    aestheticStyles as sliderLabelAestheticStyles,
 } from "./slider-label.styles.js";
-export { template as SliderLabelTemplate } from "./slider-label.template.js";
+export { template as sliderLabelTemplate } from "./slider-label.template.js";

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -1,8 +1,11 @@
 import { FASTSliderLabel } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./slider-label.styles.js";
+import { aestheticStyles, templateStyles } from "./slider-label.styles.js";
 import { template } from "./slider-label.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSliderLabel(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -6,10 +6,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host([orientation="horizontal"]) {
         align-self: start;
         grid-row: 2;
@@ -76,13 +72,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Slider Content styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/slider/index.ts
+++ b/packages/adaptive-web-components/src/components/slider/index.ts
@@ -1,6 +1,6 @@
 export { composeSlider } from "./slider.compose.js";
 export {
-    templateStyles as SliderTemplateStyles,
-    aestheticStyles as SliderAestheticStyles,
+    templateStyles as sliderTemplateStyles,
+    aestheticStyles as sliderAestheticStyles,
 } from "./slider.styles.js";
-export { template as SliderTemplate } from "./slider.template.js";
+export { template as sliderTemplate } from "./slider.template.js";

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -1,8 +1,11 @@
 import { FASTSlider } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./slider.styles.js";
+import { aestheticStyles, templateStyles } from "./slider.styles.js";
 import { template } from "./slider.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSlider(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -16,10 +16,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-grid;
         align-items: center;
@@ -166,13 +162,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Slider styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/switch/index.ts
+++ b/packages/adaptive-web-components/src/components/switch/index.ts
@@ -1,6 +1,6 @@
 export { composeSwitch } from "./switch.compose.js";
 export {
-    templateStyles as SwitchTemplateStyles,
-    aestheticStyles as SwitchAestheticStyles,
+    templateStyles as switchTemplateStyles,
+    aestheticStyles as switchAestheticStyles,
 } from "./switch.styles.js";
-export { template as SwitchTemplate } from "./switch.template.js";
+export { template as switchTemplate } from "./switch.template.js";

--- a/packages/adaptive-web-components/src/components/switch/switch.compose.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.compose.ts
@@ -1,8 +1,11 @@
 import { FASTSwitch } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./switch.styles.js";
+import { aestheticStyles, templateStyles } from "./switch.styles.js";
 import { template } from "./switch.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSwitch(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -26,10 +26,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -140,13 +136,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Switch styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tab-panel/index.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/index.ts
@@ -1,6 +1,6 @@
 export { composeTabPanel } from "./tab-panel.compose.js";
 export {
-    templateStyles as TabPanelTemplateStyles,
-    aestheticStyles as TabPanelAestheticStyles,
+    templateStyles as tabPanelTemplateStyles,
+    aestheticStyles as tabPanelAestheticStyles,
 } from "./tab-panel.styles.js";
-export { template as TabPanelTemplate } from "./tab-panel.template.js";
+export { template as tabPanelTemplate } from "./tab-panel.template.js";

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTabPanel } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tab-panel.styles.js";
+import { aestheticStyles, templateStyles } from "./tab-panel.styles.js";
 import { template } from "./tab-panel.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTabPanel(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
@@ -6,10 +6,6 @@ import { density } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: block;
     }
@@ -24,13 +20,4 @@ export const aestheticStyles: ElementStyles = css`
         padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
         ${typeRampBase}
     }
-`;
-
-/**
- * Default Adaptive UI Tab Panel styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tab/index.ts
+++ b/packages/adaptive-web-components/src/components/tab/index.ts
@@ -1,6 +1,6 @@
 export { composeTab } from "./tab.compose.js";
 export {
-    templateStyles as TabTemplateStyles,
-    aestheticStyles as TabAestheticStyles,
+    templateStyles as tabTemplateStyles,
+    aestheticStyles as tabAestheticStyles,
 } from "./tab.styles.js";
-export { template as TabTemplate } from "./tab.template.js";
+export { template as tabTemplate } from "./tab.template.js";

--- a/packages/adaptive-web-components/src/components/tab/tab.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTab } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tab.styles.js";
+import { aestheticStyles, templateStyles } from "./tab.styles.js";
 import { template } from "./tab.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTab(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -16,10 +16,6 @@ import { density, heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -63,13 +59,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Tab styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tabs/index.ts
+++ b/packages/adaptive-web-components/src/components/tabs/index.ts
@@ -1,6 +1,6 @@
 export { composeTabs } from "./tabs.compose.js";
 export {
-    templateStyles as TabsTemplateStyles,
-    aestheticStyles as TabsAestheticStyles,
+    templateStyles as tabsTemplateStyles,
+    aestheticStyles as tabsAestheticStyles,
 } from "./tabs.styles.js";
-export { template as TabsTemplate } from "./tabs.template.js";
+export { template as tabsTemplate } from "./tabs.template.js";

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTabs } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tabs.styles.js";
+import { aestheticStyles, templateStyles } from "./tabs.styles.js";
 import { template } from "./tabs.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTabs(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
@@ -9,10 +9,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: grid;
         grid-template-columns: auto 1fr auto;
@@ -100,13 +96,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([orientation="vertical"]) .activeIndicatorTransition {
         transition: transform 0.2s linear;
     }
-`;
-
-/**
- * Default Adaptive UI Tabs styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/text-area/index.ts
+++ b/packages/adaptive-web-components/src/components/text-area/index.ts
@@ -1,6 +1,6 @@
 export { composeTextArea } from "./text-area.compose.js";
 export {
-    templateStyles as TextAreaTemplateStyles,
-    aestheticStyles as TextAreaAestheticStyles,
+    templateStyles as textAreaTemplateStyles,
+    aestheticStyles as textAreaAestheticStyles,
 } from "./text-area.styles.js";
-export { template as TextAreaTemplate } from "./text-area.template.js";
+export { template as textAreaTemplate } from "./text-area.template.js";

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTextArea } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./text-area.styles.js";
+import { aestheticStyles, templateStyles } from "./text-area.styles.js";
 import { template } from "./text-area.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTextArea(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -18,10 +18,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         flex-direction: column;
@@ -94,13 +90,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:not([disabled]):focus-within) .control {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
-`;
-
-/**
- * Default Adaptive UI Text Area styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/text-field/index.ts
+++ b/packages/adaptive-web-components/src/components/text-field/index.ts
@@ -1,6 +1,6 @@
 export { composeTextField } from "./text-field.compose.js";
 export {
-    templateStyles as TextFieldTemplateStyles,
-    aestheticStyles as TextFieldAestheticStyles,
+    templateStyles as textFieldTemplateStyles,
+    aestheticStyles as textFieldAestheticStyles,
 } from "./text-field.styles.js";
-export { template as TextFieldTemplate } from "./text-field.template.js";
+export { template as textFieldTemplate } from "./text-field.template.js";

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTextField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./text-field.styles.js";
+import { aestheticStyles, templateStyles } from "./text-field.styles.js";
 import { template } from "./text-field.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTextField(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -18,10 +18,6 @@ import { heightNumber } from "../../styles/index.js";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-block;
         user-select: none;
@@ -107,13 +103,4 @@ export const aestheticStyles: ElementStyles = css`
     .control:focus-visible {
         outline: none;
     }
-`;
-
-/**
- * Default Adaptive UI Text Field styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/toolbar/index.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/index.ts
@@ -1,6 +1,6 @@
 export { composeToolbar } from "./toolbar.compose.js";
 export {
-    templateStyles as ToolbarTemplateStyles,
-    aestheticStyles as ToolbarAestheticStyles,
+    templateStyles as toolbarTemplateStyles,
+    aestheticStyles as toolbarAestheticStyles,
 } from "./toolbar.styles.js";
-export { template as ToolbarTemplate } from "./toolbar.template.js";
+export { template as toolbarTemplate } from "./toolbar.template.js";

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -1,8 +1,11 @@
 import { FASTToolbar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./toolbar.styles.js";
+import { aestheticStyles, templateStyles } from "./toolbar.styles.js";
 import { template } from "./toolbar.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeToolbar(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -5,10 +5,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: inline-flex;
         align-items: center;
@@ -54,13 +50,4 @@ export const aestheticStyles: ElementStyles = css`
     .positioning-region {
         gap: 8px;
     }
-`;
-
-/**
- * Default Adaptive UI Toolbar styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tooltip/index.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/index.ts
@@ -1,6 +1,6 @@
 export { composeTooltip } from "./tooltip.compose.js";
 export {
-    templateStyles as TooltipTemplateStyles,
-    aestheticStyles as TooltipAestheticStyles,
+    templateStyles as tooltipTemplateStyles,
+    aestheticStyles as tooltipAestheticStyles,
 } from "./tooltip.styles.js";
-export { template as TooltipTemplate } from "./tooltip.template.js";
+export { template as tooltipTemplate } from "./tooltip.template.js";

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTooltip } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tooltip.styles.js";
+import { aestheticStyles, templateStyles } from "./tooltip.styles.js";
 import { template } from "./tooltip.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTooltip(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -13,10 +13,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         visibility: hidden;
     }
@@ -62,13 +58,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([show="true"][visible]) {
         transition: none;
     }
-`;
-
-/**
- * Default Adaptive UI Tooltip styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tree-item/index.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/index.ts
@@ -1,6 +1,6 @@
 export { composeTreeItem } from "./tree-item.compose.js";
 export {
-    templateStyles as TreeItemTemplateStyles,
-    aestheticStyles as TreeItemAestheticStyles,
+    templateStyles as treeItemTemplateStyles,
+    aestheticStyles as treeItemAestheticStyles,
 } from "./tree-item.styles.js";
-export { template as TreeItemTemplate, TreeItemStatics } from "./tree-item.template.js";
+export { template as treeItemTemplate, TreeItemStatics } from "./tree-item.template.js";

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTreeItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tree-item.styles.js";
+import { aestheticStyles, templateStyles } from "./tree-item.styles.js";
 import { template, TreeItemStatics } from "./tree-item.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTreeItem(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -38,10 +38,6 @@ const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         position: relative;
         display: block;
@@ -174,13 +170,4 @@ export const aestheticStyles: ElementStyles = css`
     :host([disabled]) .control {
         opacity: 0.3;
     }
-`;
-
-/**
- * Default Adaptive UI Tree Item styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
 `;

--- a/packages/adaptive-web-components/src/components/tree-view/index.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/index.ts
@@ -1,6 +1,6 @@
 export { composeTreeView } from "./tree-view.compose.js";
 export {
-    templateStyles as TreeViewTemplateStyles,
-    aestheticStyles as TreeViewAestheticStyles,
+    templateStyles as treeViewTemplateStyles,
+    aestheticStyles as treeViewAestheticStyles,
 } from "./tree-view.styles.js";
-export { template as TreeViewTemplate } from "./tree-view.template.js";
+export { template as treeViewTemplate } from "./tree-view.template.js";

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -1,8 +1,11 @@
 import { FASTTreeView } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
+import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
-import { styles } from "./tree-view.styles.js";
+import { aestheticStyles, templateStyles } from "./tree-view.styles.js";
 import { template } from "./tree-view.template.js";
+
+const styles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTreeView(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
@@ -4,10 +4,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  * Basic layout styling associated with the anatomy of the template.
  */
 export const templateStyles: ElementStyles = css`
-    :host([hidden]) {
-        display: none;
-    }
-
     :host {
         display: flex;
         flex-direction: column;
@@ -20,12 +16,3 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css``;
-
-/**
- * Default Adaptive UI Tree View styles.
- */
-export const styles: ElementStyles = css`
-    ${templateStyles}
-
-    ${aestheticStyles}
-`;


### PR DESCRIPTION
# Pull Request

## Description

Continuing the path of composing component styling. This change uses the ability to provide an array of styles for a component, which will be important when the adaptive styles are either generated during build time or constructed from helper modules.

Pulled the host hidden common style declaration out as a helper in `adaptive-ui`. We may consider more of those structural helpers as Adaptive UI evolves.

Also made export casing consistent.

## Reviewer Notes

The same change was made to all 50 components, touching `component.compose.ts`, `component.styles.ts`, and `index.ts`.

Running `lint:fix` cleaned up `anchor.definition.ts`.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Continue migrating the `aestheticStyles` to Adaptive UI modules.