### PR TITLE
Update components to use renamed color tokens

### DIFF
--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -321,7 +321,11 @@ const neutralStrokeReadableName = "neutral-stroke-readable";
 export const neutralStrokeReadableRecipe = createRecipe(neutralStrokeReadableName,
     (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
         swatchAsOverlay(
-            contrastSwatch(resolve(neutralPalette), reference || resolve(fillColor), resolve(minContrastReadable)),
+            contrastSwatch(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(minContrastReadable)
+            ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
@@ -338,10 +342,10 @@ export const neutralForegroundHint = neutralStrokeReadableRest;
 
 // Neutral Fill Subtle (previously just "Neutral Fill")
 
-const neutralFillSubtleName = "neutral-fill";
+const neutralFillSubtleName = "neutral-fill-subtle";
 
 /** @public */
-export const neutralFillSubtleRestDelta = createDelta(neutralFillSubtleName, "rest", -1);
+export const neutralFillSubtleRestDelta = createDelta(neutralFillSubtleName, "rest", 2);
 
 /** @public */
 export const neutralFillSubtleHoverDelta = createDelta(neutralFillSubtleName, "hover", 1);

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -1,13 +1,13 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
-    accentFillRest,
+    accentFillReadableRest,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     neutralForegroundActive,
     neutralForegroundHover,
     neutralForegroundRest,
-    neutralStrokeDividerRest,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -108,7 +108,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
+        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         ${typeRampBase}
     }
 
@@ -134,7 +134,7 @@ export const aestheticStyles: ElementStyles = css`
     .icon {
         height: calc(${heightNumber} * 1px);
         width: calc(${heightNumber} * 1px);
-        fill: ${accentFillRest};
+        fill: ${accentFillReadableRest};
     }
 
     .region {

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { neutralForegroundRest, neutralStrokeDividerRest, strokeWidth, typeRampBase } from "@adaptive-web/adaptive-ui";
+import { neutralForegroundRest, neutralStrokeSubtleRest, strokeWidth, typeRampBase } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -16,7 +16,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
+        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         color: ${neutralForegroundRest};
         ${typeRampBase}
     }

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -3,9 +3,9 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillSecondaryActive,
-    neutralFillSecondaryHover,
-    neutralFillSecondaryRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
     strokeWidth,
     typeRampBase,
@@ -58,7 +58,7 @@ export const aestheticStyles: ElementStyles = css`
         gap: 10px;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         border-radius: inherit;
-        background-color: ${neutralFillSecondaryRest};
+        background-color: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
@@ -69,11 +69,11 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([href]:hover) .control {
-        background-color: ${neutralFillSecondaryHover};
+        background-color: ${neutralFillSubtleHover};
     }
 
     :host([href]:active) .control {
-        background-color: ${neutralFillSecondaryActive};
+        background-color: ${neutralFillSubtleActive};
     }
 
     .control:focus-visible {

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -1,4 +1,4 @@
-import { accentFillRest, foregroundOnAccentRest, typeRampBase } from "@adaptive-web/adaptive-ui";
+import { accentFillReadableRest, foregroundOnAccentRest, typeRampBase } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -49,7 +49,7 @@ export const aestheticStyles: ElementStyles = css`
     .backplate {
         border-radius: 100%;
         min-width: 100%;
-        background-color: ${accentFillRest};
+        background-color: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -2,7 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     controlCornerRadius,
     designUnit,
-    neutralFillSecondaryRest,
+    neutralFillSubtleRest,
     neutralForegroundRest,
     strokeWidth,
     typeRampMinus1,
@@ -31,7 +31,7 @@ export const aestheticStyles: ElementStyles = css`
         padding:
             calc(((${designUnit} * 0.5) - ${strokeWidth}) * 1px)
             calc((${designUnit} - ${strokeWidth}) * 1px);
-        background: ${neutralFillSecondaryRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -4,9 +4,9 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillSecondaryActive,
-    neutralFillSecondaryHover,
-    neutralFillSecondaryRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
     strokeWidth,
     typeRampBase,
@@ -64,7 +64,7 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         border-radius: inherit;
-        background-color: ${neutralFillSecondaryRest};
+        background-color: ${neutralFillSubtleRest};
         white-space: nowrap;
         color: ${neutralForegroundRest};
         fill: currentcolor;
@@ -77,11 +77,11 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host(:not([disabled]):hover) .control {
-        background-color: ${neutralFillSecondaryHover};
+        background-color: ${neutralFillSubtleHover};
     }
 
     :host(:not([disabled]):active) .control {
-        background-color: ${neutralFillSecondaryActive};
+        background-color: ${neutralFillSubtleActive};
     }
 
     .control:focus-visible {

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -1,11 +1,11 @@
 import {
-    accentFillRest,
+    accentFillReadableRest,
     controlCornerRadius,
     designUnit,
     fillColor,
     foregroundOnAccentRest,
-    neutralForegroundHint,
     neutralForegroundRest,
+    neutralStrokeReadableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -84,7 +84,7 @@ export const aestheticStyles: ElementStyles = css`
 
     .inactive .date,
     .inactive.disabled::before {
-        color: ${neutralForegroundHint};
+        color: ${neutralStrokeReadableRest};
     }
 
     .disabled::before {
@@ -100,8 +100,8 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .selected {
-        color: ${accentFillRest};
-        border: 1px solid ${accentFillRest};
+        color: ${accentFillReadableRest};
+        border: 1px solid ${accentFillReadableRest};
         background: ${fillColor};
     }
 
@@ -119,7 +119,7 @@ export const aestheticStyles: ElementStyles = css`
 
     .today .date {
         color: ${foregroundOnAccentRest};
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         border-radius: 50%;
         position: relative;
     }

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -1,19 +1,19 @@
 import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
+    accentFillReadableActive,
+    accentFillReadableHover,
+    accentFillReadableRest,
     controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     foregroundOnAccentRest,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeStrongActive,
-    neutralStrokeStrongHover,
-    neutralStrokeStrongRest,
+    neutralStrokePerceivableActive,
+    neutralStrokePerceivableHover,
+    neutralStrokePerceivableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -81,21 +81,21 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
     :host(:enabled:hover) .control {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeStrongHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokePerceivableHover};
     }
 
     :host(:enabled:active) .control {
-        background: ${neutralFillInputActive};
-        border-color: ${neutralStrokeStrongActive};
+        background: ${neutralFillSubtleActive};
+        border-color: ${neutralStrokePerceivableActive};
     }
 
     :host(:focus-visible) .control {
@@ -104,20 +104,20 @@ export const aestheticStyles: ElementStyles = css`
 
     :host([aria-checked="true"]) .control,
     :host([aria-checked="mixed"]) .control {
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         border-color: transparent;
         color: ${foregroundOnAccentRest};
     }
 
     :host([aria-checked="true"]:not(.disabled):hover) .control,
     :host([aria-checked="mixed"]:not(.disabled):hover) .control {
-        background: ${accentFillHover};
+        background: ${accentFillReadableHover};
         border-color: transparent;
     }
 
     :host([aria-checked="true"]:not(.disabled):active) .control,
     :host([aria-checked="mixed"]:not(.disabled):active) .control {
-        background: ${accentFillActive};
+        background: ${accentFillReadableActive};
         border-color: transparent;
     }
 

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -5,13 +5,13 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     layerFillFixedPlus1,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -88,22 +88,22 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: 250px;
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
         ${typeRampBase}
     }
 
     :host(:not([disabled]):hover) {
-        border-color: ${neutralStrokeHover};
-        background: ${neutralFillInputHover};
+        border-color: ${neutralStrokeSubtleHover};
+        background: ${neutralFillSubtleHover};
     }
 
     :host(:not([disabled]):active) {
-        border-color: ${neutralStrokeActive};
-        background: ${neutralFillInputActive};
+        border-color: ${neutralStrokeSubtleActive};
+        background: ${neutralFillSubtleActive};
     }
 
     :host(:focus-within) {

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { neutralFillRest, neutralStrokeDividerRest, strokeWidth } from "@adaptive-web/adaptive-ui";
+import { neutralFillSubtleRest, neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -23,10 +23,10 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         padding: 1px 0;
-        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
+        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
     }
 
     :host([cell-type="sticky-header"]) {
-        background: ${neutralFillRest};
+        background: ${neutralFillSubtleRest};
     }
 `;

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -1,7 +1,7 @@
 import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
+    accentFillReadableActive,
+    accentFillReadableHover,
+    accentFillReadableRest,
     controlCornerRadius,
     foregroundOnAccentActive,
     foregroundOnAccentHover,
@@ -49,7 +49,7 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     .invoker {
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};
         fill: currentcolor;
         padding: 12px;
@@ -57,12 +57,12 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .invoker:hover {
-        background: ${accentFillHover};
+        background: ${accentFillReadableHover};
         color: ${foregroundOnAccentHover};
     }
 
     .invoker:active {
-        background: ${accentFillActive};
+        background: ${accentFillReadableActive};
         color: ${foregroundOnAccentActive};
     }
 `;

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.ts
@@ -1,4 +1,4 @@
-import { neutralStrokeDividerRest, strokeWidth } from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -16,12 +16,12 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         box-sizing: content-box;
-        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
+        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
     }
 
     :host([orientation="vertical"]) {
         border-top: none;
         height: 100%;
-        border-left: calc(${strokeWidth} * 1px) solid ${neutralStrokeDividerRest};
+        border-left: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
     }
 `;

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -5,9 +5,9 @@ import {
     neutralFillStealthHover,
     neutralFillStealthRest,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
@@ -45,7 +45,7 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         width: calc(${heightNumber} * 1px);
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: 50%;
         background: ${neutralFillStealthRest};
         color: ${neutralForegroundRest};
@@ -53,12 +53,12 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host(:hover) {
-        border-color: ${neutralStrokeHover};
+        border-color: ${neutralStrokeSubtleHover};
         background: ${neutralFillStealthHover};
     }
 
     :host(:active) {
-        border-color: ${neutralStrokeActive};
+        border-color: ${neutralStrokeSubtleActive};
         background: ${neutralFillStealthActive};
     }
 

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -1,7 +1,7 @@
 import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
+    accentFillReadableActive,
+    accentFillReadableHover,
+    accentFillReadableRest,
     controlCornerRadius,
     designUnit,
     focusStrokeOuter,
@@ -74,17 +74,17 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([aria-selected="true"]) {
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};
     }
 
     :host([aria-selected="true"]:not([disabled]):hover) {
-        background: ${accentFillHover};
+        background: ${accentFillReadableHover};
         color: ${foregroundOnAccentHover};
     }
 
     :host([aria-selected="true"]:not([disabled]):active) {
-        background: ${accentFillActive};
+        background: ${accentFillReadableActive};
         color: ${foregroundOnAccentActive};
     }
 

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -4,7 +4,7 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     layerFillFixedPlus1,
-    neutralStrokeRest,
+    neutralStrokeSubtleRest,
     strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
@@ -24,7 +24,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         padding: calc(${designUnit} * 1px) 0;

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -6,8 +6,8 @@ import {
     neutralFillStealthActive,
     neutralFillStealthHover,
     neutralFillStealthRest,
-    neutralForegroundHint,
     neutralForegroundRest,
+    neutralStrokeReadableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -159,7 +159,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     ::slotted([slot="end"]:not(svg)) {
-        color: ${neutralForegroundHint};
+        color: ${neutralStrokeReadableRest};
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -3,13 +3,13 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -97,21 +97,21 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         gap: 8px;
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
     :host(:enabled:hover) .root {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokeSubtleHover};
     }
 
     :host(:enabled:active) .root {
-        background: ${neutralFillInputActive};
-        border-color: ${neutralStrokeActive};
+        background: ${neutralFillSubtleActive};
+        border-color: ${neutralStrokeSubtleActive};
     }
 
     :host(:enabled:focus-within) .root {

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -3,13 +3,13 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -46,9 +46,9 @@ export const aestheticStyles: ElementStyles = css`
         min-height: calc(${heightNumber} * 1px);
         column-gap: calc(${designUnit} * 1px);
         row-gap: calc(${designUnit} * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
         padding: calc(${designUnit} * 1px) calc(${designUnit} * 2px);
@@ -56,13 +56,13 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host(:not([disabled]):hover) {
-        border-color: ${neutralStrokeHover};
-        background: ${neutralFillInputHover};
+        border-color: ${neutralStrokeSubtleHover};
+        background: ${neutralFillSubtleHover};
     }
 
     :host(:not([disabled]):active) {
-        border-color: ${neutralStrokeActive};
-        background: ${neutralFillInputActive};
+        border-color: ${neutralStrokeSubtleActive};
+        background: ${neutralFillSubtleActive};
     }
 
     :host(:not([disabled]):focus-within) {

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -1,5 +1,5 @@
 import {
-    accentFillRest,
+    accentFillReadableRest,
     controlCornerRadius,
     designUnit,
     focusStrokeOuter,
@@ -59,7 +59,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([aria-selected="true"]) {
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};
     }
 `;

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { accentForegroundRest, neutralFillSecondaryRest } from "@adaptive-web/adaptive-ui";
+import { accentForegroundRest, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui";
 import { heightNumber } from "../../styles/index.js";
 
 /**
@@ -30,7 +30,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .background {
-        stroke: ${neutralFillSecondaryRest};
+        stroke: ${neutralFillSubtleRest};
         fill: none;
         stroke-width: 2px;
     }

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { accentForegroundRest, designUnit, neutralFillSecondaryRest } from "@adaptive-web/adaptive-ui";
+import { accentForegroundRest, designUnit, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -41,7 +41,7 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         height: calc(${designUnit} * 1px);
         border-radius: calc(${designUnit} * 1px);
-        background-color: ${neutralFillSecondaryRest};
+        background-color: ${neutralFillSubtleRest};
     }
 
     .determinate {

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -1,18 +1,18 @@
 import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
+    accentFillReadableActive,
+    accentFillReadableHover,
+    accentFillReadableRest,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     foregroundOnAccentRest,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeStrongActive,
-    neutralStrokeStrongHover,
-    neutralStrokeStrongRest,
+    neutralStrokePerceivableActive,
+    neutralStrokePerceivableHover,
+    neutralStrokePerceivableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -81,21 +81,21 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
         border-radius: 50%;
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
     :host(:enabled:hover) .control {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeStrongHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokePerceivableHover};
     }
 
     :host(:enabled:active) .control {
-        background: ${neutralFillInputActive};
-        border-color: ${neutralStrokeStrongActive};
+        background: ${neutralFillSubtleActive};
+        border-color: ${neutralStrokePerceivableActive};
     }
 
     :host(:focus-visible) .control {
@@ -103,18 +103,18 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([aria-checked="true"]) .control {
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
         border-color: transparent;
         color: ${foregroundOnAccentRest};
     }
 
     :host([aria-checked="true"]:not(.disabled):hover) .control {
-        background: ${accentFillHover};
+        background: ${accentFillReadableHover};
         border-color: transparent;
     }
 
     :host([aria-checked="true"]:not(.disabled):active) .control {
-        background: ${accentFillActive};
+        background: ${accentFillReadableActive};
         border-color: transparent;
     }
 

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -3,14 +3,14 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillInputHover,
-    neutralFillInputRest,
     neutralFillStealthActive,
     neutralFillStealthHover,
     neutralFillStealthRest,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -101,18 +101,18 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
     :host(:not([disabled]):hover) .root {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokeSubtleHover};
     }
 
     :host(:not([disabled]):focus-within) .root {

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -5,13 +5,13 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     layerFillFixedPlus1,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -89,22 +89,22 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: 250px;
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
         ${typeRampBase}
     }
 
     :host(:not([disabled]):hover) {
-        border-color: ${neutralStrokeHover};
-        background: ${neutralFillInputHover};
+        border-color: ${neutralStrokeSubtleHover};
+        background: ${neutralFillSubtleHover};
     }
 
     :host(:not([disabled]):active) {
-        border-color: ${neutralStrokeActive};
-        background: ${neutralFillInputActive};
+        border-color: ${neutralStrokeSubtleActive};
+        background: ${neutralFillSubtleActive};
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
@@ -1,4 +1,4 @@
-import { controlCornerRadius, neutralFillSecondaryHover, neutralFillSecondaryRest } from "@adaptive-web/adaptive-ui";
+import { controlCornerRadius, neutralFillSubtleHover, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -55,14 +55,14 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host {
-        background-color: ${neutralFillSecondaryRest};
+        background-color: ${neutralFillSubtleRest};
     }
 
     .shimmer {
         background-image: linear-gradient(
             90deg,
             transparent 0%,
-            ${neutralFillSecondaryHover} 50%,
+            ${neutralFillSubtleHover} 50%,
             transparent 100%
         );
         background-size: 0px 0px / 90% 100%;

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -1,4 +1,4 @@
-import { designUnit, neutralStrokeRest, typeRampMinus1 } from "@adaptive-web/adaptive-ui";
+import { designUnit, neutralStrokeSubtleRest, typeRampMinus1 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -52,7 +52,7 @@ export const templateStyles: ElementStyles = css`
         justify-self: center;
         height: calc(${heightNumber} * 0.25 * 1px);
         width: calc((${designUnit} / 2) * 1px);
-        background: ${neutralStrokeRest};
+        background: ${neutralStrokeSubtleRest};
     }
 
     :host([orientation="vertical"]) .mark {

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -5,9 +5,9 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokePerceivableRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleHover,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -136,12 +136,12 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .thumb:hover {
-        border-color: ${neutralStrokeHover};
+        border-color: ${neutralStrokeSubtleHover};
         background: ${neutralForegroundRest};
     }
 
     .thumb:active {
-        border-color: ${neutralStrokeActive};
+        border-color: ${neutralStrokeSubtleActive};
         background: ${neutralForegroundRest};
     }
 
@@ -156,7 +156,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .track {
-        background: ${neutralStrokeRest};
+        background: ${neutralStrokePerceivableRest};
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -1,7 +1,7 @@
 import {
-    accentFillActive,
-    accentFillHover,
-    accentFillRest,
+    accentFillReadableActive,
+    accentFillReadableHover,
+    accentFillReadableRest,
     designUnit,
     fillColor,
     focusStrokeOuter,
@@ -9,13 +9,13 @@ import {
     foregroundOnAccentActive,
     foregroundOnAccentHover,
     foregroundOnAccentRest,
-    neutralFillInputActive,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeStrongActive,
-    neutralStrokeStrongHover,
-    neutralStrokeStrongRest,
+    neutralStrokePerceivableActive,
+    neutralStrokePerceivableHover,
+    neutralStrokePerceivableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -74,20 +74,20 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc(((${heightNumber} / 2) + ${designUnit}) * 2px);
         height: calc(((${heightNumber} / 2) + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeStrongRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
         border-radius: calc(${heightNumber} * 1px);
         padding: 4px;
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
     }
 
     :host(:enabled:hover) .switch {
-        border-color: ${neutralStrokeStrongHover};
-        background: ${neutralFillInputHover};
+        border-color: ${neutralStrokePerceivableHover};
+        background: ${neutralFillSubtleHover};
     }
 
     :host(:enabled:active) .switch {
-        border-color: ${neutralStrokeStrongActive};
-        background: ${neutralFillInputActive};
+        border-color: ${neutralStrokePerceivableActive};
+        background: ${neutralFillSubtleActive};
     }
 
     :host(:focus-visible) .switch {
@@ -109,11 +109,11 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([aria-checked="true"]) .switch {
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
     }
 
     :host([aria-checked="true"]:enabled:hover) .switch {
-        background: ${accentFillHover};
+        background: ${accentFillReadableHover};
     }
 
     :host([aria-checked="true"]:enabled:hover) .thumb {
@@ -121,7 +121,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([aria-checked="true"]:enabled:active) .switch {
-        background: ${accentFillActive};
+        background: ${accentFillReadableActive};
     }
 
     :host([aria-checked="true"]:enabled:active) .thumb {

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
@@ -1,5 +1,5 @@
 import {
-    accentFillRest,
+    accentFillReadableRest,
     controlCornerRadius,
     neutralForegroundRest,
 } from "@adaptive-web/adaptive-ui";
@@ -74,7 +74,7 @@ export const aestheticStyles: ElementStyles = css`
 
     .active-indicator {
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${accentFillRest};
+        background: ${accentFillReadableRest};
     }
 
     :host([orientation="horizontal"]) .active-indicator {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -3,11 +3,11 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -72,19 +72,19 @@ export const aestheticStyles: ElementStyles = css`
 
     .control {
         /* position: relative; */
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 2px);
         width: 100%;
         padding: calc(${designUnit} * 1.5px) calc(${designUnit} * 2px + 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
     }
 
     :host(:not([disabled]):hover) .control {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokeSubtleHover};
     }
 
     :host(:not([disabled]):focus-within) .control {

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -3,11 +3,11 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillInputHover,
-    neutralFillInputRest,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeHover,
-    neutralStrokeRest,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -70,18 +70,18 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        background: ${neutralFillInputRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
     :host(:not([disabled]):hover) .root {
-        background: ${neutralFillInputHover};
-        border-color: ${neutralStrokeHover};
+        background: ${neutralFillSubtleHover};
+        border-color: ${neutralStrokeSubtleHover};
     }
 
     :host(:not([disabled]):focus-within) .root {

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -1,4 +1,4 @@
-import { focusStrokeWidth, neutralForegroundRest, neutralStrokeFocus } from "@adaptive-web/adaptive-ui";
+import { focusStrokeOuter, focusStrokeWidth, neutralForegroundRest } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -44,7 +44,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host(:focus-visible) {
-        outline: calc(${focusStrokeWidth} * 1px) solid ${neutralStrokeFocus};
+        outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
 
     .positioning-region {

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -1,9 +1,9 @@
 import {
     controlCornerRadius,
     elevationTooltip,
-    neutralFillRest,
+    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokeRest,
+    neutralStrokeSubtleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -36,9 +36,9 @@ export const aestheticStyles: ElementStyles = css`
         height: fit-content;
         width: fit-content;
         padding: 4px 12px;
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillRest};
+        background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
         ${typeRampBase}
         white-space: nowrap;

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -4,12 +4,12 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillSecondaryRecipe,
-    neutralFillSecondaryRest,
     neutralFillStealthActive,
     neutralFillStealthHover,
     neutralFillStealthRecipe,
     neutralFillStealthRest,
+    neutralFillSubtleRecipe,
+    neutralFillSubtleRest,
     neutralForegroundRest,
     strokeWidth,
     Swatch,
@@ -28,7 +28,7 @@ const expandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collaps
 
 const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collapse-selected-hover").withDefault(
     (resolve: DesignTokenResolver) => {
-        const baseRecipe = resolve(neutralFillSecondaryRecipe);
+        const baseRecipe = resolve(neutralFillSubtleRecipe);
         const buttonRecipe = resolve(neutralFillStealthRecipe);
         return buttonRecipe.evaluate(resolve, baseRecipe.evaluate(resolve).rest).hover;
     }
@@ -148,7 +148,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     :host([selected]) .control {
-        background: ${neutralFillSecondaryRest};
+        background: ${neutralFillSubtleRest};
     }
 
     :host([selected]) .expand-collapse-button:hover {


### PR DESCRIPTION
# Pull Request

## Description

Following #54, update component styles to use non-deprecated color tokens.
Fix neutral fill subtle tokens.

## Reviewer Notes

The component styles have been migrated to the non-deprecated recommendations from the previous PR.

## Test Plan

Ran through Storybook for visual check.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Migrate to a modular definition of the styles, initially for color tokens only.