### PR TITLE
Updated example svg inline config

### DIFF
--- a/examples/use-adaptive-components/package.json
+++ b/examples/use-adaptive-components/package.json
@@ -27,7 +27,7 @@
         "@adaptive-web/adaptive-web-components": "0.1.0"
     },
     "devDependencies": {
-        "vite-plugin-svgo": "^1.2.0",
+        "vite-plugin-svgo": "1.0.5",
         "rimraf": "^3.0.2",
         "typescript": "^4.7.0",
         "vite": "^4.1.1"

--- a/examples/use-adaptive-components/vite.config.js
+++ b/examples/use-adaptive-components/vite.config.js
@@ -2,5 +2,7 @@ import { defineConfig } from "vite";
 import svg from 'vite-plugin-svgo'
 
 export default defineConfig({
-	plugins: [svg()]
-})
+	// Turn off all plugins, effectively just using the inlining capability.
+	// Many icon libraries, like Fluent System Icons, are already optimized and the defaults can have negative consequences.
+	plugins: [svg({plugins:[]})]
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "rimraf": "^3.0.2",
                 "typescript": "^4.7.0",
                 "vite": "^4.1.1",
-                "vite-plugin-svgo": "^1.2.0"
+                "vite-plugin-svgo": "1.0.5"
             }
         },
         "examples/use-adaptive-components/node_modules/acorn": {
@@ -56,129 +56,6 @@
             "dev": true,
             "optional": true,
             "peer": true
-        },
-        "examples/use-adaptive-components/node_modules/css-select": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-            "dev": true,
-            "dependencies": {
-                "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-            "dev": true,
-            "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/csso": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-            "dev": true,
-            "dependencies": {
-                "css-tree": "~2.2.0"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/csso/node_modules/css-tree": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-            "dev": true,
-            "dependencies": {
-                "mdn-data": "2.0.28",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/csso/node_modules/mdn-data": {
-            "version": "2.0.28",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-            "dev": true
-        },
-        "examples/use-adaptive-components/node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dev": true,
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-            "dev": true,
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/entities": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-            "dev": true
         },
         "examples/use-adaptive-components/node_modules/picocolors": {
             "version": "1.0.0",
@@ -208,39 +85,6 @@
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/svgo": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
-            "dev": true,
-            "dependencies": {
-                "@trysound/sax": "0.2.0",
-                "commander": "^7.2.0",
-                "css-select": "^5.1.0",
-                "css-tree": "^2.2.1",
-                "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
-            },
-            "bin": {
-                "svgo": "bin/svgo"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/svgo"
-            }
-        },
-        "examples/use-adaptive-components/node_modules/svgo/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10"
             }
         },
         "examples/use-adaptive-components/node_modules/terser": {
@@ -310,20 +154,6 @@
                 "terser": {
                     "optional": true
                 }
-            }
-        },
-        "examples/use-adaptive-components/node_modules/vite-plugin-svgo": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-svgo/-/vite-plugin-svgo-1.2.0.tgz",
-            "integrity": "sha512-Pbc8lL3al5ZhI6467VdmwGfR/LoEi1kD2opt546Nh2drcVuUPaGG6jHKaHpFDueFSAKM8OdiAKp/cF702JvaIQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/svgo": "3.0.0",
-                "svgo": "3.0.2"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.9.4",
-                "vite": ">=4.0.2"
             }
         },
         "node_modules/@adaptive-web/adaptive-ui": {
@@ -12162,13 +11992,12 @@
             "dev": true
         },
         "node_modules/@types/svgo": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-3.0.0.tgz",
-            "integrity": "sha512-G5qLWNq/rMvSM1EyY4E2iEd+s9km/PxLkzPkA2lghrgWJ2jrVMuB1ZsGOzL4YAWCy5sAoUw7SEQseHE2qypF2w==",
-            "deprecated": "This is a stub types definition. svgo provides its own type definitions, so you do not need this installed.",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-2.6.4.tgz",
+            "integrity": "sha512-l4cmyPEckf8moNYHdJ+4wkHvFxjyW6ulm9l4YGaOxeyBWPhBOT0gvni1InpFPdzx1dKf/2s62qGITwxNWnPQng==",
             "dev": true,
             "dependencies": {
-                "svgo": "*"
+                "@types/node": "*"
             }
         },
         "node_modules/@types/tapable": {
@@ -28740,6 +28569,16 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/vite-plugin-svgo": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vite-plugin-svgo/-/vite-plugin-svgo-1.0.5.tgz",
+            "integrity": "sha512-8UXU/A20ugTLgl2LJI60hRgfmp2H8civpSWMGJFsg2P6jyrw/bavyMY945M3JR5q5mVunAZ1dVHaIBy2AgYQvg==",
+            "dev": true,
+            "dependencies": {
+                "@types/svgo": "2.6.4",
+                "svgo": "2.8.0"
+            }
+        },
         "node_modules/vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -30441,7 +30280,7 @@
                 "rimraf": "^3.0.2",
                 "typescript": "^4.7.0",
                 "vite": "^4.1.1",
-                "vite-plugin-svgo": "^1.2.0"
+                "vite-plugin-svgo": "1.0.5"
             },
             "dependencies": {
                 "acorn": {
@@ -30460,99 +30299,6 @@
                     "optional": true,
                     "peer": true
                 },
-                "css-select": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-                    "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-                    "dev": true,
-                    "requires": {
-                        "boolbase": "^1.0.0",
-                        "css-what": "^6.1.0",
-                        "domhandler": "^5.0.2",
-                        "domutils": "^3.0.1",
-                        "nth-check": "^2.0.1"
-                    }
-                },
-                "css-tree": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-                    "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-                    "dev": true,
-                    "requires": {
-                        "mdn-data": "2.0.30",
-                        "source-map-js": "^1.0.1"
-                    }
-                },
-                "csso": {
-                    "version": "5.0.5",
-                    "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-                    "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-                    "dev": true,
-                    "requires": {
-                        "css-tree": "~2.2.0"
-                    },
-                    "dependencies": {
-                        "css-tree": {
-                            "version": "2.2.1",
-                            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-                            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-                            "dev": true,
-                            "requires": {
-                                "mdn-data": "2.0.28",
-                                "source-map-js": "^1.0.1"
-                            }
-                        },
-                        "mdn-data": {
-                            "version": "2.0.28",
-                            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-                            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-                            "dev": true
-                        }
-                    }
-                },
-                "dom-serializer": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-                    "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-                    "dev": true,
-                    "requires": {
-                        "domelementtype": "^2.3.0",
-                        "domhandler": "^5.0.2",
-                        "entities": "^4.2.0"
-                    }
-                },
-                "domhandler": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-                    "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-                    "dev": true,
-                    "requires": {
-                        "domelementtype": "^2.3.0"
-                    }
-                },
-                "domutils": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-                    "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-                    "dev": true,
-                    "requires": {
-                        "dom-serializer": "^2.0.0",
-                        "domelementtype": "^2.3.0",
-                        "domhandler": "^5.0.1"
-                    }
-                },
-                "entities": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-                    "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-                    "dev": true
-                },
-                "mdn-data": {
-                    "version": "2.0.30",
-                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-                    "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-                    "dev": true
-                },
                 "picocolors": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -30568,28 +30314,6 @@
                         "nanoid": "^3.3.4",
                         "picocolors": "^1.0.0",
                         "source-map-js": "^1.0.2"
-                    }
-                },
-                "svgo": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-                    "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
-                    "dev": true,
-                    "requires": {
-                        "@trysound/sax": "0.2.0",
-                        "commander": "^7.2.0",
-                        "css-select": "^5.1.0",
-                        "css-tree": "^2.2.1",
-                        "csso": "^5.0.5",
-                        "picocolors": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "commander": {
-                            "version": "7.2.0",
-                            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-                            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-                            "dev": true
-                        }
                     }
                 },
                 "terser": {
@@ -30617,16 +30341,6 @@
                         "postcss": "^8.4.21",
                         "resolve": "^1.22.1",
                         "rollup": "^3.10.0"
-                    }
-                },
-                "vite-plugin-svgo": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vite-plugin-svgo/-/vite-plugin-svgo-1.2.0.tgz",
-                    "integrity": "sha512-Pbc8lL3al5ZhI6467VdmwGfR/LoEi1kD2opt546Nh2drcVuUPaGG6jHKaHpFDueFSAKM8OdiAKp/cF702JvaIQ==",
-                    "dev": true,
-                    "requires": {
-                        "@types/svgo": "3.0.0",
-                        "svgo": "3.0.2"
                     }
                 }
             }
@@ -39346,12 +39060,12 @@
             "dev": true
         },
         "@types/svgo": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-3.0.0.tgz",
-            "integrity": "sha512-G5qLWNq/rMvSM1EyY4E2iEd+s9km/PxLkzPkA2lghrgWJ2jrVMuB1ZsGOzL4YAWCy5sAoUw7SEQseHE2qypF2w==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-2.6.4.tgz",
+            "integrity": "sha512-l4cmyPEckf8moNYHdJ+4wkHvFxjyW6ulm9l4YGaOxeyBWPhBOT0gvni1InpFPdzx1dKf/2s62qGITwxNWnPQng==",
             "dev": true,
             "requires": {
-                "svgo": "*"
+                "@types/node": "*"
             }
         },
         "@types/tapable": {
@@ -52199,6 +51913,16 @@
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-stringify-position": "^2.0.0"
+            }
+        },
+        "vite-plugin-svgo": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vite-plugin-svgo/-/vite-plugin-svgo-1.0.5.tgz",
+            "integrity": "sha512-8UXU/A20ugTLgl2LJI60hRgfmp2H8civpSWMGJFsg2P6jyrw/bavyMY945M3JR5q5mVunAZ1dVHaIBy2AgYQvg==",
+            "dev": true,
+            "requires": {
+                "@types/svgo": "2.6.4",
+                "svgo": "2.8.0"
             }
         },
         "vm-browserify": {


### PR DESCRIPTION
# Pull Request

## Description

Downgraded the dependency on `vite-plugin-svgo`. It has a dependency on `svgo`, which prior to version 3 did not contain type information. When the plugin was updated it migrated to types version 3, which was just a stub package. This was causing an issue with adding our Figma Designer package which needs to override TypeScript type lookup config.

Also turned off all plugins to simply pass svgs through. The default settings of svgo can sometimes cause issues, specifically removing the `viewBox` so since our default icons (Fluent) are already optimized let's defer the optimization. If consumers want in their own configuration they can turn it on.

### Issues

[#r3dDoX/vite-plugin-svgo/1](https://github.com/r3dDoX/vite-plugin-svgo/issues/1)

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Could update back to the current version of the plugin once the types issue is fixed.