### PR TITLE
Add style modules

### DIFF
--- a/change/@adaptive-web-adaptive-ui-d459eac4-9359-495a-94b6-db1b9e726274.json
+++ b/change/@adaptive-web-adaptive-ui-d459eac4-9359-495a-94b6-db1b9e726274.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Package color tokens as sets and style modules, add style module rendering to ElementStyles",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-ca691012-4ca5-4f72-ae9e-ce28f0d7e6b6.json
+++ b/change/@adaptive-web-adaptive-web-components-ca691012-4ca5-4f72-ae9e-ce28f0d7e6b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Anchor to illustrate initial migration to style modules for components",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -1,4 +1,4 @@
-import { stylesToElementStyles } from "@adaptive-web/adaptive-ui";
+import { renderElementStyles } from "@adaptive-web/adaptive-ui";
 import type { Styles } from "@adaptive-web/adaptive-ui";
 import {
     css,
@@ -54,7 +54,7 @@ export class AdaptiveComponent extends FASTElement {
         // if (prev) {
         //     prev.forEach((s) => this.$fastController.removeStyles(s));
         // }
-        const elementStyles = stylesToElementStyles(next, params);
+        const elementStyles = renderElementStyles(next, params);
         elementStyles.forEach((s) => this.$fastController.addStyles(s));
     }
 }

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -1,4 +1,5 @@
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { stylesToElementStyles } from "@adaptive-web/adaptive-ui";
+import type { Styles } from "@adaptive-web/adaptive-ui";
 import {
     css,
     customElement,
@@ -7,28 +8,13 @@ import {
     html,
     observable,
 } from "@microsoft/fast-element";
-import { CSSDesignToken } from "@microsoft/fast-foundation";
 
 function template<T extends AdaptiveComponent>(): ElementViewTemplate<T> {
     return html<T>`
-        <template
-            tabindex="0"
-            style="
-                --ac-fill-rest: ${x => x.fillRest?.createCSS() || "transparent"};
-                --ac-fill-hover: ${x => x.fillHover?.createCSS() || x.fillRest?.createCSS() || "transparent"};
-                --ac-fill-active: ${x => x.fillActive?.createCSS() || x.fillRest?.createCSS() || "transparent"};
-                --ac-fill-focus: ${x => x.fillFocus?.createCSS() || x.fillRest?.createCSS() || "transparent"};
-                --ac-stroke-rest: ${x => x.strokeRest?.createCSS() || "transparent"};
-                --ac-stroke-hover: ${x => x.strokeHover?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
-                --ac-stroke-active: ${x => x.strokeActive?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
-                --ac-stroke-focus: ${x => x.strokeFocus?.createCSS() || x.strokeRest?.createCSS() || "transparent"};
-                --ac-foreground-rest: ${x => x.foregroundRest?.createCSS() || "transparent"};
-                --ac-foreground-hover: ${x => x.foregroundHover?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
-                --ac-foreground-active: ${x => x.foregroundActive?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
-                --ac-foreground-focus: ${x => x.foregroundFocus?.createCSS() || x.foregroundRest?.createCSS() || "transparent"};
-            "
-        >
-            <slot></slot>
+        <template tabindex="0">
+            <span class="content" part="content">
+                <slot></slot>
+            </span>
         </template>
     `;
 }
@@ -41,75 +27,34 @@ const styles = css`
         box-sizing: border-box;
         font-size: 14px;
         justify-items: start;
-        border: 1px solid transparent;
+        border-width: 1px;
+        border-style: solid;
         border-radius: 4px;
         cursor: pointer;
     }
 
-    :host {
-        background: var(--ac-fill-rest);
-        border-color: var(--ac-stroke-rest) !important;
-        color: var(--ac-foreground-rest);
-    }
-
-    :host(:hover) {
-        background: var(--ac-fill-hover);
-        border-color: var(--ac-stroke-hover) !important;
-        color: var(--ac-foreground-hover);
-    }
-
-    :host(:active) {
-        background: var(--ac-fill-active);
-        border-color: var(--ac-stroke-active) !important;
-        color: var(--ac-foreground-active);
-    }
-
-    :host(:focus) {
-        background: var(--ac-fill-focus);
-        border-color: var(--ac-stroke-focus) !important;
-        color: var(--ac-foreground-focus);
-    }
 `;
+
+const params = {
+    interactivitySelector: "",
+    nonInteractivitySelector: "",
+};
 
 @customElement({
     name: "app-adaptive-component",
     template: template(),
-    styles,
+    styles
 })
 export class AdaptiveComponent extends FASTElement {
     @observable
-    public fillRest?: CSSDesignToken<Swatch>;
-
-    @observable
-    public fillHover?: CSSDesignToken<Swatch>;
-
-    @observable
-    public fillActive?: CSSDesignToken<Swatch>;
-
-    @observable
-    public fillFocus?: CSSDesignToken<Swatch>;
-
-    @observable
-    public strokeRest?: CSSDesignToken<Swatch>;
-
-    @observable
-    public strokeHover?: CSSDesignToken<Swatch>;
-
-    @observable
-    public strokeActive?: CSSDesignToken<Swatch>;
-
-    @observable
-    public strokeFocus?: CSSDesignToken<Swatch>;
-
-    @observable
-    public foregroundRest?: CSSDesignToken<Swatch>;
-
-    @observable
-    public foregroundHover?: CSSDesignToken<Swatch>;
-
-    @observable
-    public foregroundActive?: CSSDesignToken<Swatch>;
-
-    @observable
-    public foregroundFocus?: CSSDesignToken<Swatch>;
+    public styles?: Styles;
+    protected stylesChanged(prev: Styles, next: Styles) {
+        console.log("stylesChanged", next);
+        
+        // if (prev) {
+        //     prev.forEach((s) => this.$fastController.removeStyles(s));
+        // }
+        const elementStyles = stylesToElementStyles(next, params);
+        elementStyles.forEach((s) => this.$fastController.addStyles(s));
+    }
 }

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -1,45 +1,15 @@
 import {
-    accentFillActive,
-    accentFillFocus,
-    accentFillHover,
-    accentFillRest,
-    accentForegroundActive,
-    accentForegroundFocus,
-    accentForegroundHover,
-    accentForegroundRest,
+    accentFillControlStyles,
+    accentForegroundReadableStyles,
     fillColor,
-    focusStrokeInner,
-    focusStrokeOuter,
-    foregroundOnAccentActive,
-    foregroundOnAccentFocus,
-    foregroundOnAccentHover,
-    foregroundOnAccentRest,
-    neutralFillActive,
-    neutralFillFocus,
-    neutralFillHover,
-    neutralFillInputActive,
-    neutralFillInputFocus,
-    neutralFillInputHover,
-    neutralFillInputRest,
-    neutralFillRest,
-    neutralFillStealthActive,
-    neutralFillStealthFocus,
-    neutralFillStealthHover,
-    neutralFillStealthRest,
-    neutralForegroundActive,
-    neutralForegroundFocus,
-    neutralForegroundHint,
-    neutralForegroundHover,
-    neutralForegroundRest,
-    neutralStrokeActive,
-    neutralStrokeDividerRest,
-    neutralStrokeFocus,
-    neutralStrokeHover,
-    neutralStrokeRest,
-    neutralStrokeStrongActive,
-    neutralStrokeStrongFocus,
-    neutralStrokeStrongHover,
-    neutralStrokeStrongRest,
+    neutralFillControlStyles,
+    neutralForegroundReadableStyles,
+    neutralForegroundStrongStyles,
+    neutralOutlineControlStyles,
+    neutralPerceivableControlStyles,
+    neutralStealthControlStyles,
+    neutralStrokeReadableRest,
+    neutralStrokeSubtleRest,
     SwatchRGB,
 } from "@adaptive-web/adaptive-ui";
 import { parseColorHexRGB } from "@microsoft/fast-colors";
@@ -53,416 +23,55 @@ import {
     ViewTemplate,
     when,
 } from "@microsoft/fast-element";
-import { display } from "@microsoft/fast-foundation";
 import { ComponentType } from "../component-type.js";
 import "./adaptive-component.js";
+import "./style-example.js";
 import "./swatch.js";
 
 const backplateComponents = html<ColorBlock>`
-    <template>
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => accentFillRest}"
-                :fillHover="${x => accentFillHover}"
-                :fillActive="${x => accentFillActive}"
-                :fillFocus="${x => accentFillFocus}"
-                :foregroundRest="${x => foregroundOnAccentRest}"
-                :foregroundHover="${x => foregroundOnAccentHover}"
-                :foregroundActive="${x => foregroundOnAccentActive}"
-                :foregroundFocus="${x => foregroundOnAccentFocus}"
-            >
-                Accent button
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="fill"
-            recipe-name="accentFillRest"
-            :fillRecipe="${x => accentFillRest}"
-            :foregroundRecipe="${x => foregroundOnAccentRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="accentFillHover"
-            :fillRecipe="${x => accentFillHover}"
-            :foregroundRecipe="${x => foregroundOnAccentRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="accentFillActive"
-            :fillRecipe="${x => accentFillActive}"
-            :foregroundRecipe="${x => foregroundOnAccentRest}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="foregroundOnAccent"
-            :fillRecipe="${x => accentFillRest}"
-            :foregroundRecipe="${x => foregroundOnAccentRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeInner"
-            :fillRecipe="${x => focusStrokeOuter}"
-            :foregroundRecipe="${x => focusStrokeInner}"
-            :outlineRecipe="${x => focusStrokeInner}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
-        ></app-swatch>
+    <app-style-example :styles="${x => accentFillControlStyles}">
+        Accent fill
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => neutralFillRest}"
-                :fillHover="${x => neutralFillHover}"
-                :fillActive="${x => neutralFillActive}"
-                :fillFocus="${x => neutralFillFocus}"
-                :foregroundRest="${x => neutralForegroundRest}"
-            >
-                Neutral button
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillRest"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillHover"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillHover}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillActive"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillActive}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralFillControlStyles}">
+        Neutral fill
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => fillColor}"
-                :strokeRest="${x => neutralStrokeRest}"
-                :strokeHover="${x => neutralStrokeHover}"
-                :strokeActive="${x => neutralStrokeActive}"
-                :strokeFocus="${x => neutralStrokeFocus}"
-                :foregroundRest="${x => neutralForegroundRest}"
-            >
-                Outline button
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeRest"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => fillColor}"
-            :outlineRecipe="${x => neutralStrokeRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeHover"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => fillColor}"
-            :outlineRecipe="${x => neutralStrokeHover}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeActive"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => fillColor}"
-            :outlineRecipe="${x => neutralStrokeActive}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralOutlineControlStyles}">
+        Neutral outline
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => neutralFillStealthRest}"
-                :fillHover="${x => neutralFillStealthHover}"
-                :fillActive="${x => neutralFillStealthActive}"
-                :fillFocus="${x => neutralFillStealthFocus}"
-                :foregroundRest="${x => neutralForegroundRest}"
-            >
-                Stealth button
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillStealthRest"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillStealthRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillStealthHover"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillStealthHover}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillStealthActive"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :fillRecipe="${x => neutralFillStealthActive}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
-        ></app-swatch>
-    </template>
+    <app-style-example :styles="${x => neutralStealthControlStyles}">
+        Neutral stealth
+    </app-style-example>
 `;
 
 const textComponents = html<ColorBlock>`
-    <template>
-        <div class="example">
-            <app-adaptive-component
-                :foregroundRest="${x => neutralForegroundRest}"
-                :foregroundHover="${x => neutralForegroundHover}"
-                :foregroundActive="${x => neutralForegroundActive}"
-                :foregroundFocus="${x => neutralForegroundFocus}"
-            >
-                Neutral
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundHover"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundHover}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundActive"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundActive}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralForegroundStrongStyles}">
+        Neutral
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :foregroundRest="${x => neutralForegroundHint}"
-            >
-                Hint
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundHint"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundHint}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralForegroundReadableStyles}">
+        Hint / placeholder
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :foregroundRest="${x => accentForegroundRest}"
-                :foregroundHover="${x => accentForegroundHover}"
-                :foregroundActive="${x => accentForegroundActive}"
-                :foregroundFocus="${x => accentForegroundFocus}"
-            >
-                Accent
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="foreground"
-            recipe-name="accentForegroundRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => accentForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="accentForegroundHover"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => accentForegroundHover}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="accentForegroundActive"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => accentForegroundActive}"
-        ></app-swatch>
-    </template>
+    <app-style-example :styles="${x => accentForegroundReadableStyles}">
+        Accent
+    </app-style-example>
 `;
 
 const formComponents = html<ColorBlock>`
-    <template>
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => neutralFillInputRest}"
-                :fillHover="${x => neutralFillInputHover}"
-                :fillActive="${x => neutralFillInputActive}"
-                :fillFocus="${x => neutralFillInputFocus}"
-                :foregroundRest="${x => neutralForegroundRest}"
-                :strokeRest="${x => neutralStrokeRest}"
-                :strokeHover="${x => neutralStrokeHover}"
-                :strokeActive="${x => neutralStrokeActive}"
-                :strokeFocus="${x => neutralStrokeFocus}"
-            >
-                Text field
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillInputRest"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundHint"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundHint}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeHover"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeHover}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="focusStrokeOuter"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => focusStrokeOuter}"
-            :outlineRecipe="${x => focusStrokeOuter}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralFillControlStyles}">
+        Text field
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :fillRest="${x => neutralFillInputRest}"
-                :fillHover="${x => neutralFillInputHover}"
-                :fillActive="${x => neutralFillInputActive}"
-                :fillFocus="${x => neutralFillInputFocus}"
-                :foregroundRest="${x => neutralForegroundRest}"
-                :strokeRest="${x => neutralStrokeStrongRest}"
-                :strokeHover="${x => neutralStrokeStrongHover}"
-                :strokeActive="${x => neutralStrokeStrongActive}"
-                :strokeFocus="${x => neutralStrokeStrongFocus}"
-            >
-                Checkbox
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillInputRest"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillInputRest"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillInputHover"
-            :fillRecipe="${x => neutralFillInputHover}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="fill"
-            recipe-name="neutralFillInputActive"
-            :fillRecipe="${x => neutralFillInputActive}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="foreground"
-            recipe-name="neutralForegroundRest"
-            :fillRecipe="${x => neutralFillInputRest}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeStrongRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeStrongRest}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeStrongHover"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeStrongHover}"
-        ></app-swatch>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeStrongActive"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeStrongActive}"
-        ></app-swatch>
+    <app-style-example :styles="${x => neutralPerceivableControlStyles}">
+        Checkbox
+    </app-style-example>
 
-        <div class="example">
-            <app-adaptive-component
-                :strokeRest="${x => neutralStrokeDividerRest}"
-            >
-                Divider
-            </app-adaptive-component>
-        </div>
-        <app-swatch
-            type="outline"
-            recipe-name="neutralStrokeDividerRest"
-            :fillRecipe="${x => fillColor}"
-            :foregroundRecipe="${x => neutralForegroundRest}"
-            :outlineRecipe="${x => neutralStrokeDividerRest}"
-        ></app-swatch>
-    </template>
+    <app-style-example :styles="${{"color": neutralStrokeSubtleRest}}">
+        Divider
+    </app-style-example>
 `;
 
 const template = html<ColorBlock>`
@@ -484,7 +93,8 @@ const template = html<ColorBlock>`
 `;
 
 const styles = css`
-    ${display("flex")} :host {
+    :host {
+        display: flex;
         flex-direction: column;
         flex-grow: 1;
         align-items: stretch;
@@ -494,14 +104,14 @@ const styles = css`
         height: max-content;
         min-height: 100%;
         background-color: ${fillColor};
-        color: ${neutralForegroundRest};
+        color: ${neutralStrokeReadableRest};
     }
 
     .title {
         margin: 16px auto 4px;
         font-weight: 600;
         height: 34px;
-        color: ${neutralForegroundHint};
+        color: ${neutralStrokeReadableRest};
     }
 
     .title code {
@@ -513,18 +123,7 @@ const styles = css`
         display: flex;
         flex-direction: column;
         align-items: center;
-        padding: 0 48px 36px;
-    }
-
-    .example {
-        height: 60px;
-        display: flex;
-        align-items: center;
-        margin-top: 24px;
-    }
-
-    .divider {
-        width: 150px;
+        padding: 0 36px 36px;
     }
 `;
 
@@ -564,8 +163,10 @@ export class ColorBlock extends FASTElement {
 
     private updateColor(): void {
         if (this.color && this.$fastController.isConnected) {
-            const color = parseColorHexRGB(this.color)!;
-            fillColor.setValueFor(this, SwatchRGB.from(color));
+            const color = parseColorHexRGB(this.color);
+            if (color) {
+                fillColor.setValueFor(this, SwatchRGB.from(color));
+            }
         }
     }
 }

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -1,0 +1,191 @@
+import { fillColor, InteractiveTokenSet, Styles, Swatch } from "@adaptive-web/adaptive-ui";
+import { css, customElement, FASTElement, html, observable, repeat, volatile } from "@microsoft/fast-element";
+import { CSSDesignToken } from "@microsoft/fast-foundation";
+import { SwatchType } from "./swatch.js";
+import "./adaptive-component.js";
+import "./swatch.js";
+
+const template = html<StyleExample>`
+    <template>
+        <div class="example">
+            <app-adaptive-component :styles="${x => x.styles}">
+                <slot></slot>
+            </app-adaptive-component>
+        </div>
+        ${repeat(x => x.styleValues, html<StyleValue, StyleExample>`
+            <app-swatch
+                type="${x => x.type}"
+                recipe-name="${x => x.tokenName}"
+                :fillRecipe="${x => x.fillRecipe}"
+                :foregroundRecipe="${x => x.foregroundRecipe}"
+                :outlineRecipe="${x => x.outlineRecipe}"
+            ></app-swatch>
+        `)}
+    </template>
+`;
+
+const styles = css`
+    :host {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    .example {
+        height: 60px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-top: 24px;
+    }
+`;
+
+interface StyleValue {
+    type: SwatchType;
+    tokenName: string;
+    foregroundRecipe?: CSSDesignToken<Swatch>;
+    fillRecipe?: CSSDesignToken<Swatch>;
+    outlineRecipe?: CSSDesignToken<Swatch>;
+}
+
+@customElement({
+    name: "app-style-example",
+    template,
+    styles,
+})
+export class StyleExample extends FASTElement {
+    @observable
+    public styles?: Styles;
+    
+    @volatile
+    public get styleValues(): StyleValue[] {
+        const values: StyleValue[] = [];
+
+        let backgroundRest = fillColor;
+        let backgroundHover = fillColor;
+        let backgroundActive = fillColor;
+        let backgroundFocus = fillColor;
+
+        const backgroundValue = (this.styles || {})["background-color"];
+        if (backgroundValue) {
+            if (typeof backgroundValue === "string") {
+                // ignore for now
+            } else if (backgroundValue instanceof CSSDesignToken) {
+                backgroundRest = backgroundValue;
+                values.push({
+                    type: SwatchType.fill,
+                    tokenName: (backgroundValue as CSSDesignToken<any>).name,
+                    fillRecipe: backgroundValue,
+                });
+            } else {
+                const set = backgroundValue as InteractiveTokenSet<any>;
+                backgroundRest = set.rest;
+                backgroundHover = set.hover;
+                backgroundActive = set.active;
+                backgroundFocus = set.focus;
+                values.push({
+                    type: SwatchType.fill,
+                    tokenName: set.rest.name,
+                    fillRecipe: set.rest,
+                });
+                values.push({
+                    type: SwatchType.fill,
+                    tokenName: set.hover.name,
+                    fillRecipe: set.hover,
+                });
+                values.push({
+                    type: SwatchType.fill,
+                    tokenName: set.active.name,
+                    fillRecipe: set.active,
+                });
+                values.push({
+                    type: SwatchType.fill,
+                    tokenName: set.focus.name,
+                    fillRecipe: set.focus,
+                });
+            }
+        }
+
+        const colorValue = (this.styles || {})["color"];
+        if (colorValue) {
+            if (typeof colorValue === "string") {
+                // ignore for now
+            } else if (colorValue instanceof CSSDesignToken) {
+                values.push({
+                    type: SwatchType.foreground,
+                    tokenName: (colorValue as CSSDesignToken<any>).name,
+                    foregroundRecipe: colorValue,
+                    fillRecipe: backgroundRest,
+                });
+            } else {
+                const set = colorValue as InteractiveTokenSet<any>;
+                values.push({
+                    type: SwatchType.foreground,
+                    tokenName: set.rest.name,
+                    foregroundRecipe: set.rest,
+                    fillRecipe: backgroundRest,
+                });
+                values.push({
+                    type: SwatchType.foreground,
+                    tokenName: set.hover.name,
+                    foregroundRecipe: set.hover,
+                    fillRecipe: backgroundHover,
+                });
+                values.push({
+                    type: SwatchType.foreground,
+                    tokenName: set.active.name,
+                    foregroundRecipe: set.active,
+                    fillRecipe: backgroundActive,
+                });
+                values.push({
+                    type: SwatchType.foreground,
+                    tokenName: set.focus.name,
+                    foregroundRecipe: set.focus,
+                    fillRecipe: backgroundFocus,
+                });
+            }
+        }
+
+        const borderValue = (this.styles || {})["border-color"];
+        if (borderValue) {
+            if (typeof borderValue === "string") {
+                // ignore for now
+            } else if (borderValue instanceof CSSDesignToken) {
+                values.push({
+                    type: SwatchType.outline,
+                    tokenName: (borderValue as CSSDesignToken<any>).name,
+                    outlineRecipe: borderValue,
+                    fillRecipe: backgroundRest,
+                });
+            } else {
+                const set = borderValue as InteractiveTokenSet<any>;
+                values.push({
+                    type: SwatchType.outline,
+                    tokenName: set.rest.name,
+                    outlineRecipe: set.rest,
+                    fillRecipe: backgroundRest,
+                });
+                values.push({
+                    type: SwatchType.outline,
+                    tokenName: set.hover.name,
+                    outlineRecipe: set.hover,
+                    fillRecipe: backgroundHover,
+                });
+                values.push({
+                    type: SwatchType.outline,
+                    tokenName: set.active.name,
+                    outlineRecipe: set.active,
+                    fillRecipe: backgroundActive,
+                });
+                values.push({
+                    type: SwatchType.outline,
+                    tokenName: set.focus.name,
+                    outlineRecipe: set.focus,
+                    fillRecipe: backgroundFocus,
+                });
+            }
+        }
+
+        return values;
+    }
+}

--- a/packages/adaptive-ui-explorer/src/components/swatch.ts
+++ b/packages/adaptive-ui-explorer/src/components/swatch.ts
@@ -44,10 +44,6 @@ const styles = css`
         justify-items: start;
     }
 
-    :host([type="foreground"]) .icon {
-        border: 1px solid black;
-    }
-
     :host([type="foreground"]) .icon::before {
         font-size: 13px;
         content: "A";
@@ -167,42 +163,26 @@ export class AppSwatch extends FASTElement {
             : "";
     }
 
-    private formatBackgroundContrast(
+    private formatContrastMessage(
         a?: DesignToken<Swatch>,
         b?: DesignToken<Swatch>
     ): string {
-        return `BG contrast: ${this.formatContrast(a, b)} : 1`;
-    }
-
-    private formatForegroundContrast(
-        a?: DesignToken<Swatch>,
-        b?: DesignToken<Swatch>
-    ): string {
-        return `Text contrast: ${this.formatContrast(a, b)} : 1`;
+        return `Contrast: ${this.formatContrast(a, b)} : 1`;
     }
 
     private updateContrastMessage(): void {
-        const backgroundContrastMessage: string = this.formatBackgroundContrast(
+        const contrastMessage: string = this.formatContrastMessage(
             this.type === SwatchType.foreground
                 ? this.foregroundRecipe
                 : this.type === SwatchType.outline
                 ? this.outlineRecipe
                 : this.fillRecipe,
-            this.type === SwatchType.foreground || this.type === SwatchType.outline
+            this.type === SwatchType.foreground
                 ? this.fillRecipe
                 : fillColor
         );
 
-        this.contrastMessage =
-            this.type === SwatchType.fill
-                ? backgroundContrastMessage.concat(
-                      "\n",
-                      this.formatForegroundContrast(
-                          this.fillRecipe,
-                          this.foregroundRecipe
-                      )
-                  )
-                : backgroundContrastMessage;
+        this.contrastMessage = contrastMessage;
     }
 
     private updateColorValue(): void {

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -878,6 +878,11 @@ export interface RelativeLuminance {
     readonly relativeLuminance: number;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "renderElementStyles" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
+//
+// @public
+export function renderElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[];
+
 // @public
 export function resolvePaletteDirection(direction: PaletteDirection): PaletteDirectionValue;
 
@@ -916,11 +921,6 @@ export interface StyleModuleEvaluateParameters {
 
 // @public
 export type Styles = Record<string, CSSDesignToken<any> | InteractiveTokenSet<any> | string>;
-
-// Warning: (ae-incompatible-release-tags) The symbol "stylesToElementStyles" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
-//
-// @public
-export function stylesToElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[];
 
 // @public
 export interface Swatch extends RelativeLuminance {

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -9,6 +9,7 @@ import { CSSDesignToken } from '@microsoft/fast-foundation';
 import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
 import { DesignTokenResolver } from '@microsoft/fast-foundation';
+import type { ElementStyles } from '@microsoft/fast-element';
 import type { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public (undocumented)
@@ -22,6 +23,9 @@ export const accentFillActive: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillActiveDelta: DesignToken<number>;
+
+// @public
+export const accentFillControlStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const accentFillFocus: CSSDesignToken<Swatch>;
@@ -55,6 +59,9 @@ export const accentFillReadableHover: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentFillReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public (undocumented)
 export const accentFillReadableMinContrast: DesignToken<number>;
@@ -96,7 +103,13 @@ export const accentForegroundHover: CSSDesignToken<Swatch>;
 export const accentForegroundHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const accentForegroundInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const accentForegroundMinContrast: DesignToken<number>;
+
+// @public
+export const accentForegroundReadableStyles: Styles;
 
 // @public (undocumented)
 export const accentForegroundRecipe: DesignToken<InteractiveColorRecipe>;
@@ -232,6 +245,9 @@ export const elevationTooltipSize: DesignToken<number>;
 // @public (undocumented)
 export const fillColor: CSSDesignToken<Swatch>;
 
+// @public
+export type FocusSelector = "focus" | "focus-visible" | "focus-within";
+
 // @public (undocumented)
 export const focusStrokeInner: CSSDesignToken<Swatch>;
 
@@ -260,6 +276,9 @@ export const foregroundOnAccentFocus: CSSDesignToken<Swatch>;
 export const foregroundOnAccentHover: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
+export const foregroundOnAccentInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const foregroundOnAccentRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -273,15 +292,23 @@ export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet
 }
 
 // @public
-export interface InteractiveSwatchSet {
-    active: Swatch;
-    focus: Swatch;
-    hover: Swatch;
-    rest: Swatch;
+export interface InteractiveSet<T> {
+    active: T;
+    focus: T;
+    hover: T;
+    rest: T;
+}
+
+// @public
+export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {
 }
 
 // @public
 export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
+
+// @public
+export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>> {
+}
 
 // @public
 export function isDark(color: RelativeLuminance): boolean;
@@ -366,6 +393,11 @@ export interface LayerRecipe {
 // @public
 export function luminanceSwatch(luminance: number): Swatch;
 
+// Warning: (ae-incompatible-release-tags) The symbol "makeSelector" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
+//
+// @public
+export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string;
+
 // @public (undocumented)
 export const minContrastPerceivable: DesignToken<number>;
 
@@ -386,6 +418,9 @@ export const neutralFillActive: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillActiveDelta: DesignToken<number>;
+
+// @public
+export const neutralFillControlStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const neutralFillFocus: CSSDesignToken<Swatch>;
@@ -443,6 +478,9 @@ export const neutralFillPerceivableHover: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const neutralFillPerceivableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public (undocumented)
 export const neutralFillPerceivableMinContrast: DesignToken<number>;
@@ -511,6 +549,9 @@ export const neutralFillStealthHover: CSSDesignToken<Swatch>;
 export const neutralFillStealthHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralFillStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const neutralFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -568,6 +609,9 @@ export const neutralFillSubtleHover: CSSDesignToken<Swatch>;
 export const neutralFillSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralFillSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const neutralFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -601,7 +645,13 @@ export const neutralForegroundHover: CSSDesignToken<Swatch>;
 export const neutralForegroundHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralForegroundInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const neutralForegroundMinContrast: DesignToken<number>;
+
+// @public
+export const neutralForegroundReadableStyles: Styles;
 
 // @public (undocumented)
 export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipe>;
@@ -612,8 +662,20 @@ export const neutralForegroundRest: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralForegroundRestDelta: DesignToken<number>;
 
+// @public
+export const neutralForegroundStrongStyles: Styles;
+
+// @public
+export const neutralOutlineControlStyles: Styles;
+
 // @public (undocumented)
 export const neutralPalette: DesignToken<Palette<Swatch>>;
+
+// @public
+export const neutralPerceivableControlStyles: Styles;
+
+// @public
+export const neutralStealthControlStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeActive: CSSDesignToken<Swatch>;
@@ -686,6 +748,9 @@ export const neutralStrokePerceivableHover: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const neutralStrokePerceivableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public (undocumented)
 export const neutralStrokePerceivableMinContrast: DesignToken<number>;
@@ -763,6 +828,9 @@ export const neutralStrokeSubtleHover: CSSDesignToken<Swatch>;
 export const neutralStrokeSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const neutralStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const neutralStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -826,8 +894,33 @@ export const StandardFontWeight: {
     readonly Black: 900;
 };
 
+// @public
+export type StateSelector = "hover" | "active" | FocusSelector;
+
 // @public (undocumented)
 export const strokeWidth: CSSDesignToken<number>;
+
+// @beta
+export interface StyleModuleEvaluateParameters {
+    // (undocumented)
+    hostCondition?: string;
+    // (undocumented)
+    interactivitySelector?: string;
+    // (undocumented)
+    nonInteractivitySelector?: string;
+    // (undocumented)
+    part?: string;
+    // (undocumented)
+    partCondition?: string;
+}
+
+// @public
+export type Styles = Record<string, CSSDesignToken<any> | InteractiveTokenSet<any> | string>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "stylesToElementStyles" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
+//
+// @public
+export function stylesToElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[];
 
 // @public
 export interface Swatch extends RelativeLuminance {

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -1,4 +1,5 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import { InteractiveSet } from "../types.js";
 import { Swatch } from "./swatch.js";
 
 /**
@@ -28,24 +29,4 @@ export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet
  *
  * @public
  */
-export interface InteractiveSwatchSet {
-    /**
-     * The Swatch to apply to the rest state.
-     */
-    rest: Swatch;
-
-    /**
-     * The Swatch to apply to the hover state.
-     */
-    hover: Swatch;
-
-    /**
-     * The Swatch to apply to the active state.
-     */
-    active: Swatch;
-
-    /**
-     * The Swatch to apply to the focus state.
-     */
-    focus: Swatch;
-}
+export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {}

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -795,10 +795,10 @@ export const neutralStrokePerceivableMinContrast = createMinContrast(neutralStro
 export const neutralStrokePerceivableRestDelta = createDelta(neutralStrokePerceivableName, "rest", 0);
 
 /** @public */
-export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 0);
+export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 8);
 
 /** @public */
-export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", 0);
+export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", -4);
 
 /** @public */
 export const neutralStrokePerceivableFocusDelta = createDelta(neutralStrokePerceivableName, "focus", 0);

--- a/packages/adaptive-ui/src/design-tokens/index.ts
+++ b/packages/adaptive-ui/src/design-tokens/index.ts
@@ -2,5 +2,6 @@ export * from "./appearance.js";
 export * from "./color.js";
 export * from "./elevation.js";
 export * from "./layer.js";
+export * from "./modules.js";
 export * from "./palette.js";
 export * from "./type.js";

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,0 +1,217 @@
+import { Swatch } from "../color/swatch.js";
+import type { InteractiveTokenSet, Styles } from "../types.js";
+import {
+    accentFillReadableActive,
+    accentFillReadableFocus,
+    accentFillReadableHover,
+    accentFillReadableRest,
+    accentForegroundActive,
+    accentForegroundFocus,
+    accentForegroundHover,
+    accentForegroundRest,
+    fillColor,
+    foregroundOnAccentActive,
+    foregroundOnAccentFocus,
+    foregroundOnAccentHover,
+    foregroundOnAccentRest,
+    neutralFillPerceivableActive,
+    neutralFillPerceivableFocus,
+    neutralFillPerceivableHover,
+    neutralFillPerceivableRest,
+    neutralFillStealthActive,
+    neutralFillStealthFocus,
+    neutralFillStealthHover,
+    neutralFillStealthRest,
+    neutralFillSubtleActive,
+    neutralFillSubtleFocus,
+    neutralFillSubtleHover,
+    neutralFillSubtleRest,
+    neutralForegroundActive,
+    neutralForegroundFocus,
+    neutralForegroundHover,
+    neutralForegroundRest,
+    neutralStrokePerceivableActive,
+    neutralStrokePerceivableFocus,
+    neutralStrokePerceivableHover,
+    neutralStrokePerceivableRest,
+    neutralStrokeReadableRest,
+    neutralStrokeSubtleActive,
+    neutralStrokeSubtleFocus,
+    neutralStrokeSubtleHover,
+    neutralStrokeSubtleRest,
+} from "./color.js";
+
+/**
+ * @public
+ */
+export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: accentFillReadableRest,
+    hover: accentFillReadableHover,
+    active: accentFillReadableActive,
+    focus: accentFillReadableFocus,
+};
+
+/**
+ * @public
+ */
+export const foregroundOnAccentInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: foregroundOnAccentRest,
+    hover: foregroundOnAccentHover,
+    active: foregroundOnAccentActive,
+    focus: foregroundOnAccentFocus,
+};
+
+/**
+ * @public
+ */
+export const accentForegroundInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: accentForegroundRest,
+    hover: accentForegroundHover,
+    active: accentForegroundActive,
+    focus: accentForegroundFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralFillStealthInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralFillStealthRest,
+    hover: neutralFillStealthHover,
+    active: neutralFillStealthActive,
+    focus: neutralFillStealthFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralFillSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralFillSubtleRest,
+    hover: neutralFillSubtleHover,
+    active: neutralFillSubtleActive,
+    focus: neutralFillSubtleFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralFillPerceivableRest,
+    hover: neutralFillPerceivableHover,
+    active: neutralFillPerceivableActive,
+    focus: neutralFillPerceivableFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralForegroundInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralForegroundRest,
+    hover: neutralForegroundHover,
+    active: neutralForegroundActive,
+    focus: neutralForegroundFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralStrokeSubtleRest,
+    hover: neutralStrokeSubtleHover,
+    active: neutralStrokeSubtleActive,
+    focus: neutralStrokeSubtleFocus,
+};
+
+/**
+ * @public
+ */
+export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralStrokePerceivableRest,
+    hover: neutralStrokePerceivableHover,
+    active: neutralStrokePerceivableActive,
+    focus: neutralStrokePerceivableFocus,
+};
+
+/**
+ * Convenience style module for an accent-filled control.
+ *
+ * @public
+ */
+export const accentFillControlStyles: Styles = {
+    "background-color": accentFillReadableInteractiveSet,
+    "border-color": "transparent",
+    "color": foregroundOnAccentInteractiveSet,
+};
+
+/**
+ * Convenience style module for a neutral-filled control.
+ *
+ * @public
+ */
+export const neutralFillControlStyles: Styles = {
+    "background-color": neutralFillSubtleInteractiveSet,
+    "border-color": neutralStrokeSubtleInteractiveSet,
+    "color": neutralForegroundRest,
+};
+
+/**
+ * Convenience style module for a neutral control with accessibility requirements, like a checkbox.
+ *
+ * @public
+ */
+export const neutralPerceivableControlStyles: Styles = {
+    "background-color": neutralFillSubtleInteractiveSet,
+    "border-color": neutralStrokePerceivableInteractiveSet,
+    "color": neutralForegroundRest,
+};
+
+/**
+ * Convenience style module for a neutral-outlined control.
+ *
+ * @public
+ */
+export const neutralOutlineControlStyles: Styles = {
+    "background-color": fillColor,
+    "border-color": neutralStrokePerceivableInteractiveSet,
+    "color": neutralForegroundRest,
+};
+
+/**
+ * Convenience style module for a neutral stealth control.
+ *
+ * @public
+ */
+export const neutralStealthControlStyles: Styles = {
+    "background-color": neutralFillStealthInteractiveSet,
+    "border-color": "transparent",
+    "color": neutralForegroundRest,
+};
+
+/**
+ * Convenience style module for accent-colored text or icons.
+ *
+ * @public
+ */
+export const accentForegroundReadableStyles: Styles = {
+    "border-color": "transparent",
+    "color": accentForegroundInteractiveSet,
+};
+
+/**
+ * Convenience style module for neutral-colored hint or placeholder text or icons.
+ *
+ * @public
+ */
+export const neutralForegroundReadableStyles: Styles = {
+    "border-color": "transparent",
+    "color": neutralStrokeReadableRest,
+};
+
+/**
+ * Convenience style module for neutral-colored main text or icons.
+ *
+ * @public
+ */
+export const neutralForegroundStrongStyles: Styles = {
+    "border-color": "transparent",
+    "color": neutralForegroundInteractiveSet,
+};

--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./color/index.js";
 export * from "./design-tokens/index.js";
 export * from "./elevation/index.js";
+export * from "./modules/index.js";
 export * from "./type/index.js";
 export * from "./styles.js";
+export * from "./types.js";

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -1,0 +1,75 @@
+import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
+import { CSSDesignToken } from "@microsoft/fast-foundation";
+import type { InteractiveTokenSet, Styles } from "../types.js";
+import { makeSelector } from "./selector.js";
+import type { FocusSelector, StyleModuleEvaluateParameters } from "./types.js";
+
+type StyleModuleEvaluate = (params: StyleModuleEvaluateParameters) => ElementStyles;
+
+function property<T = string>(
+    property: string,
+    value: string | CSSDesignToken<T>,
+): StyleModuleEvaluate {
+    return (params: StyleModuleEvaluateParameters): ElementStyles =>
+        css`${makeSelector(params)} { ${property}: ${value}; }`;
+}
+
+function propertyInteractive<T = string>(
+    property: string,
+    values: InteractiveTokenSet<T>,
+    focusSelector: FocusSelector = "focus-visible",
+): StyleModuleEvaluate {
+    return (params: StyleModuleEvaluateParameters): ElementStyles => css`
+        ${makeSelector(params)} { ${property}: ${values.rest}; }
+        ${
+            values.hover
+                ? css.partial`${makeSelector(params, "hover")} { ${property}: ${values.hover}; }`
+                : ``
+        }
+        ${
+            values.active
+                ? css.partial`${makeSelector(params, "active")} { ${property}: ${values.active}; }`
+                : ``
+        }
+        ${
+            values.focus
+                ? css.partial`${makeSelector(params, focusSelector)} { ${property}: ${values.focus}; }`
+                : ``
+        }
+    `;
+}
+
+function createElementStyleModules(styles: Styles): StyleModuleEvaluate[] {
+    const modules: StyleModuleEvaluate[] = [];
+    for (const key in styles) {
+        const value = styles[key];
+        if (typeof value === "string" || value instanceof CSSDesignToken) {
+            const ev = property(key, value as CSSDesignToken<any>);
+            modules.push(ev);
+        } else {
+            const ev = propertyInteractive(key, value as InteractiveTokenSet<any>);
+            modules.push(ev);
+        }
+    }
+    return modules;
+}
+
+function createElementStyles(modules: StyleModuleEvaluate[], params: StyleModuleEvaluateParameters): ElementStyles[] {
+    return modules.map((module) =>
+        module(params)
+    );
+}
+
+/**
+ * Convert style definitions to `ElementStyles`.
+ *
+ * @param styles - A collection of individual styling properties.
+ * @param params - Parameters for creating the selectors for component states.
+ * @returns An array of `ElementStyles`.
+ *
+ * @public
+ */
+export function stylesToElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[] {
+    return createElementStyles(createElementStyleModules(styles), params);
+}

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -70,6 +70,6 @@ function createElementStyles(modules: StyleModuleEvaluate[], params: StyleModule
  *
  * @public
  */
-export function stylesToElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[] {
+export function renderElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[] {
     return createElementStyles(createElementStyleModules(styles), params);
 }

--- a/packages/adaptive-ui/src/modules/index.ts
+++ b/packages/adaptive-ui/src/modules/index.ts
@@ -1,0 +1,3 @@
+export * from "./element-styles-renderer.js";
+export * from "./selector.js";
+export * from "./types.js";

--- a/packages/adaptive-ui/src/modules/selector.ts
+++ b/packages/adaptive-ui/src/modules/selector.ts
@@ -1,0 +1,41 @@
+import type { StateSelector, StyleModuleEvaluateParameters } from "./types.js";
+
+/**
+ * Creates a single css selector for the provided `params` and optional `state`.
+ *
+ * @param params - Parameters for the selector.
+ * @param state - An optional interactive state.
+ * @returns A css selector string.
+ *
+ * @public
+ */
+export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string {
+    const selectors: string[] = [];
+
+    if (params.hostCondition || (state && params.interactivitySelector !== undefined)) {
+        // Use any base host condition like `[appearance='accent']`.
+        let hostCondition = params.hostCondition || "";
+
+        // Add any interactive condition like `:not([disabled])`.
+        hostCondition += (params.interactivitySelector || "");
+
+        // If this is not targeting a part, apply the state at the `:host`.
+        if (!params.part && state) {
+            hostCondition += ":" + state;
+        }
+
+        if (hostCondition !== "") {
+            selectors.push(`:host(${hostCondition})`);
+        }
+    } else if (!params.part) {
+        selectors.push(":host");
+    }
+
+    if (params.part) {
+        // Using class selector notation for now.
+        selectors.push(`.${params.part}${params.partCondition || ""}${state ? ":" + state : ""}`);
+    }
+    const ret = selectors.join(" ");
+    // console.log("makeSelector", ret);
+    return ret;
+}

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Selectors for focus state.
+ *
+ * @public
+ */
+export type FocusSelector = "focus" | "focus-visible" | "focus-within";
+
+/**
+ * Selectors for interactive component states.
+ *
+ * @public
+ */
+export type StateSelector = "hover" | "active" | FocusSelector;
+
+/**
+ * Parameters provided when rendering style modules.
+ *
+ * @remarks This may be split into `host` and `part` needs.
+ * @beta
+ */
+export interface StyleModuleEvaluateParameters {
+    hostCondition?: string;
+    part?: string;
+    partCondition?: string;
+    interactivitySelector?: string;
+    nonInteractivitySelector?: string;
+}

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -1,0 +1,42 @@
+import type { CSSDesignToken } from "@microsoft/fast-foundation";
+
+/**
+ * A set of values to use for an interactive element's states.
+ *
+ * @public
+ */
+export interface InteractiveSet<T> {
+    /**
+     * The value to apply to the rest state.
+     */
+    rest: T;
+
+    /**
+     * The value to apply to the hover state.
+     */
+    hover: T;
+
+    /**
+     * The value to apply to the active state.
+     */
+    active: T;
+
+    /**
+     * The value to apply to the focus state.
+     */
+    focus: T;
+}
+
+/**
+ * A set of tokens to use for an interactive element's states.
+ *
+ * @public
+ */
+export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>> {}
+
+/**
+ * A style definition, where the key is the css property and the value is the token.
+ *
+ * @public
+ */
+export type Styles = Record<string, CSSDesignToken<any> | InteractiveTokenSet<any> | string>;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -2,10 +2,10 @@ import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import type { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveAnchor } from "./anchor.js";
-import { aestheticStyles, templateStyles } from "./anchor.styles.js";
+import { aestheticStyles, moduleStyles, templateStyles } from "./anchor.styles.js";
 import { template } from "./anchor.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const styles = [componentBaseStyles, templateStyles, aestheticStyles, ...moduleStyles];
 
 export function composeAnchor(
     ds: DesignSystem,

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -3,14 +3,15 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillSubtleActive,
-    neutralFillSubtleHover,
-    neutralFillSubtleRest,
+    neutralFillControlStyles,
     neutralForegroundRest,
     strokeWidth,
+    stylesToElementStyles,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
-import { css, ElementStyles } from "@microsoft/fast-element";
+import type { StyleModuleEvaluateParameters } from "@adaptive-web/adaptive-ui";
+import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
 
 /**
@@ -49,7 +50,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
         ${typeRampBase}
     }
 
@@ -57,8 +57,7 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         gap: 10px;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
-        border-radius: inherit;
-        background-color: ${neutralFillSubtleRest};
+        border-radius: calc(${controlCornerRadius} * 1px);
         color: ${neutralForegroundRest};
         fill: currentcolor;
     }
@@ -68,15 +67,18 @@ export const aestheticStyles: ElementStyles = css`
         line-height: 0;
     }
 
-    :host([href]:hover) .control {
-        background-color: ${neutralFillSubtleHover};
-    }
-
-    :host([href]:active) .control {
-        background-color: ${neutralFillSubtleActive};
-    }
-
     .control:focus-visible {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }
 `;
+
+const moduleParams: StyleModuleEvaluateParameters = {
+    part: "control",
+    interactivitySelector: "[href]",
+    nonInteractivitySelector: ":not([href])",
+};
+
+/**
+ * Visual styles composed by modules.
+ */
+export const moduleStyles = stylesToElementStyles(neutralFillControlStyles, moduleParams);

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -5,8 +5,8 @@ import {
     focusStrokeWidth,
     neutralFillControlStyles,
     neutralForegroundRest,
+    renderElementStyles,
     strokeWidth,
-    stylesToElementStyles,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import type { StyleModuleEvaluateParameters } from "@adaptive-web/adaptive-ui";
@@ -80,5 +80,7 @@ const moduleParams: StyleModuleEvaluateParameters = {
 
 /**
  * Visual styles composed by modules.
+ * 
+ * @internal
  */
-export const moduleStyles = stylesToElementStyles(neutralFillControlStyles, moduleParams);
+export const moduleStyles = renderElementStyles(neutralFillControlStyles, moduleParams);


### PR DESCRIPTION
# Pull Request

## Description

This PR adds style modules, which consists of:
- Packaging color design tokens as sets and style modules
- Adding support for rendering style modules as ElementStyles
- Updating Adaptive UI Explorer to use style modules
- Updating Anchor to illustrate initial migration for components

This is based on #30 and represents the `style module` -> `component` relationship. It excludes the W3C token format parsing.

## Reviewer Notes

I'm particularly looking for clarity around the model and naming. I'll add docs and diagrams to support this, but:
- A "style module" is a reusable set of design decisions, illustrated so far as color sets like background, border, and foreground.
- A "renderer" is something that can turn a "style module" into rendered output. So far the only option is `ElementStyles`, but there could be one based on the css object model as well, or plain style sheets that could be applied for non-FASTElement elements.

## Test Plan

I verified both the Adaptive UI Explorer and the components in Storybook functioned and looked correct.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

I believe this is in a viable and usable state on the evolution path of Adaptive UI. Also publishing to further inform the conversation on [evolving design tokens](https://github.com/microsoft/fast/issues/6678).

Further next steps are to add support for other tokens aside from color.