### PR TITLE
Updated to semantic color recipes and added WCAG contrast level support

### DIFF
--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -14,6 +14,7 @@ import {
     Palette,
     Swatch,
     SwatchRGB,
+    wcagContrastLevel,
 } from "@adaptive-web/adaptive-ui";
 import {
     attr,
@@ -296,6 +297,12 @@ export class App extends FASTElement implements AppAttributes {
 
     public controlPaneHandler(e: CustomEvent) {
         const detail: { field: string; value: any } = e.detail;
-        (this as any)[detail.field] = detail.value;
+        if (detail.field === "wcagContrastLevel") {
+            if (this.$fastController.isConnected) {
+                wcagContrastLevel.setValueFor(this.canvas, detail.value);
+            }
+        } else {
+            (this as any)[detail.field] = detail.value;
+        }
     }
 }

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -26,9 +26,6 @@ import {
     neutralFillStealthFocus,
     neutralFillStealthHover,
     neutralFillStealthRest,
-    neutralFillStrongActive,
-    neutralFillStrongHover,
-    neutralFillStrongRest,
     neutralForegroundActive,
     neutralForegroundFocus,
     neutralForegroundHint,
@@ -407,20 +404,20 @@ const formComponents = html<ColorBlock>`
         ></app-swatch>
         <app-swatch
             type="fill"
-            recipe-name="neutralFillStrongRest"
-            :fillRecipe="${x => neutralFillStrongRest}"
+            recipe-name="neutralFillInputRest"
+            :fillRecipe="${x => neutralFillInputRest}"
             :foregroundRecipe="${x => neutralForegroundRest}"
         ></app-swatch>
         <app-swatch
             type="fill"
-            recipe-name="neutralFillStrongHover"
-            :fillRecipe="${x => neutralFillStrongHover}"
+            recipe-name="neutralFillInputHover"
+            :fillRecipe="${x => neutralFillInputHover}"
             :foregroundRecipe="${x => neutralForegroundRest}"
         ></app-swatch>
         <app-swatch
             type="fill"
-            recipe-name="neutralFillStrongActive"
-            :fillRecipe="${x => neutralFillStrongActive}"
+            recipe-name="neutralFillInputActive"
+            :fillRecipe="${x => neutralFillInputActive}"
             :foregroundRecipe="${x => neutralForegroundRest}"
         ></app-swatch>
         <app-swatch
@@ -431,10 +428,24 @@ const formComponents = html<ColorBlock>`
         ></app-swatch>
         <app-swatch
             type="outline"
-            recipe-name="focusStrokeOuter"
+            recipe-name="neutralStrokeStrongRest"
             :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
+            :foregroundRecipe="${x => neutralForegroundRest}"
+            :outlineRecipe="${x => neutralStrokeStrongRest}"
+        ></app-swatch>
+        <app-swatch
+            type="outline"
+            recipe-name="neutralStrokeStrongHover"
+            :fillRecipe="${x => fillColor}"
+            :foregroundRecipe="${x => neutralForegroundRest}"
+            :outlineRecipe="${x => neutralStrokeStrongHover}"
+        ></app-swatch>
+        <app-swatch
+            type="outline"
+            recipe-name="neutralStrokeStrongActive"
+            :fillRecipe="${x => fillColor}"
+            :foregroundRecipe="${x => neutralForegroundRest}"
+            :outlineRecipe="${x => neutralStrokeStrongActive}"
         ></app-swatch>
 
         <div class="example">

--- a/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.template.ts
+++ b/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.template.ts
@@ -1,3 +1,4 @@
+import { WcagContrastLevel } from "@adaptive-web/adaptive-ui";
 import { ElementViewTemplate, html, repeat } from "@microsoft/fast-element";
 import { ComponentType } from "../../component-type.js";
 import { ControlPane } from "./control-pane.js";
@@ -60,6 +61,26 @@ export function controlPaneTemplate<T extends ControlPane>(): ElementViewTemplat
                     x.updateFormValue("accentColor", c.eventTarget<HTMLInputElement>().value);
                 }}"
             />
+        </div>
+        <div class="radio-group">
+            <label>WCAG Contrast Level</label>
+            ${repeat(
+                (x) => Object.keys(WcagContrastLevel),
+                html<string, T>`
+                    <label>
+                        <input
+                            type="radio"
+                            name="wcagContrastLevel"
+                            value="${(x) => x}"
+                            ?checked="${(x, c) => c.parent.wcagContrastLevel === x}"
+                            @change="${(x, c) => {
+                                c.parent.updateFormValue("wcagContrastLevel", c.eventTarget<HTMLInputElement>().value);
+                            }}"
+                        />
+                        <span>${(x) => x.toUpperCase()}</span>
+                    </label>
+                `
+            )}
         </div>
     `;
 }

--- a/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.ts
+++ b/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.ts
@@ -1,3 +1,4 @@
+import type { WcagContrastLevel } from "@adaptive-web/adaptive-ui";
 import { FASTElement, observable } from "@microsoft/fast-element";
 
 export class ControlPane extends FASTElement {
@@ -12,6 +13,9 @@ export class ControlPane extends FASTElement {
 
     @observable
     public showOnlyLayerBackgrounds: boolean = true;
+
+    @observable
+    public wcagContrastLevel: WcagContrastLevel = "aa";
 
     public updateFormValue(field: string, value: any) {
         this.$emit("formvaluechange", { field: field, value: value });

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -9,6 +9,7 @@ import { CSSDesignToken } from '@microsoft/fast-foundation';
 import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
 import { DesignTokenResolver } from '@microsoft/fast-foundation';
+import type { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public (undocumented)
 export const accentBaseColor: CSSDesignToken<string>;
@@ -16,34 +17,64 @@ export const accentBaseColor: CSSDesignToken<string>;
 // @public (undocumented)
 export const accentBaseSwatch: DesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillMinContrast: DesignToken<number>;
 
 // @public (undocumented)
+export const accentFillReadableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillReadableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillReadableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillReadableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillReadableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillReadableMinContrast: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentFillReadableRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillReadableRestDelta: DesignToken<number>;
+
+// @public @deprecated (undocumented)
 export const accentFillRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -127,7 +158,7 @@ export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, m
 // @public
 export function contrastSwatch(palette: Palette, reference: Swatch, minContrast: number, direction?: PaletteDirection): Swatch;
 
-// @public
+// @public @deprecated
 export const ContrastTarget: Readonly<{
     readonly NormalText: 4.5;
     readonly LargeText: 3;
@@ -336,6 +367,12 @@ export interface LayerRecipe {
 export function luminanceSwatch(luminance: number): Swatch;
 
 // @public (undocumented)
+export const minContrastPerceivable: DesignToken<number>;
+
+// @public (undocumented)
+export const minContrastReadable: DesignToken<number>;
+
+// @public (undocumented)
 export const neutralAsOverlay: DesignToken<boolean>;
 
 // @public (undocumented)
@@ -344,85 +381,115 @@ export const neutralBaseColor: CSSDesignToken<string>;
 // @public (undocumented)
 export const neutralBaseSwatch: DesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillInputRestDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralFillPerceivableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillPerceivableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillPerceivableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillPerceivableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillPerceivableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillPerceivableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillPerceivableMinContrast: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillPerceivableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralFillPerceivableRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillPerceivableRestDelta: DesignToken<number>;
+
+// @public @deprecated (undocumented)
 export const neutralFillRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSecondaryRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -452,35 +519,62 @@ export const neutralFillStealthRest: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralFillStealthRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongMinContrast: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStrongRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillSubtleActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillSubtleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillSubtleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillSubtleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillSubtleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralFillSubtleRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillSubtleRestDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralForegroundActive: CSSDesignToken<Swatch>;
@@ -494,10 +588,10 @@ export const neutralForegroundFocus: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralForegroundFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundHint: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundHintRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
@@ -521,98 +615,161 @@ export const neutralForegroundRestDelta: DesignToken<number>;
 // @public (undocumented)
 export const neutralPalette: DesignToken<Palette<Swatch>>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDividerRecipe: DesignToken<ColorRecipe<Swatch>>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDividerRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDividerRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeInputRestDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralStrokePerceivableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableMinContrast: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeReadableRecipe: DesignToken<ColorRecipe<Swatch>>;
+
+// @public (undocumented)
+export const neutralStrokeReadableRest: CSSDesignToken<Swatch>;
+
+// @public @deprecated (undocumented)
 export const neutralStrokeRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongMinContrast: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleRestDelta: DesignToken<number>;
 
 // @public
 export interface Palette<T extends Swatch = Swatch> {
@@ -808,6 +965,18 @@ export const typeRampPlus6FontVariations: CSSDesignToken<string>;
 
 // @public (undocumented)
 export const typeRampPlus6LineHeight: CSSDesignToken<string>;
+
+// @public
+export const WcagContrastLevel: {
+    readonly aa: "aa";
+    readonly aaa: "aaa";
+};
+
+// @public (undocumented)
+export type WcagContrastLevel = ValuesOf<typeof WcagContrastLevel>;
+
+// @public (undocumented)
+export const wcagContrastLevel: DesignToken<WcagContrastLevel>;
 
 // @internal
 export const _white: SwatchRGB;

--- a/packages/adaptive-ui/src/design-tokens/README.md
+++ b/packages/adaptive-ui/src/design-tokens/README.md
@@ -1,0 +1,80 @@
+# Design Tokens
+
+This directory defines a specific set of design tokens that are generally useful for building components and experiences. Token values can be updated to reflect your visual design. We've found you can get a long way with these foundational tokens, but they don't provide for every possible visual design you might have.
+
+These predefined tokens exist both because they are a good foundation, as well as they have already been published and are in use by consuming design systems. This package is evolving to provide more control in defining your complete token needs.
+
+## Color
+
+Color has specific requirements for accessibility. The updated color token model is designed to provide the flexibility you need in crafting your visual design, while ensuring that design will always meet contrast requirements. As a bonus, it adds automatic support for increased contrast preferences.
+
+Most color tokens come as an interactive set for rest, hover, active, and focus states.
+
+### Usage behavior
+
+Color tokens are named for semantic use cases:
+
+#### Stealth
+
+Has no color at rest, typically a subtle color on hover or active.
+
+Has no accessibility configuration relative to its context.
+
+#### Safety
+
+A special use case that can be thought of as a placeholder for increased contrast scenarios. Primarily intended for a stroke that's transparent until someone prefers increased contrast.
+
+#### Subtle
+
+Has a subtle color at rest, typically with a slight increase or decrease on hover or active.
+
+Has no accessibility configuration relative to its context.
+
+#### Perceivable
+
+Considered to be perceivable from a contrast perspective. Intended for use as a component bounding outline or for large text.
+
+Meets accessibility requirements for 3:1 contrast relative to its context in AA mode. Increases to 4.5:1 in AAA mode.
+
+#### Readable
+
+Considered to be readable from a contrast perspective. Safe for use on small text, though probably reads more like "hint" or "placeholder" text.
+
+Meets accessibility requirements for 4.5:1 contrast relative to its context in AA mode. Increases to 7:1 in AAA mode.
+
+#### Strong
+
+Considered to be readable from a contrast perspective. Intended for use on small text, with more contrast than "Readable".
+
+### Application
+
+Color tokens based on the above usage behaviors are split by intended application:
+
+#### Fill
+
+Fills are intended to cover large areas. Because of the large coverage area, it takes less of a change for hover or active state to notice.
+
+#### Stroke (and temporarily Foreground)
+
+Strokes are intended for lines, icons, or text. Because of the smaller coverage area, it takes more of a change for hover or active states to notice.
+
+### Availability
+
+The combinations of recipes currently implemented:
+
+|                    | Safety | Stealth | Subtle | Perceivable (3:1) | Readable (4.5:1) | Strong |
+| ------------------ | ------ | ------- | ------ | ----------------- | ---------------- | ------ |
+| Neutral fill       | -      | ✓       | ✓      | ✓                | o                | -      |
+| Neutral stroke     | o      | o       | ✓      | ✓                | *                | *      |
+| Neutral foreground | -      | -       | -      | -                 | ✓ *              | ✓ *    |
+| Accent fill        | -      | o       | o      | o                 | ✓                | -      |
+| Accent stroke      | o      | o       | o      | o                 | *                | -      |
+| Accent foreground  | -      | -       | -      | -                 | ✓ *              | -      |
+
+✓ = implemented
+
+o = coming soon
+
+\- = not applicable
+
+\* "Foreground" recipes will be migrating to "Stroke"

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -1,5 +1,5 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
-import type { CSSDesignToken, DesignToken } from "@microsoft/fast-foundation";
+import type { CSSDesignToken, DesignToken, ValuesOf } from "@microsoft/fast-foundation";
 import { blackOrWhiteByContrast, interactiveSwatchSetAsOverlay, swatchAsOverlay } from "../color/index.js";
 import { ColorRecipe, InteractiveColorRecipe, InteractiveSwatchSet } from "../color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../color/recipes/black-or-white-by-contrast-set.js";
@@ -16,7 +16,7 @@ function createDelta(name: string, state: keyof InteractiveSwatchSet, value: num
     return createNonCss<number>(`${name}-${state}-delta`).withDefault(value);
 }
 
-function createMinContrast(name: string, value: number) {
+function createMinContrast(name: string, value: number | DesignToken<number>) {
     return createNonCss<number>(`${name}-min-contrast`).withDefault(value);
 }
 
@@ -59,6 +59,7 @@ function createRecipeToken(recipeToken: DesignToken<ColorRecipe>): CSSDesignToke
  * Convenience values for WCAG contrast requirements.
  *
  * @public
+ * @deprecated Use `minContrastPerceivable` or `minContrastReadable` tokens instead
  */
 export const ContrastTarget = Object.freeze({
     /**
@@ -72,58 +73,116 @@ export const ContrastTarget = Object.freeze({
     LargeText: 3,
 } as const);
 
+/**
+ * WCAG Contrast Level (AA or AAA)
+ * 
+ * @public
+ */
+export const WcagContrastLevel = {
+    aa: "aa",
+    aaa: "aaa"
+} as const;
+
+/** @public */
+export type WcagContrastLevel = ValuesOf<typeof WcagContrastLevel>;
+
+/** @public */
+export const wcagContrastLevel = createNonCss<WcagContrastLevel>("wcag-contrast-level").withDefault("aa");
+
+/** @public */
+export const minContrastPerceivable = createNonCss<number>("min-contrast-perceivable").withDefault(
+    (resolve: DesignTokenResolver) =>
+        resolve(wcagContrastLevel) === "aa" ? 3 : 4.5
+);
+
+/** @public */
+export const minContrastReadable = createNonCss<number>("min-contrast-readable").withDefault(
+    (resolve: DesignTokenResolver) =>
+        resolve(wcagContrastLevel) === "aa" ? 4.5 : 7
+);
+
 /** @public */
 export const fillColor = create<Swatch>("fill-color").withDefault(_white);
 
 /** @public */
 export const neutralAsOverlay = createNonCss<boolean>("neutral-as-overlay").withDefault(false);
 
-// Accent Fill
+// Accent Fill Readable (previously just "Accent Fill")
 
-const accentFillName = "accent-fill";
-
-/** @public */
-export const accentFillMinContrast = createMinContrast(accentFillName, 4.5);
+const accentFillReadableName = "accent-fill-readable";
 
 /** @public */
-export const accentFillRestDelta = createDelta(accentFillName, "rest", 0);
+export const accentFillReadableMinContrast = createMinContrast(accentFillReadableName, minContrastReadable);
 
 /** @public */
-export const accentFillHoverDelta = createDelta(accentFillName, "hover", -2);
+export const accentFillReadableRestDelta = createDelta(accentFillReadableName, "rest", 0);
 
 /** @public */
-export const accentFillActiveDelta = createDelta(accentFillName, "active", -5);
+export const accentFillReadableHoverDelta = createDelta(accentFillReadableName, "hover", -2);
 
 /** @public */
-export const accentFillFocusDelta = createDelta(accentFillName, "focus", 0);
+export const accentFillReadableActiveDelta = createDelta(accentFillReadableName, "active", -5);
 
 /** @public */
-export const accentFillRecipe = createRecipeInteractive(accentFillName,
+export const accentFillReadableFocusDelta = createDelta(accentFillReadableName, "focus", 0);
+
+/** @public */
+export const accentFillReadableRecipe = createRecipeInteractive(accentFillReadableName,
     (resolve: DesignTokenResolver, reference?: Swatch) =>
         contrastAndDeltaSwatchSet(
             resolve(accentPalette),
             reference || resolve(fillColor),
-            resolve(accentFillMinContrast),
-            resolve(accentFillRestDelta),
-            resolve(accentFillHoverDelta),
-            resolve(accentFillActiveDelta),
-            resolve(accentFillFocusDelta)
+            resolve(accentFillReadableMinContrast),
+            resolve(accentFillReadableRestDelta),
+            resolve(accentFillReadableHoverDelta),
+            resolve(accentFillReadableActiveDelta),
+            resolve(accentFillReadableFocusDelta)
         )
 );
 
-const accentFillSet = createSet(accentFillRecipe);
+const accentFillReadableSet = createSet(accentFillReadableRecipe);
 
 /** @public */
-export const accentFillRest = createStateToken(accentFillSet, "rest");
+export const accentFillReadableRest = createStateToken(accentFillReadableSet, "rest");
 
 /** @public */
-export const accentFillHover = createStateToken(accentFillSet, "hover");
+export const accentFillReadableHover = createStateToken(accentFillReadableSet, "hover");
 
 /** @public */
-export const accentFillActive = createStateToken(accentFillSet, "active");
+export const accentFillReadableActive = createStateToken(accentFillReadableSet, "active");
 
 /** @public */
-export const accentFillFocus = createStateToken(accentFillSet, "focus");
+export const accentFillReadableFocus = createStateToken(accentFillReadableSet, "focus");
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillMinContrast = accentFillReadableMinContrast;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRestDelta = accentFillReadableRestDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillHoverDelta = accentFillReadableHoverDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillActiveDelta = accentFillReadableActiveDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillFocusDelta = accentFillReadableFocusDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRecipe = accentFillReadableRecipe;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRest = accentFillReadableRest;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillHover = accentFillReadableHover;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillActive = accentFillReadableActive;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillFocus = accentFillReadableFocus;
 
 // Foreground On Accent
 
@@ -133,11 +192,11 @@ const foregroundOnAccentName = "foreground-on-accent";
 export const foregroundOnAccentRecipe = createRecipeInteractive(foregroundOnAccentName,
     (resolve: DesignTokenResolver): InteractiveSwatchSet =>
         blackOrWhiteByContrastSet(
-            resolve(accentFillRest),
-            resolve(accentFillHover),
-            resolve(accentFillActive),
-            resolve(accentFillFocus),
-            ContrastTarget.NormalText,
+            resolve(accentFillReadableRest),
+            resolve(accentFillReadableHover),
+            resolve(accentFillReadableActive),
+            resolve(accentFillReadableFocus),
+            resolve(minContrastReadable),
             false
         )
 );
@@ -161,7 +220,7 @@ export const foregroundOnAccentFocus = createStateToken(foregroundOnAccentSet, "
 const accentForegroundName = "accent-foreground";
 
 /** @public */
-export const accentForegroundMinContrast = createMinContrast(accentForegroundName, ContrastTarget.NormalText);
+export const accentForegroundMinContrast = createMinContrast(accentForegroundName, minContrastReadable);
 
 /** @public */
 export const accentForegroundRestDelta = createDelta(accentForegroundName, "rest", 0);
@@ -254,87 +313,120 @@ export const neutralForegroundActive = createStateToken(neutralForegroundSet, "a
 /** @public */
 export const neutralForegroundFocus = createStateToken(neutralForegroundSet, "focus");
 
-// Neutral Foreground Hint
+// Neutral Stroke Readable (previously "Foreground Hint")
 
-const neutralForegroundHintName = "neutral-foreground-hint";
+const neutralStrokeReadableName = "neutral-stroke-readable";
 
 /** @public */
-export const neutralForegroundHintRecipe = createRecipe(neutralForegroundHintName,
+export const neutralStrokeReadableRecipe = createRecipe(neutralStrokeReadableName,
     (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
         swatchAsOverlay(
-            contrastSwatch(resolve(neutralPalette), reference || resolve(fillColor), ContrastTarget.NormalText),
+            contrastSwatch(resolve(neutralPalette), reference || resolve(fillColor), resolve(minContrastReadable)),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
 /** @public */
-export const neutralForegroundHint = createRecipeToken(neutralForegroundHintRecipe)
+export const neutralStrokeReadableRest = createRecipeToken(neutralStrokeReadableRecipe)
 
-// Neutral Fill
+/** @public @deprecated Use "Stroke Readable" instead */
+export const neutralForegroundHintRecipe = neutralStrokeReadableRecipe;
 
-const neutralFillName = "neutral-fill";
+/** @public @deprecated Use "Stroke Readable" instead */
+export const neutralForegroundHint = neutralStrokeReadableRest;
 
-/** @public */
-export const neutralFillRestDelta = createDelta(neutralFillName, "rest", -1);
+// Neutral Fill Subtle (previously just "Neutral Fill")
 
-/** @public */
-export const neutralFillHoverDelta = createDelta(neutralFillName, "hover", 1);
-
-/** @public */
-export const neutralFillActiveDelta = createDelta(neutralFillName, "active", 0);
+const neutralFillSubtleName = "neutral-fill";
 
 /** @public */
-export const neutralFillFocusDelta = createDelta(neutralFillName, "focus", 0);
+export const neutralFillSubtleRestDelta = createDelta(neutralFillSubtleName, "rest", -1);
 
 /** @public */
-export const neutralFillRecipe = createRecipeInteractive(neutralFillName,
+export const neutralFillSubtleHoverDelta = createDelta(neutralFillSubtleName, "hover", 1);
+
+/** @public */
+export const neutralFillSubtleActiveDelta = createDelta(neutralFillSubtleName, "active", 0);
+
+/** @public */
+export const neutralFillSubtleFocusDelta = createDelta(neutralFillSubtleName, "focus", 0);
+
+/** @public */
+export const neutralFillSubtleRecipe = createRecipeInteractive(neutralFillSubtleName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             deltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(neutralFillRestDelta),
-                resolve(neutralFillHoverDelta),
-                resolve(neutralFillActiveDelta),
-                resolve(neutralFillFocusDelta)
+                resolve(neutralFillSubtleRestDelta),
+                resolve(neutralFillSubtleHoverDelta),
+                resolve(neutralFillSubtleActiveDelta),
+                resolve(neutralFillSubtleFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralFillSet = createSet(neutralFillRecipe);
+const neutralFillSubtleSet = createSet(neutralFillSubtleRecipe);
 
 /** @public */
-export const neutralFillRest = createStateToken(neutralFillSet, "rest");
+export const neutralFillSubtleRest = createStateToken(neutralFillSubtleSet, "rest");
 
 /** @public */
-export const neutralFillHover = createStateToken(neutralFillSet, "hover");
+export const neutralFillSubtleHover = createStateToken(neutralFillSubtleSet, "hover");
 
 /** @public */
-export const neutralFillActive = createStateToken(neutralFillSet, "active");
+export const neutralFillSubtleActive = createStateToken(neutralFillSubtleSet, "active");
 
 /** @public */
-export const neutralFillFocus = createStateToken(neutralFillSet, "focus");
+export const neutralFillSubtleFocus = createStateToken(neutralFillSubtleSet, "focus");
 
-// Neutral Fill Input
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillRestDelta = neutralFillSubtleRestDelta;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillHoverDelta = neutralFillSubtleHoverDelta;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillActiveDelta = neutralFillSubtleActiveDelta;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillFocusDelta = neutralFillSubtleFocusDelta;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillRecipe = neutralFillSubtleRecipe;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillRest = neutralFillSubtleRest;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillHover = neutralFillSubtleHover;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillActive = neutralFillSubtleActive;
+
+/** @public @deprecated use "Subtle" instead */
+export const neutralFillFocus = neutralFillSubtleFocus;
+
+// Neutral Fill Input (deprecated)
 
 const neutralFillInputName = "neutral-fill-input";
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputRestDelta = createDelta(neutralFillInputName, "rest", -1);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputHoverDelta = createDelta(neutralFillInputName, "hover", 1);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputActiveDelta = createDelta(neutralFillInputName, "active", -2);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputFocusDelta = createDelta(neutralFillInputName, "focus", -2);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputRecipe = createRecipeInteractive(neutralFillInputName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
@@ -351,37 +443,38 @@ export const neutralFillInputRecipe = createRecipeInteractive(neutralFillInputNa
         )
 );
 
+/** @deprecated */
 const neutralFillInputSet = createSet(neutralFillInputRecipe);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputRest = createStateToken(neutralFillInputSet, "rest");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputHover = createStateToken(neutralFillInputSet, "hover");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputActive = createStateToken(neutralFillInputSet, "active");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputFocus = createStateToken(neutralFillInputSet, "focus");
 
-// Neutral Fill Secondary
+// Neutral Fill Secondary (deprecated)
 
 const neutralFillSecondaryName = "neutral-fill-secondary";
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryRestDelta = createDelta(neutralFillSecondaryName, "rest", 3);
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryHoverDelta = createDelta(neutralFillSecondaryName, "hover", 2);
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryActiveDelta = createDelta(neutralFillSecondaryName, "active", 1);
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryFocusDelta = createDelta(neutralFillSecondaryName, "focus", 3);
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryRecipe = createRecipeInteractive(neutralFillSecondaryName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
@@ -398,18 +491,19 @@ export const neutralFillSecondaryRecipe = createRecipeInteractive(neutralFillSec
         )
 );
 
+/** @deprecated */
 const neutralFillSecondarySet = createSet(neutralFillSecondaryRecipe);
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryRest = createStateToken(neutralFillSecondarySet, "rest");
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryHover = createStateToken(neutralFillSecondarySet, "hover");
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryActive = createStateToken(neutralFillSecondarySet, "active");
 
-/** @public */
+/** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryFocus = createStateToken(neutralFillSecondarySet, "focus");
 
 // Neutral Fill Stealth
@@ -459,112 +553,169 @@ export const neutralFillStealthActive = createStateToken(neutralFillStealthSet, 
 /** @public */
 export const neutralFillStealthFocus = createStateToken(neutralFillStealthSet, "focus");
 
-// Neutral Fill Strong
+// Neutral Fill Perceivable (previously "Strong")
 
-const neutralFillStrongName = "neutral-fill-strong";
-
-/** @public */
-export const neutralFillStrongMinContrast = createMinContrast(neutralFillStrongName, 3);
+const neutralFillPerceivableName = "neutral-fill-perceivable";
 
 /** @public */
-export const neutralFillStrongRestDelta = createDelta(neutralFillStrongName, "rest", 0);
+export const neutralFillPerceivableMinContrast = createMinContrast(neutralFillPerceivableName, minContrastPerceivable);
 
 /** @public */
-export const neutralFillStrongHoverDelta = createDelta(neutralFillStrongName, "hover", 8);
+export const neutralFillPerceivableRestDelta = createDelta(neutralFillPerceivableName, "rest", 0);
 
 /** @public */
-export const neutralFillStrongActiveDelta = createDelta(neutralFillStrongName, "active", -5);
+export const neutralFillPerceivableHoverDelta = createDelta(neutralFillPerceivableName, "hover", 8);
 
 /** @public */
-export const neutralFillStrongFocusDelta = createDelta(neutralFillStrongName, "focus", 0);
+export const neutralFillPerceivableActiveDelta = createDelta(neutralFillPerceivableName, "active", -5);
 
 /** @public */
-export const neutralFillStrongRecipe = createRecipeInteractive(neutralFillStrongName,
+export const neutralFillPerceivableFocusDelta = createDelta(neutralFillPerceivableName, "focus", 0);
+
+/** @public */
+export const neutralFillPerceivableRecipe = createRecipeInteractive(neutralFillPerceivableName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(neutralFillStrongMinContrast),
-                resolve(neutralFillStrongRestDelta),
-                resolve(neutralFillStrongHoverDelta),
-                resolve(neutralFillStrongActiveDelta),
-                resolve(neutralFillStrongFocusDelta)
+                resolve(neutralFillPerceivableMinContrast),
+                resolve(neutralFillPerceivableRestDelta),
+                resolve(neutralFillPerceivableHoverDelta),
+                resolve(neutralFillPerceivableActiveDelta),
+                resolve(neutralFillPerceivableFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralFillStrongSet = createSet(neutralFillStrongRecipe);
+const neutralFillPerceivableSet = createSet(neutralFillPerceivableRecipe);
 
 /** @public */
-export const neutralFillStrongRest = createStateToken(neutralFillStrongSet, "rest");
+export const neutralFillPerceivableRest = createStateToken(neutralFillPerceivableSet, "rest");
 
 /** @public */
-export const neutralFillStrongHover = createStateToken(neutralFillStrongSet, "hover");
+export const neutralFillPerceivableHover = createStateToken(neutralFillPerceivableSet, "hover");
 
 /** @public */
-export const neutralFillStrongActive = createStateToken(neutralFillStrongSet, "active");
+export const neutralFillPerceivableActive = createStateToken(neutralFillPerceivableSet, "active");
 
 /** @public */
-export const neutralFillStrongFocus = createStateToken(neutralFillStrongSet, "focus");
+export const neutralFillPerceivableFocus = createStateToken(neutralFillPerceivableSet, "focus");
 
-// Neutral Stroke
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongMinContrast = neutralFillPerceivableMinContrast;
 
-const neutralStrokeName = "neutral-stroke";
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongRestDelta = neutralFillPerceivableRestDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongHoverDelta = neutralFillPerceivableHoverDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongActiveDelta = neutralFillPerceivableActiveDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongFocusDelta = neutralFillPerceivableFocusDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongRecipe = neutralFillPerceivableRecipe;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongRest = neutralFillPerceivableRest;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongHover = neutralFillPerceivableHover;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongActive = neutralFillPerceivableActive;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralFillStrongFocus = neutralFillPerceivableFocus;
+
+// Neutral Stroke Subtle (previously just "Neutral Stroke")
+
+const neutralStrokeSubtleName = "neutral-stroke-subtle";
 
 /** @public */
-export const neutralStrokeRestDelta = createDelta(neutralStrokeName, "rest", 8);
+export const neutralStrokeSubtleRestDelta = createDelta(neutralStrokeSubtleName, "rest", 8);
 
 /** @public */
-export const neutralStrokeHoverDelta = createDelta(neutralStrokeName, "hover", 12);
+export const neutralStrokeSubtleHoverDelta = createDelta(neutralStrokeSubtleName, "hover", 12);
 
 /** @public */
-export const neutralStrokeActiveDelta = createDelta(neutralStrokeName, "active", 6);
+export const neutralStrokeSubtleActiveDelta = createDelta(neutralStrokeSubtleName, "active", 6);
 
 /** @public */
-export const neutralStrokeFocusDelta = createDelta(neutralStrokeName, "focus", 8);
+export const neutralStrokeSubtleFocusDelta = createDelta(neutralStrokeSubtleName, "focus", 8);
 
 /** @public */
-export const neutralStrokeRecipe = createRecipeInteractive(neutralStrokeName,
+export const neutralStrokeSubtleRecipe = createRecipeInteractive(neutralStrokeSubtleName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             deltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(neutralStrokeRestDelta),
-                resolve(neutralStrokeHoverDelta),
-                resolve(neutralStrokeActiveDelta),
-                resolve(neutralStrokeFocusDelta)
+                resolve(neutralStrokeSubtleRestDelta),
+                resolve(neutralStrokeSubtleHoverDelta),
+                resolve(neutralStrokeSubtleActiveDelta),
+                resolve(neutralStrokeSubtleFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralStrokeSet = createSet(neutralStrokeRecipe);
+const neutralStrokeSubtleSet = createSet(neutralStrokeSubtleRecipe);
 
 /** @public */
-export const neutralStrokeRest = createStateToken(neutralStrokeSet, "rest");
+export const neutralStrokeSubtleRest = createStateToken(neutralStrokeSubtleSet, "rest");
 
 /** @public */
-export const neutralStrokeHover = createStateToken(neutralStrokeSet, "hover");
+export const neutralStrokeSubtleHover = createStateToken(neutralStrokeSubtleSet, "hover");
 
 /** @public */
-export const neutralStrokeActive = createStateToken(neutralStrokeSet, "active");
+export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet, "active");
 
 /** @public */
-export const neutralStrokeFocus = createStateToken(neutralStrokeSet, "focus");
+export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus");
 
-// Neutral Stroke Divider
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeRestDelta = neutralStrokeSubtleRestDelta;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeHoverDelta = neutralStrokeSubtleHoverDelta;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeActiveDelta = neutralStrokeSubtleActiveDelta;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeFocusDelta = neutralStrokeSubtleFocusDelta;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeRecipe = neutralStrokeSubtleRecipe;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeRest = neutralStrokeSubtleRest;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeHover = neutralStrokeSubtleHover;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeActive = neutralStrokeSubtleActive;
+
+/** @public @deprecated Use "Subtle" instead */
+export const neutralStrokeFocus = neutralStrokeSubtleFocus;
+
+// Neutral Stroke Divider (deprecated)
 
 const neutralStrokeDividerName = "neutral-stroke-divider";
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeDividerRestDelta = createDelta(neutralStrokeDividerName, "rest", 4);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeDividerRecipe = createRecipe(neutralStrokeDividerName,
     (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
         swatchAsOverlay(
@@ -578,26 +729,26 @@ export const neutralStrokeDividerRecipe = createRecipe(neutralStrokeDividerName,
         )
 );
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeDividerRest = createRecipeToken(neutralStrokeDividerRecipe);
 
-// Neutral Stroke Input
+// Neutral Stroke Input (deprecated)
 
 const neutralStrokeInputName = "neutral-stroke-input";
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputRestDelta = createDelta(neutralStrokeInputName, "rest", 3);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputHoverDelta = createDelta(neutralStrokeInputName, "hover", 5);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputActiveDelta = createDelta(neutralStrokeInputName, "active", 5);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputFocusDelta = createDelta(neutralStrokeInputName, "focus", 5);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputRecipe = createRecipeInteractive(neutralStrokeInputName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
@@ -614,70 +765,101 @@ export const neutralStrokeInputRecipe = createRecipeInteractive(neutralStrokeInp
         )
 );
 
+/** @deprecated */
 const neutralStrokeInputSet = createSet(neutralStrokeInputRecipe);
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputRest = createStateToken(neutralStrokeInputSet, "rest");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputHover = createStateToken(neutralStrokeInputSet, "hover");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputActive = createStateToken(neutralStrokeInputSet, "active");
 
-/** @public */
+/** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputFocus = createStateToken(neutralStrokeInputSet, "focus");
 
-// Neutral Stroke Strong
+// Neutral Stroke Perceivable (previously "Strong")
 
-const neutralStrokeStrongName = "neutral-stroke-strong";
-
-/** @public */
-export const neutralStrokeStrongMinContrast = createMinContrast(neutralStrokeStrongName, 5.5);
+const neutralStrokePerceivableName = "neutral-stroke-perceivable";
 
 /** @public */
-export const neutralStrokeStrongRestDelta = createDelta(neutralStrokeStrongName, "rest", 0);
+export const neutralStrokePerceivableMinContrast = createMinContrast(neutralStrokePerceivableName, minContrastPerceivable);
 
 /** @public */
-export const neutralStrokeStrongHoverDelta = createDelta(neutralStrokeStrongName, "hover", 0);
+export const neutralStrokePerceivableRestDelta = createDelta(neutralStrokePerceivableName, "rest", 0);
 
 /** @public */
-export const neutralStrokeStrongActiveDelta = createDelta(neutralStrokeStrongName, "active", 0);
+export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 0);
 
 /** @public */
-export const neutralStrokeStrongFocusDelta = createDelta(neutralStrokeStrongName, "focus", 0);
+export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", 0);
 
 /** @public */
-export const neutralStrokeStrongRecipe = createRecipeInteractive(neutralStrokeStrongName,
+export const neutralStrokePerceivableFocusDelta = createDelta(neutralStrokePerceivableName, "focus", 0);
+
+/** @public */
+export const neutralStrokePerceivableRecipe = createRecipeInteractive(neutralStrokePerceivableName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(neutralStrokeStrongMinContrast),
-                resolve(neutralStrokeStrongRestDelta),
-                resolve(neutralStrokeStrongHoverDelta),
-                resolve(neutralStrokeStrongActiveDelta),
-                resolve(neutralStrokeStrongFocusDelta)
+                resolve(neutralStrokePerceivableMinContrast),
+                resolve(neutralStrokePerceivableRestDelta),
+                resolve(neutralStrokePerceivableHoverDelta),
+                resolve(neutralStrokePerceivableActiveDelta),
+                resolve(neutralStrokePerceivableFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralStrokeStrongSet = createSet(neutralStrokeStrongRecipe);
+const neutralStrokePerceivableSet = createSet(neutralStrokePerceivableRecipe);
 
 /** @public */
-export const neutralStrokeStrongRest = createStateToken(neutralStrokeStrongSet, "rest");
+export const neutralStrokePerceivableRest = createStateToken(neutralStrokePerceivableSet, "rest");
 
 /** @public */
-export const neutralStrokeStrongHover = createStateToken(neutralStrokeStrongSet, "hover");
+export const neutralStrokePerceivableHover = createStateToken(neutralStrokePerceivableSet, "hover");
 
 /** @public */
-export const neutralStrokeStrongActive = createStateToken(neutralStrokeStrongSet, "active");
+export const neutralStrokePerceivableActive = createStateToken(neutralStrokePerceivableSet, "active");
 
 /** @public */
-export const neutralStrokeStrongFocus = createStateToken(neutralStrokeStrongSet, "focus");
+export const neutralStrokePerceivableFocus = createStateToken(neutralStrokePerceivableSet, "focus");
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongMinContrast = neutralStrokePerceivableMinContrast;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongRestDelta = neutralStrokePerceivableRestDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongHoverDelta = neutralStrokePerceivableHoverDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongActiveDelta = neutralStrokePerceivableActiveDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongFocusDelta = neutralStrokePerceivableFocusDelta;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongRecipe = neutralStrokePerceivableRecipe;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongRest = neutralStrokePerceivableRest;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongHover = neutralStrokePerceivableHover;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongActive = neutralStrokePerceivableActive;
+
+/** @public @deprecated Use "Perceivable instead of "Strong" */
+export const neutralStrokeStrongFocus = neutralStrokePerceivableFocus;
 
 // Focus Stroke Outer
 
@@ -686,7 +868,7 @@ const focusStrokeOuterName = "focus-stroke-outer";
 /** @public */
 export const focusStrokeOuterRecipe = createRecipe(focusStrokeOuterName,
     (resolve: DesignTokenResolver): Swatch =>
-        blackOrWhiteByContrast(resolve(fillColor), ContrastTarget.NormalText, true)
+        blackOrWhiteByContrast(resolve(fillColor), resolve(minContrastReadable), true)
 );
 
 /** @public */
@@ -699,7 +881,7 @@ const focusStrokeInnerName = "focus-stroke-inner";
 /** @public */
 export const focusStrokeInnerRecipe = createRecipe(focusStrokeInnerName,
     (resolve: DesignTokenResolver): Swatch =>
-        blackOrWhiteByContrast(resolve(focusStrokeOuter), ContrastTarget.NormalText, false)
+        blackOrWhiteByContrast(resolve(focusStrokeOuter), resolve(minContrastReadable), false)
 );
 
 /** @public */

--- a/packages/adaptive-ui/src/styles.ts
+++ b/packages/adaptive-ui/src/styles.ts
@@ -1,6 +1,7 @@
 /**
  * Recommended base styles for a component.
  * 
+ * @public
  * @remarks
  * Adds support for `[hidden]` custom elements.
  */


### PR DESCRIPTION
# Pull Request

## Description

This is part of the evolution of the design tokens, specifically the color recipes that will evolve to the default configuration.

The new doc file describes this in detail, but the intent is to create base recipes that can be combined into patterns to be applied to components. Typically (for color) this is fill, border, and text. What this intends to solve is the fact that once you have these patterns, many need to follow contrast requirements. For instance, you can't safely use only a "subtle" fill on a checkbox because it doesn't provide 3:1 contrast. So the intent is that the patterns can be built such that they follow accessibility guidelines, and then applied as desired.

I expect we can find overlap in the treatments and am hoping to define only the behaviors and mix that with the palette in the configurations. This would make it easy to create additional color patterns like info, error, and warning, and use the same behaviors like subtle fill and perceivable stroke.

## Reviewer Notes

This is mostly a rename of some color recipes. I've also added a doc describing the intent, as well as addressed related examples in the Adaptive UI Explorer.

## Test Plan

This should not break anything as renamed tokens have been aliased and deprecated.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

A stylistic breaking change to rename the "foreground" recipes to "stroke", which merges a couple of previously separate token sets.