### PR TITLE
Restructure color recipe design token definition

### DIFF
--- a/change/@adaptive-web-adaptive-ui-5c23ca46-af72-4a7c-88fd-ccefcc81bd59.json
+++ b/change/@adaptive-web-adaptive-ui-5c23ca46-af72-4a7c-88fd-ccefcc81bd59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restructure color recipe design token definition",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -111,8 +111,8 @@ export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference:
 export const bodyFont: CSSDesignToken<string>;
 
 // @public
-export interface ColorRecipe {
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): Swatch;
+export interface ColorRecipe<T = Swatch> {
+    evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
 }
 
 // @public
@@ -205,13 +205,13 @@ export const fillColor: CSSDesignToken<Swatch>;
 export const focusStrokeInner: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const focusStrokeInnerRecipe: DesignToken<ColorRecipe>;
+export const focusStrokeInnerRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
 export const focusStrokeOuter: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const focusStrokeOuterRecipe: DesignToken<ColorRecipe>;
+export const focusStrokeOuterRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
 export const focusStrokeWidth: CSSDesignToken<number>;
@@ -238,8 +238,7 @@ export const foregroundOnAccentRest: CSSDesignToken<Swatch>;
 export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection): InteractiveSwatchSet;
 
 // @public
-export interface InteractiveColorRecipe {
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet;
+export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet> {
 }
 
 // @public
@@ -499,7 +498,7 @@ export const neutralForegroundFocusDelta: DesignToken<number>;
 export const neutralForegroundHint: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralForegroundHintRecipe: DesignToken<ColorRecipe>;
+export const neutralForegroundHintRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
 export const neutralForegroundHover: CSSDesignToken<Swatch>;
@@ -529,7 +528,7 @@ export const neutralStrokeActive: CSSDesignToken<Swatch>;
 export const neutralStrokeActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDividerRecipe: DesignToken<ColorRecipe>;
+export const neutralStrokeDividerRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
 export const neutralStrokeDividerRest: CSSDesignToken<Swatch>;

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -6,14 +6,14 @@ import { Swatch } from "./swatch.js";
  *
  * @public
  */
-export interface ColorRecipe {
+export interface ColorRecipe<T = Swatch> {
     /**
-     * Evaluate a single color value.
+     * Evaluate a color recipe.
      *
      * @param resolver - A function that resolves design tokens
      * @param reference - The reference color, implementation defaults to `fillColor`, but sometimes overridden for nested color recipes
      */
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): Swatch;
+    evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
 }
 
 /**
@@ -21,15 +21,7 @@ export interface ColorRecipe {
  *
  * @public
  */
-export interface InteractiveColorRecipe {
-    /**
-     * Evaluate an interactive color set.
-     *
-     * @param resolver - A function that resolves design tokens
-     * @param reference - The reference color, implementation defaults to `fillColor`, but sometimes overridden for nested color recipes
-     */
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet;
-}
+export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet> {}
 
 /**
  * A set of {@link Swatch}es to use for an interactive control's states.


### PR DESCRIPTION
# Pull Request

## Description

Updates the definition of the color `DesignToken`s to use some helper functions to tie the definitions together more. These tokens have been difficult to keep in sync because there are so many strings.

I tried to talk myself out of doing this change because the evolution is to move these to being generated, but as part of the evolution I need to rename some of the recipe sets, so I wanted to start here.

### Issues

An update of [FAST 6238](https://github.com/microsoft/fast/pull/6238).

## Reviewer Notes

A lot of find and replace here. Same change for each recipe set.

## Test Plan

Tested that the build worked and that the Storybook site looked correct.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

The immediately following change will introduce semantic named color recipe sets that will be composed into functional styles that will maintain accessibility and design intent. These will be the default recommended Adaptive UI styles, though the infrastructure will still exist to do whatever is needed.