### PR TITLE
Fix black or white foreground recipe

### DIFF
--- a/change/@adaptive-web-adaptive-ui-a7fba9b9-4637-44fe-bbe8-525e6a6b464e.json
+++ b/change/@adaptive-web-adaptive-ui-a7fba9b9-4637-44fe-bbe8-525e6a6b464e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix black or white foreground recipe Minor Adaptive UI Explorer fixes",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/package.json
+++ b/packages/adaptive-ui-explorer/package.json
@@ -24,7 +24,7 @@
         "clean": "rimraf dist",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
-        "start": "vite --open",
+        "start": "vite --force --open",
         "test": "npm run lint && npm run build"
     },
     "dependencies": {

--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -33,6 +33,8 @@ import "./components/control-pane/index.js";
 import "./components/layer-background/index.js";
 import "./components/palette-gradient/palette-gradient.js";
 
+DesignToken.registerDefaultStyleTarget();
+
 const colorBlockTemplate = html<App>`
     ${repeat(
         (x) => x.backgrounds,

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -15,17 +15,17 @@ function template<T extends AdaptiveComponent>(): ElementViewTemplate<T> {
             tabindex="0"
             style="
                 --ac-fill-rest: ${x => x.fillRest?.createCSS() || "transparent"};
-                --ac-fill-hover: ${x => x.fillHover?.createCSS() || "transparent"};
-                --ac-fill-active: ${x => x.fillActive?.createCSS() || "transparent"};
-                --ac-fill-focus: ${x => x.fillFocus?.createCSS() || "transparent"};
+                --ac-fill-hover: ${x => x.fillHover?.createCSS() || x.fillRest?.createCSS() || "transparent"};
+                --ac-fill-active: ${x => x.fillActive?.createCSS() || x.fillRest?.createCSS() || "transparent"};
+                --ac-fill-focus: ${x => x.fillFocus?.createCSS() || x.fillRest?.createCSS() || "transparent"};
                 --ac-stroke-rest: ${x => x.strokeRest?.createCSS() || "transparent"};
-                --ac-stroke-hover: ${x => x.strokeHover?.createCSS() || "transparent"};
-                --ac-stroke-active: ${x => x.strokeActive?.createCSS() || "transparent"};
-                --ac-stroke-focus: ${x => x.strokeFocus?.createCSS() || "transparent"};
+                --ac-stroke-hover: ${x => x.strokeHover?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
+                --ac-stroke-active: ${x => x.strokeActive?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
+                --ac-stroke-focus: ${x => x.strokeFocus?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
                 --ac-foreground-rest: ${x => x.foregroundRest?.createCSS() || "transparent"};
-                --ac-foreground-hover: ${x => x.foregroundHover?.createCSS() || "transparent"};
-                --ac-foreground-active: ${x => x.foregroundActive?.createCSS() || "transparent"};
-                --ac-foreground-focus: ${x => x.foregroundFocus?.createCSS() || "transparent"};
+                --ac-foreground-hover: ${x => x.foregroundHover?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
+                --ac-foreground-active: ${x => x.foregroundActive?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
+                --ac-foreground-focus: ${x => x.foregroundFocus?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
             "
         >
             <slot></slot>

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -283,7 +283,9 @@ const textComponents = html<ColorBlock>`
         ></app-swatch>
 
         <div class="example">
-            <app-adaptive-component :foregroundRest="${x => neutralForegroundHint}">
+            <app-adaptive-component
+                :foregroundRest="${x => neutralForegroundHint}"
+            >
                 Hint
             </app-adaptive-component>
         </div>
@@ -321,13 +323,6 @@ const textComponents = html<ColorBlock>`
             recipe-name="accentForegroundActive"
             :fillRecipe="${x => fillColor}"
             :foregroundRecipe="${x => accentForegroundActive}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
         ></app-swatch>
     </template>
 `;
@@ -443,7 +438,9 @@ const formComponents = html<ColorBlock>`
         ></app-swatch>
 
         <div class="example">
-            <app-adaptive-component :strokeRest="${x => neutralStrokeDividerRest}">
+            <app-adaptive-component
+                :strokeRest="${x => neutralStrokeDividerRest}"
+            >
                 Divider
             </app-adaptive-component>
         </div>

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.spec.ts
@@ -1,3 +1,4 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 import chai from "chai";
 import { SwatchRGB } from "../swatch.js";
 import { _black, _white } from "../utilities/color-constants.js";
@@ -5,8 +6,10 @@ import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 const { expect } = chai;
 
+const middleGrey = SwatchRGB.from(parseColorHexRGB("#808080")!);
+
 describe("blackOrWhiteByContrast", (): void => {
-    it("should return black when background does not meet contrast ratio", (): void => {
+    it("should return black when background does not meet contrast ratio with white", (): void => {
         const small = blackOrWhiteByContrast(_white, 4.5, false) as SwatchRGB;
         const large = blackOrWhiteByContrast(_white, 3, false) as SwatchRGB;
 
@@ -17,5 +20,34 @@ describe("blackOrWhiteByContrast", (): void => {
         expect(large.r).to.equal(_black.r);
         expect(large.g).to.equal(_black.g);
         expect(large.b).to.equal(_black.b);
+    });
+
+    it("should return black when default if either pass", (): void => {
+        const result = blackOrWhiteByContrast(middleGrey, 3, true) as SwatchRGB;
+
+        expect(result.r).to.equal(_black.r);
+        expect(result.g).to.equal(_black.g);
+        expect(result.b).to.equal(_black.b);
+    });
+
+    it("should return white when default if either pass", (): void => {
+        const result = blackOrWhiteByContrast(middleGrey, 3, false) as SwatchRGB;
+
+        expect(result.r).to.equal(_white.r);
+        expect(result.g).to.equal(_white.g);
+        expect(result.b).to.equal(_white.b);
+    });
+
+    it("should return highest contrast when neither black nor white pass", (): void => {
+        const resultDefaultWhite = blackOrWhiteByContrast(middleGrey, 7, false) as SwatchRGB;
+        const resultDefaultBlack = blackOrWhiteByContrast(middleGrey, 7, true) as SwatchRGB;
+
+        expect(resultDefaultWhite.r).to.equal(_black.r);
+        expect(resultDefaultWhite.g).to.equal(_black.g);
+        expect(resultDefaultWhite.b).to.equal(_black.b);
+
+        expect(resultDefaultBlack.r).to.equal(_black.r);
+        expect(resultDefaultBlack.g).to.equal(_black.g);
+        expect(resultDefaultBlack.b).to.equal(_black.b);
     });
 });

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.ts
@@ -4,6 +4,9 @@ import { _black, _white } from "../utilities/color-constants.js";
 /**
  * Gets a black or white Swatch based on the reference color and minimum contrast.
  *
+ * @remarks
+ * If neither black nor white meet the requested contrast the highest contrasting color is returned.
+ *
  * @param reference - The reference color
  * @param minContrast - The minimum contrast required for black or white from `reference`
  * @param defaultBlack - True to default to black if both black and white meet contrast
@@ -14,5 +17,13 @@ import { _black, _white } from "../utilities/color-constants.js";
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch {
     const defaultColor = defaultBlack ? _black : _white;
     const otherColor = defaultBlack ? _white : _black;
-    return reference.contrast(defaultColor) >= minContrast ? defaultColor : otherColor;
+    const defaultContrast = reference.contrast(defaultColor);
+    const otherContrast = reference.contrast(otherColor);
+    return defaultContrast >= minContrast
+        ? defaultColor
+        : otherContrast >= minContrast
+        ? otherColor
+        : defaultContrast > otherContrast
+        ? defaultColor
+        : otherColor;
 }


### PR DESCRIPTION
# Pull Request

## Description

In some cases, a less-contrasting foreground color might be returned. The `blackOrWhiteByContrast` recipe has an option for whether to force black as the foreground color if it passes. Otherwise it will default to white because that tends to be easier to read over an accent color. In some cases, particularly dark accent colors, if the preferred foreground color didn't pass min contrast the "other" color was returned, even though _that_ color might not pass the min contrast either.

Now it will return the highest contrasting color if neither meets the requirements.

Includes minor Adaptive UI Explorer fixes.

## Reviewer Notes

The other changes in the `adaptive-ui-explorer` package are minor formatting or consistency issues I ran into while working on this.

## Test Plan
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.