### PR TITLE
Updated more color tokens and modules

### DIFF
--- a/change/@adaptive-web-adaptive-ui-4e972827-718f-45be-b101-e9d54bf6899b.json
+++ b/change/@adaptive-web-adaptive-ui-4e972827-718f-45be-b101-e9d54bf6899b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated more color tokens and modules - Renamed remaining \"foreground\" tokens - Added support for derived foreground recipes over a background - Minor recipe tweaks",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -7,7 +7,6 @@ import {
     layerFillFixedMinus1,
     layerFillFixedMinus2,
     layerFillFixedMinus3,
-    layerFillFixedMinus4,
     layerFillFixedPlus1,
     neutralBaseColor,
     neutralPalette,
@@ -251,7 +250,6 @@ export class App extends FASTElement implements AppAttributes {
         [layerFillFixedMinus1, "-1"],
         [layerFillFixedMinus2, "-2"],
         [layerFillFixedMinus3, "-3"],
-        [layerFillFixedMinus4, "-4"],
     ];
 
     private resolveLayerRecipes = (luminance: number): SwatchInfo[] => {

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -3,10 +3,11 @@ import {
     accentForegroundReadableStyles,
     fillColor,
     neutralFillControlStyles,
+    neutralFillPerceivableControlStyles,
     neutralForegroundReadableStyles,
     neutralForegroundStrongStyles,
     neutralOutlineControlStyles,
-    neutralPerceivableControlStyles,
+    neutralOutlinePerceivableControlStyles,
     neutralStealthControlStyles,
     neutralStrokeReadableRest,
     neutralStrokeSubtleRest,
@@ -65,8 +66,12 @@ const formComponents = html<ColorBlock>`
         Text field
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralPerceivableControlStyles}">
-        Checkbox
+    <app-style-example :styles="${x => neutralOutlinePerceivableControlStyles}">
+        Checkbox (unchecked)
+    </app-style-example>
+
+    <app-style-example :styles="${x => neutralFillPerceivableControlStyles}">
+        Checkbox (checked)
     </app-style-example>
 
     <app-style-example :styles="${{"color": neutralStrokeSubtleRest}}">

--- a/packages/adaptive-ui-explorer/src/components/swatch.ts
+++ b/packages/adaptive-ui-explorer/src/components/swatch.ts
@@ -24,7 +24,7 @@ function template<T extends AppSwatch>(): ElementViewTemplate<T> {
             style="${x => x.iconStyle}"
             title="${x => x.contrastMessage}"
         ></div>
-        <code class="recipe-name">${x => x.recipeName}</code>
+        <code class="recipe-name" title="${x => x.recipeName}">${x => x.recipeName}</code>
         <code class="hex-code">${x => x.colorValue}</code>
     `;
 }
@@ -63,6 +63,11 @@ const styles = css`
     .recipe-name {
         grid-column: 2;
         grid-row: 1;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        width: 100%;
+        text-align: start;
     }
 
     .hex-code {

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -39,9 +39,6 @@ export const accentFillHover: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const accentFillHoverDelta: DesignToken<number>;
 
-// @public @deprecated (undocumented)
-export const accentFillMinContrast: DesignToken<number>;
-
 // @public (undocumented)
 export const accentFillReadableActive: CSSDesignToken<Swatch>;
 
@@ -64,9 +61,6 @@ export const accentFillReadableHoverDelta: DesignToken<number>;
 export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public (undocumented)
-export const accentFillReadableMinContrast: DesignToken<number>;
-
-// @public (undocumented)
 export const accentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -84,44 +78,68 @@ export const accentFillRest: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const accentFillRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundFocusDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundHoverDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const accentForegroundInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
-export const accentForegroundMinContrast: DesignToken<number>;
 
 // @public
 export const accentForegroundReadableStyles: Styles;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentForegroundRestDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const accentPalette: DesignToken<Palette<Swatch>>;
+
+// @public (undocumented)
+export const accentStrokeReadableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentStrokeReadableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentStrokeReadableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeReadableRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableRestDelta: DesignToken<number>;
 
 // @public
 export class BasePalette<T extends Swatch> implements Palette<T> {
@@ -266,22 +284,37 @@ export const focusStrokeWidth: CSSDesignToken<number>;
 // @public (undocumented)
 export const fontWeight: CSSDesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentActive: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
+export const foregroundOnAccentFillReadableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const foregroundOnAccentFillReadableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const foregroundOnAccentFillReadableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const foregroundOnAccentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const foregroundOnAccentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const foregroundOnAccentFillReadableRest: CSSDesignToken<Swatch>;
+
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
-export const foregroundOnAccentInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentRest: CSSDesignToken<Swatch>;
 
 // @public
@@ -467,6 +500,9 @@ export const neutralFillPerceivableActive: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralFillPerceivableActiveDelta: DesignToken<number>;
 
+// @public
+export const neutralFillPerceivableControlStyles: Styles;
+
 // @public (undocumented)
 export const neutralFillPerceivableFocus: CSSDesignToken<Swatch>;
 
@@ -481,9 +517,6 @@ export const neutralFillPerceivableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableMinContrast: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralFillPerceivableRecipe: DesignToken<InteractiveColorRecipe>;
@@ -579,9 +612,6 @@ export const neutralFillStrongHover: CSSDesignToken<Swatch>;
 export const neutralFillStrongHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongMinContrast: DesignToken<number>;
-
-// @public @deprecated (undocumented)
 export const neutralFillStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
@@ -620,46 +650,43 @@ export const neutralFillSubtleRest: CSSDesignToken<Swatch>;
 // @public (undocumented)
 export const neutralFillSubtleRestDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundActiveDelta: DesignToken<number>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundHint: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundHintRecipe: DesignToken<ColorRecipe<Swatch>>;
+export const neutralForegroundHintRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundHoverDelta: DesignToken<number>;
 
-// @public (undocumented)
-export const neutralForegroundInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundMinContrast: DesignToken<number>;
 
 // @public
 export const neutralForegroundReadableStyles: Styles;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralForegroundRestDelta: DesignToken<number>;
 
 // @public
@@ -668,11 +695,11 @@ export const neutralForegroundStrongStyles: Styles;
 // @public
 export const neutralOutlineControlStyles: Styles;
 
+// @public
+export const neutralOutlinePerceivableControlStyles: Styles;
+
 // @public (undocumented)
 export const neutralPalette: DesignToken<Palette<Swatch>>;
-
-// @public
-export const neutralPerceivableControlStyles: Styles;
 
 // @public
 export const neutralStealthControlStyles: Styles;
@@ -753,9 +780,6 @@ export const neutralStrokePerceivableHoverDelta: DesignToken<number>;
 export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokePerceivableMinContrast: DesignToken<number>;
-
-// @public (undocumented)
 export const neutralStrokePerceivableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
@@ -765,10 +789,31 @@ export const neutralStrokePerceivableRest: CSSDesignToken<Swatch>;
 export const neutralStrokePerceivableRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableRecipe: DesignToken<ColorRecipe<Swatch>>;
+export const neutralStrokeReadableActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeReadableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeReadableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeReadableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeReadableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
 export const neutralStrokeReadableRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeReadableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeRecipe: DesignToken<InteractiveColorRecipe>;
@@ -779,34 +824,37 @@ export const neutralStrokeRest: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const neutralStrokeRestDelta: DesignToken<number>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongActiveDelta: DesignToken<number>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongFocus: CSSDesignToken<Swatch>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongFocusDelta: DesignToken<number>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongHover: CSSDesignToken<Swatch>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongHoverDelta: DesignToken<number>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
+export const neutralStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
 export const neutralStrokeStrongMinContrast: DesignToken<number>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongRest: CSSDesignToken<Swatch>;
 
-// @public @deprecated (undocumented)
+// @public (undocumented)
 export const neutralStrokeStrongRestDelta: DesignToken<number>;
 
 // @public (undocumented)

--- a/packages/adaptive-ui/src/design-tokens/README.md
+++ b/packages/adaptive-ui/src/design-tokens/README.md
@@ -14,15 +14,15 @@ Most color tokens come as an interactive set for rest, hover, active, and focus 
 
 Color tokens are named for semantic use cases:
 
+#### Safety
+
+A special use case that can be thought of as a placeholder for increased contrast scenarios. Primarily intended for a stroke that's transparent until someone prefers increased contrast.
+
 #### Stealth
 
 Has no color at rest, typically a subtle color on hover or active.
 
 Has no accessibility configuration relative to its context.
-
-#### Safety
-
-A special use case that can be thought of as a placeholder for increased contrast scenarios. Primarily intended for a stroke that's transparent until someone prefers increased contrast.
 
 #### Subtle
 
@@ -54,7 +54,7 @@ Color tokens based on the above usage behaviors are split by intended applicatio
 
 Fills are intended to cover large areas. Because of the large coverage area, it takes less of a change for hover or active state to notice.
 
-#### Stroke (and temporarily Foreground)
+#### Stroke
 
 Strokes are intended for lines, icons, or text. Because of the smaller coverage area, it takes more of a change for hover or active states to notice.
 
@@ -65,16 +65,12 @@ The combinations of recipes currently implemented:
 |                    | Safety | Stealth | Subtle | Perceivable (3:1) | Readable (4.5:1) | Strong |
 | ------------------ | ------ | ------- | ------ | ----------------- | ---------------- | ------ |
 | Neutral fill       | -      | ✓       | ✓      | ✓                | o                | -      |
-| Neutral stroke     | o      | o       | ✓      | ✓                | *                | *      |
-| Neutral foreground | -      | -       | -      | -                 | ✓ *              | ✓ *    |
+| Neutral stroke     | o      | o       | ✓      | ✓                | ✓                | ✓      |
 | Accent fill        | -      | o       | o      | o                 | ✓                | -      |
-| Accent stroke      | o      | o       | o      | o                 | *                | -      |
-| Accent foreground  | -      | -       | -      | -                 | ✓ *              | -      |
+| Accent stroke      | o      | o       | o      | o                 | ✓                | -      |
 
 ✓ = implemented
 
 o = coming soon
 
 \- = not applicable
-
-\* "Foreground" recipes will be migrating to "Stroke"

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -4,7 +4,6 @@ import { blackOrWhiteByContrast, interactiveSwatchSetAsOverlay, swatchAsOverlay 
 import { ColorRecipe, InteractiveColorRecipe, InteractiveSwatchSet } from "../color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../color/recipes/black-or-white-by-contrast-set.js";
 import { contrastAndDeltaSwatchSet } from "../color/recipes/contrast-and-delta-swatch-set.js";
-import { contrastSwatch } from "../color/recipes/contrast-swatch.js";
 import { deltaSwatchSet } from "../color/recipes/delta-swatch-set.js";
 import { deltaSwatch } from "../color/recipes/delta-swatch.js";
 import { Swatch } from "../color/swatch.js";
@@ -112,9 +111,6 @@ export const neutralAsOverlay = createNonCss<boolean>("neutral-as-overlay").with
 const accentFillReadableName = "accent-fill-readable";
 
 /** @public */
-export const accentFillReadableMinContrast = createMinContrast(accentFillReadableName, minContrastReadable);
-
-/** @public */
 export const accentFillReadableRestDelta = createDelta(accentFillReadableName, "rest", 0);
 
 /** @public */
@@ -132,7 +128,7 @@ export const accentFillReadableRecipe = createRecipeInteractive(accentFillReadab
         contrastAndDeltaSwatchSet(
             resolve(accentPalette),
             reference || resolve(fillColor),
-            resolve(accentFillReadableMinContrast),
+            resolve(minContrastReadable),
             resolve(accentFillReadableRestDelta),
             resolve(accentFillReadableHoverDelta),
             resolve(accentFillReadableActiveDelta),
@@ -154,42 +150,12 @@ export const accentFillReadableActive = createStateToken(accentFillReadableSet, 
 /** @public */
 export const accentFillReadableFocus = createStateToken(accentFillReadableSet, "focus");
 
-/** @public @deprecated use "Readable" instead */
-export const accentFillMinContrast = accentFillReadableMinContrast;
+// Foreground On Accent Fill Readable (previously just "Foreground On Accent")
 
-/** @public @deprecated use "Readable" instead */
-export const accentFillRestDelta = accentFillReadableRestDelta;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillHoverDelta = accentFillReadableHoverDelta;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillActiveDelta = accentFillReadableActiveDelta;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillFocusDelta = accentFillReadableFocusDelta;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillRecipe = accentFillReadableRecipe;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillRest = accentFillReadableRest;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillHover = accentFillReadableHover;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillActive = accentFillReadableActive;
-
-/** @public @deprecated use "Readable" instead */
-export const accentFillFocus = accentFillReadableFocus;
-
-// Foreground On Accent
-
-const foregroundOnAccentName = "foreground-on-accent";
+const foregroundOnAccentFillReadableName = "foreground-on-accent-fill-readable";
 
 /** @public */
-export const foregroundOnAccentRecipe = createRecipeInteractive(foregroundOnAccentName,
+export const foregroundOnAccentFillReadableRecipe = createRecipeInteractive(foregroundOnAccentFillReadableName,
     (resolve: DesignTokenResolver): InteractiveSwatchSet =>
         blackOrWhiteByContrastSet(
             resolve(accentFillReadableRest),
@@ -201,144 +167,162 @@ export const foregroundOnAccentRecipe = createRecipeInteractive(foregroundOnAcce
         )
 );
 
-const foregroundOnAccentSet = createSet(foregroundOnAccentRecipe);
+const foregroundOnAccentFillReadableSet = createSet(foregroundOnAccentFillReadableRecipe);
 
 /** @public */
-export const foregroundOnAccentRest = createStateToken(foregroundOnAccentSet, "rest");
+export const foregroundOnAccentFillReadableRest = createStateToken(foregroundOnAccentFillReadableSet, "rest");
 
 /** @public */
-export const foregroundOnAccentHover = createStateToken(foregroundOnAccentSet, "hover");
+export const foregroundOnAccentFillReadableHover = createStateToken(foregroundOnAccentFillReadableSet, "hover");
 
 /** @public */
-export const foregroundOnAccentActive = createStateToken(foregroundOnAccentSet, "active");
+export const foregroundOnAccentFillReadableActive = createStateToken(foregroundOnAccentFillReadableSet, "active");
 
 /** @public */
-export const foregroundOnAccentFocus = createStateToken(foregroundOnAccentSet, "focus");
+export const foregroundOnAccentFillReadableFocus = createStateToken(foregroundOnAccentFillReadableSet, "focus");
 
-// Accent Foreground
+// Accent Stroke Readable (previously "Foreground")
 
-const accentForegroundName = "accent-foreground";
-
-/** @public */
-export const accentForegroundMinContrast = createMinContrast(accentForegroundName, minContrastReadable);
+const accentStrokeReadableName = "accent-stroke-readable";
 
 /** @public */
-export const accentForegroundRestDelta = createDelta(accentForegroundName, "rest", 0);
+export const accentStrokeReadableRestDelta = createDelta(accentStrokeReadableName, "rest", 0);
 
 /** @public */
-export const accentForegroundHoverDelta = createDelta(accentForegroundName, "hover", 3);
+export const accentStrokeReadableHoverDelta = createDelta(accentStrokeReadableName, "hover", 6);
 
 /** @public */
-export const accentForegroundActiveDelta = createDelta(accentForegroundName, "active", -8);
+export const accentStrokeReadableActiveDelta = createDelta(accentStrokeReadableName, "active", -8);
 
 /** @public */
-export const accentForegroundFocusDelta = createDelta(accentForegroundName, "focus", 0);
+export const accentStrokeReadableFocusDelta = createDelta(accentStrokeReadableName, "focus", 0);
 
 /** @public */
-export const accentForegroundRecipe = createRecipeInteractive(accentForegroundName,
+export const accentStrokeReadableRecipe = createRecipeInteractive(accentStrokeReadableName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         contrastAndDeltaSwatchSet(
             resolve(accentPalette),
             reference || resolve(fillColor),
-            resolve(accentForegroundMinContrast),
-            resolve(accentForegroundRestDelta),
-            resolve(accentForegroundHoverDelta),
-            resolve(accentForegroundActiveDelta),
-            resolve(accentForegroundFocusDelta)
+            resolve(minContrastReadable),
+            resolve(accentStrokeReadableRestDelta),
+            resolve(accentStrokeReadableHoverDelta),
+            resolve(accentStrokeReadableActiveDelta),
+            resolve(accentStrokeReadableFocusDelta)
         )
 );
 
-const accentForegroundSet = createSet(accentForegroundRecipe);
+const accentStrokeReadableSet = createSet(accentStrokeReadableRecipe);
 
 /** @public */
-export const accentForegroundRest = createStateToken(accentForegroundSet, "rest");
+export const accentStrokeReadableRest = createStateToken(accentStrokeReadableSet, "rest");
 
 /** @public */
-export const accentForegroundHover = createStateToken(accentForegroundSet, "hover");
+export const accentStrokeReadableHover = createStateToken(accentStrokeReadableSet, "hover");
 
 /** @public */
-export const accentForegroundActive = createStateToken(accentForegroundSet, "active");
+export const accentStrokeReadableActive = createStateToken(accentStrokeReadableSet, "active");
 
 /** @public */
-export const accentForegroundFocus = createStateToken(accentForegroundSet, "focus");
+export const accentStrokeReadableFocus = createStateToken(accentStrokeReadableSet, "focus");
 
-// Neutral Foreground
+// Neutral Stroke Strong (previously "Foreground")
 
-const neutralForegroundName = "neutral-foreground";
-
-/** @public */
-export const neutralForegroundMinContrast = createMinContrast(neutralForegroundName, 16);
+const neutralStrokeStrongName = "neutral-stroke-strong";
 
 /** @public */
-export const neutralForegroundRestDelta = createDelta(neutralForegroundName, "rest", 0);
+export const neutralStrokeStrongMinContrast = createMinContrast(neutralStrokeStrongName, 12);
 
 /** @public */
-export const neutralForegroundHoverDelta = createDelta(neutralForegroundName, "hover", -19);
+export const neutralStrokeStrongRestDelta = createDelta(neutralStrokeStrongName, "rest", 0);
 
 /** @public */
-export const neutralForegroundActiveDelta = createDelta(neutralForegroundName, "active", -30);
+export const neutralStrokeStrongHoverDelta = createDelta(neutralStrokeStrongName, "hover", 10);
 
 /** @public */
-export const neutralForegroundFocusDelta = createDelta(neutralForegroundName, "focus", 0);
+export const neutralStrokeStrongActiveDelta = createDelta(neutralStrokeStrongName, "active", -10);
 
 /** @public */
-export const neutralForegroundRecipe = createRecipeInteractive(neutralForegroundName,
+export const neutralStrokeStrongFocusDelta = createDelta(neutralStrokeStrongName, "focus", 0);
+
+/** @public */
+export const neutralStrokeStrongRecipe = createRecipeInteractive(neutralStrokeStrongName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(neutralForegroundMinContrast),
-                resolve(neutralForegroundRestDelta),
-                resolve(neutralForegroundHoverDelta),
-                resolve(neutralForegroundActiveDelta),
-                resolve(neutralForegroundFocusDelta)
+                resolve(neutralStrokeStrongMinContrast),
+                resolve(neutralStrokeStrongRestDelta),
+                resolve(neutralStrokeStrongHoverDelta),
+                resolve(neutralStrokeStrongActiveDelta),
+                resolve(neutralStrokeStrongFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralForegroundSet = createSet(neutralForegroundRecipe);
+const neutralStrokeStrongSet = createSet(neutralStrokeStrongRecipe);
 
 /** @public */
-export const neutralForegroundRest = createStateToken(neutralForegroundSet, "rest");
+export const neutralStrokeStrongRest = createStateToken(neutralStrokeStrongSet, "rest");
 
 /** @public */
-export const neutralForegroundHover = createStateToken(neutralForegroundSet, "hover");
+export const neutralStrokeStrongHover = createStateToken(neutralStrokeStrongSet, "hover");
 
 /** @public */
-export const neutralForegroundActive = createStateToken(neutralForegroundSet, "active");
+export const neutralStrokeStrongActive = createStateToken(neutralStrokeStrongSet, "active");
 
 /** @public */
-export const neutralForegroundFocus = createStateToken(neutralForegroundSet, "focus");
+export const neutralStrokeStrongFocus = createStateToken(neutralStrokeStrongSet, "focus");
 
 // Neutral Stroke Readable (previously "Foreground Hint")
 
 const neutralStrokeReadableName = "neutral-stroke-readable";
 
 /** @public */
-export const neutralStrokeReadableRecipe = createRecipe(neutralStrokeReadableName,
-    (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
-        swatchAsOverlay(
-            contrastSwatch(
+export const neutralStrokeReadableRestDelta = createDelta(neutralStrokeReadableName, "rest", 0);
+
+/** @public */
+export const neutralStrokeReadableHoverDelta = createDelta(neutralStrokeReadableName, "hover", 8);
+
+/** @public */
+export const neutralStrokeReadableActiveDelta = createDelta(neutralStrokeReadableName, "active", -4);
+
+/** @public */
+export const neutralStrokeReadableFocusDelta = createDelta(neutralStrokeReadableName, "focus", 0);
+
+/** @public */
+export const neutralStrokeReadableRecipe = createRecipeInteractive(neutralStrokeReadableName,
+    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(minContrastReadable)
+                resolve(minContrastReadable),
+                resolve(neutralStrokeReadableRestDelta),
+                resolve(neutralStrokeReadableHoverDelta),
+                resolve(neutralStrokeReadableActiveDelta),
+                resolve(neutralStrokeReadableFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
+const neutralStrokeReadableSet = createSet(neutralStrokeReadableRecipe);
+
 /** @public */
-export const neutralStrokeReadableRest = createRecipeToken(neutralStrokeReadableRecipe)
+export const neutralStrokeReadableRest = createStateToken(neutralStrokeReadableSet, "rest")
 
-/** @public @deprecated Use "Stroke Readable" instead */
-export const neutralForegroundHintRecipe = neutralStrokeReadableRecipe;
+/** @public */
+export const neutralStrokeReadableHover = createStateToken(neutralStrokeReadableSet, "rest")
 
-/** @public @deprecated Use "Stroke Readable" instead */
-export const neutralForegroundHint = neutralStrokeReadableRest;
+/** @public */
+export const neutralStrokeReadableActive = createStateToken(neutralStrokeReadableSet, "rest")
+
+/** @public */
+export const neutralStrokeReadableFocus = createStateToken(neutralStrokeReadableSet, "rest")
 
 // Neutral Fill Subtle (previously just "Neutral Fill")
 
@@ -354,7 +338,7 @@ export const neutralFillSubtleHoverDelta = createDelta(neutralFillSubtleName, "h
 export const neutralFillSubtleActiveDelta = createDelta(neutralFillSubtleName, "active", 0);
 
 /** @public */
-export const neutralFillSubtleFocusDelta = createDelta(neutralFillSubtleName, "focus", 0);
+export const neutralFillSubtleFocusDelta = createDelta(neutralFillSubtleName, "focus", 2);
 
 /** @public */
 export const neutralFillSubtleRecipe = createRecipeInteractive(neutralFillSubtleName,
@@ -386,6 +370,329 @@ export const neutralFillSubtleActive = createStateToken(neutralFillSubtleSet, "a
 
 /** @public */
 export const neutralFillSubtleFocus = createStateToken(neutralFillSubtleSet, "focus");
+
+// Neutral Fill Stealth
+
+const neutralFillStealthName = "neutral-fill-stealth";
+
+/** @public */
+export const neutralFillStealthRestDelta = createDelta(neutralFillStealthName, "rest", 0);
+
+/** @public */
+export const neutralFillStealthHoverDelta = createDelta(neutralFillStealthName, "hover", 3);
+
+/** @public */
+export const neutralFillStealthActiveDelta = createDelta(neutralFillStealthName, "active", 2);
+
+/** @public */
+export const neutralFillStealthFocusDelta = createDelta(neutralFillStealthName, "focus", 0);
+
+/** @public */
+export const neutralFillStealthRecipe = createRecipeInteractive(neutralFillStealthName,
+    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillStealthRestDelta),
+                resolve(neutralFillStealthHoverDelta),
+                resolve(neutralFillStealthActiveDelta),
+                resolve(neutralFillStealthFocusDelta)
+            ),
+            reference || resolve(fillColor),
+            resolve(neutralAsOverlay)
+        )
+);
+
+const neutralFillStealthSet = createSet(neutralFillStealthRecipe);
+
+/** @public */
+export const neutralFillStealthRest = createStateToken(neutralFillStealthSet, "rest");
+
+/** @public */
+export const neutralFillStealthHover = createStateToken(neutralFillStealthSet, "hover");
+
+/** @public */
+export const neutralFillStealthActive = createStateToken(neutralFillStealthSet, "active");
+
+/** @public */
+export const neutralFillStealthFocus = createStateToken(neutralFillStealthSet, "focus");
+
+// Neutral Fill Perceivable (previously "Strong")
+
+const neutralFillPerceivableName = "neutral-fill-perceivable";
+
+/** @public */
+export const neutralFillPerceivableRestDelta = createDelta(neutralFillPerceivableName, "rest", 0);
+
+/** @public */
+export const neutralFillPerceivableHoverDelta = createDelta(neutralFillPerceivableName, "hover", 8);
+
+/** @public */
+export const neutralFillPerceivableActiveDelta = createDelta(neutralFillPerceivableName, "active", -5);
+
+/** @public */
+export const neutralFillPerceivableFocusDelta = createDelta(neutralFillPerceivableName, "focus", 0);
+
+/** @public */
+export const neutralFillPerceivableRecipe = createRecipeInteractive(neutralFillPerceivableName,
+    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(minContrastPerceivable),
+                resolve(neutralFillPerceivableRestDelta),
+                resolve(neutralFillPerceivableHoverDelta),
+                resolve(neutralFillPerceivableActiveDelta),
+                resolve(neutralFillPerceivableFocusDelta)
+            ),
+            reference || resolve(fillColor),
+            resolve(neutralAsOverlay)
+        )
+);
+
+const neutralFillPerceivableSet = createSet(neutralFillPerceivableRecipe);
+
+/** @public */
+export const neutralFillPerceivableRest = createStateToken(neutralFillPerceivableSet, "rest");
+
+/** @public */
+export const neutralFillPerceivableHover = createStateToken(neutralFillPerceivableSet, "hover");
+
+/** @public */
+export const neutralFillPerceivableActive = createStateToken(neutralFillPerceivableSet, "active");
+
+/** @public */
+export const neutralFillPerceivableFocus = createStateToken(neutralFillPerceivableSet, "focus");
+
+// Neutral Stroke Subtle (previously just "Neutral Stroke")
+
+const neutralStrokeSubtleName = "neutral-stroke-subtle";
+
+/** @public */
+export const neutralStrokeSubtleRestDelta = createDelta(neutralStrokeSubtleName, "rest", 8);
+
+/** @public */
+export const neutralStrokeSubtleHoverDelta = createDelta(neutralStrokeSubtleName, "hover", 12);
+
+/** @public */
+export const neutralStrokeSubtleActiveDelta = createDelta(neutralStrokeSubtleName, "active", 6);
+
+/** @public */
+export const neutralStrokeSubtleFocusDelta = createDelta(neutralStrokeSubtleName, "focus", 8);
+
+/** @public */
+export const neutralStrokeSubtleRecipe = createRecipeInteractive(neutralStrokeSubtleName,
+    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralStrokeSubtleRestDelta),
+                resolve(neutralStrokeSubtleHoverDelta),
+                resolve(neutralStrokeSubtleActiveDelta),
+                resolve(neutralStrokeSubtleFocusDelta)
+            ),
+            reference || resolve(fillColor),
+            resolve(neutralAsOverlay)
+        )
+);
+
+const neutralStrokeSubtleSet = createSet(neutralStrokeSubtleRecipe);
+
+/** @public */
+export const neutralStrokeSubtleRest = createStateToken(neutralStrokeSubtleSet, "rest");
+
+/** @public */
+export const neutralStrokeSubtleHover = createStateToken(neutralStrokeSubtleSet, "hover");
+
+/** @public */
+export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet, "active");
+
+/** @public */
+export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus");
+
+// Neutral Stroke Perceivable (previously "Strong")
+
+const neutralStrokePerceivableName = "neutral-stroke-perceivable";
+
+/** @public */
+export const neutralStrokePerceivableRestDelta = createDelta(neutralStrokePerceivableName, "rest", 0);
+
+/** @public */
+export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 8);
+
+/** @public */
+export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", -4);
+
+/** @public */
+export const neutralStrokePerceivableFocusDelta = createDelta(neutralStrokePerceivableName, "focus", 0);
+
+/** @public */
+export const neutralStrokePerceivableRecipe = createRecipeInteractive(neutralStrokePerceivableName,
+    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(minContrastPerceivable),
+                resolve(neutralStrokePerceivableRestDelta),
+                resolve(neutralStrokePerceivableHoverDelta),
+                resolve(neutralStrokePerceivableActiveDelta),
+                resolve(neutralStrokePerceivableFocusDelta)
+            ),
+            reference || resolve(fillColor),
+            resolve(neutralAsOverlay)
+        )
+);
+
+const neutralStrokePerceivableSet = createSet(neutralStrokePerceivableRecipe);
+
+/** @public */
+export const neutralStrokePerceivableRest = createStateToken(neutralStrokePerceivableSet, "rest");
+
+/** @public */
+export const neutralStrokePerceivableHover = createStateToken(neutralStrokePerceivableSet, "hover");
+
+/** @public */
+export const neutralStrokePerceivableActive = createStateToken(neutralStrokePerceivableSet, "active");
+
+/** @public */
+export const neutralStrokePerceivableFocus = createStateToken(neutralStrokePerceivableSet, "focus");
+
+// Focus Stroke Outer
+
+const focusStrokeOuterName = "focus-stroke-outer";
+
+/** @public */
+export const focusStrokeOuterRecipe = createRecipe(focusStrokeOuterName,
+    (resolve: DesignTokenResolver): Swatch =>
+        blackOrWhiteByContrast(resolve(fillColor), resolve(minContrastReadable), true)
+);
+
+/** @public */
+export const focusStrokeOuter = createRecipeToken(focusStrokeOuterRecipe);
+
+// Focus Stroke Inner
+
+const focusStrokeInnerName = "focus-stroke-inner";
+
+/** @public */
+export const focusStrokeInnerRecipe = createRecipe(focusStrokeInnerName,
+    (resolve: DesignTokenResolver): Swatch =>
+        blackOrWhiteByContrast(resolve(focusStrokeOuter), resolve(minContrastReadable), false)
+);
+
+/** @public */
+export const focusStrokeInner = createRecipeToken(focusStrokeInnerRecipe);
+
+// Deprecated tokens
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRestDelta = accentFillReadableRestDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillHoverDelta = accentFillReadableHoverDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillActiveDelta = accentFillReadableActiveDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillFocusDelta = accentFillReadableFocusDelta;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRecipe = accentFillReadableRecipe;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillRest = accentFillReadableRest;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillHover = accentFillReadableHover;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillActive = accentFillReadableActive;
+
+/** @public @deprecated use "Readable" instead */
+export const accentFillFocus = accentFillReadableFocus;
+
+/** @public @deprecated use "foregroundOnAccentFillReadable" instead */
+export const foregroundOnAccentRecipe = foregroundOnAccentFillReadableRecipe;
+
+/** @public @deprecated use "foregroundOnAccentFillReadable" instead */
+export const foregroundOnAccentRest = foregroundOnAccentFillReadableRest;
+
+/** @public @deprecated use "foregroundOnAccentFillReadable" instead */
+export const foregroundOnAccentHover = foregroundOnAccentFillReadableHover;
+
+/** @public @deprecated use "foregroundOnAccentFillReadable" instead */
+export const foregroundOnAccentActive = foregroundOnAccentFillReadableActive;
+
+/** @public @deprecated use "foregroundOnAccentFillReadable" instead */
+export const foregroundOnAccentFocus = foregroundOnAccentFillReadableFocus;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundRestDelta = accentStrokeReadableRestDelta;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundHoverDelta = accentStrokeReadableHoverDelta;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundActiveDelta = accentStrokeReadableActiveDelta;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundFocusDelta = accentStrokeReadableFocusDelta;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundRecipe = accentStrokeReadableRecipe;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundRest = accentStrokeReadableRest;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundHover = accentStrokeReadableHover;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundActive = accentStrokeReadableActive;
+
+/** @public @deprecated use "Stroke Readable" instead */
+export const accentForegroundFocus = accentStrokeReadableFocus;
+
+/** @public @deprecated Use "Stroke Readable" instead */
+export const neutralForegroundHintRecipe = neutralStrokeReadableRecipe;
+
+/** @public @deprecated Use "Stroke Readable" instead */
+export const neutralForegroundHint = neutralStrokeReadableRest;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundMinContrast = neutralStrokeStrongMinContrast;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundRestDelta = neutralStrokeStrongRestDelta;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundHoverDelta = neutralStrokeStrongHoverDelta;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundActiveDelta = neutralStrokeStrongActiveDelta;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundFocusDelta = neutralStrokeStrongFocusDelta;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundRecipe = neutralStrokeStrongRecipe;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundRest = neutralStrokeStrongRest;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundHover = neutralStrokeStrongHover;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundActive = neutralStrokeStrongActive;
+
+/** @public @deprecated Use "Stroke Strong" instead */
+export const neutralForegroundFocus = neutralStrokeStrongFocus;
 
 /** @public @deprecated use "Subtle" instead */
 export const neutralFillRestDelta = neutralFillSubtleRestDelta;
@@ -510,107 +817,6 @@ export const neutralFillSecondaryActive = createStateToken(neutralFillSecondaryS
 /** @public @deprecated Use "Subtle" or "Perceivable" instead */
 export const neutralFillSecondaryFocus = createStateToken(neutralFillSecondarySet, "focus");
 
-// Neutral Fill Stealth
-
-const neutralFillStealthName = "neutral-fill-stealth";
-
-/** @public */
-export const neutralFillStealthRestDelta = createDelta(neutralFillStealthName, "rest", 0);
-
-/** @public */
-export const neutralFillStealthHoverDelta = createDelta(neutralFillStealthName, "hover", 3);
-
-/** @public */
-export const neutralFillStealthActiveDelta = createDelta(neutralFillStealthName, "active", 2);
-
-/** @public */
-export const neutralFillStealthFocusDelta = createDelta(neutralFillStealthName, "focus", 0);
-
-/** @public */
-export const neutralFillStealthRecipe = createRecipeInteractive(neutralFillStealthName,
-    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        interactiveSwatchSetAsOverlay(
-            deltaSwatchSet(
-                resolve(neutralPalette),
-                reference || resolve(fillColor),
-                resolve(neutralFillStealthRestDelta),
-                resolve(neutralFillStealthHoverDelta),
-                resolve(neutralFillStealthActiveDelta),
-                resolve(neutralFillStealthFocusDelta)
-            ),
-            reference || resolve(fillColor),
-            resolve(neutralAsOverlay)
-        )
-);
-
-const neutralFillStealthSet = createSet(neutralFillStealthRecipe);
-
-/** @public */
-export const neutralFillStealthRest = createStateToken(neutralFillStealthSet, "rest");
-
-/** @public */
-export const neutralFillStealthHover = createStateToken(neutralFillStealthSet, "hover");
-
-/** @public */
-export const neutralFillStealthActive = createStateToken(neutralFillStealthSet, "active");
-
-/** @public */
-export const neutralFillStealthFocus = createStateToken(neutralFillStealthSet, "focus");
-
-// Neutral Fill Perceivable (previously "Strong")
-
-const neutralFillPerceivableName = "neutral-fill-perceivable";
-
-/** @public */
-export const neutralFillPerceivableMinContrast = createMinContrast(neutralFillPerceivableName, minContrastPerceivable);
-
-/** @public */
-export const neutralFillPerceivableRestDelta = createDelta(neutralFillPerceivableName, "rest", 0);
-
-/** @public */
-export const neutralFillPerceivableHoverDelta = createDelta(neutralFillPerceivableName, "hover", 8);
-
-/** @public */
-export const neutralFillPerceivableActiveDelta = createDelta(neutralFillPerceivableName, "active", -5);
-
-/** @public */
-export const neutralFillPerceivableFocusDelta = createDelta(neutralFillPerceivableName, "focus", 0);
-
-/** @public */
-export const neutralFillPerceivableRecipe = createRecipeInteractive(neutralFillPerceivableName,
-    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        interactiveSwatchSetAsOverlay(
-            contrastAndDeltaSwatchSet(
-                resolve(neutralPalette),
-                reference || resolve(fillColor),
-                resolve(neutralFillPerceivableMinContrast),
-                resolve(neutralFillPerceivableRestDelta),
-                resolve(neutralFillPerceivableHoverDelta),
-                resolve(neutralFillPerceivableActiveDelta),
-                resolve(neutralFillPerceivableFocusDelta)
-            ),
-            reference || resolve(fillColor),
-            resolve(neutralAsOverlay)
-        )
-);
-
-const neutralFillPerceivableSet = createSet(neutralFillPerceivableRecipe);
-
-/** @public */
-export const neutralFillPerceivableRest = createStateToken(neutralFillPerceivableSet, "rest");
-
-/** @public */
-export const neutralFillPerceivableHover = createStateToken(neutralFillPerceivableSet, "hover");
-
-/** @public */
-export const neutralFillPerceivableActive = createStateToken(neutralFillPerceivableSet, "active");
-
-/** @public */
-export const neutralFillPerceivableFocus = createStateToken(neutralFillPerceivableSet, "focus");
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongMinContrast = neutralFillPerceivableMinContrast;
-
 /** @public @deprecated Use "Perceivable instead of "Strong" */
 export const neutralFillStrongRestDelta = neutralFillPerceivableRestDelta;
 
@@ -637,53 +843,6 @@ export const neutralFillStrongActive = neutralFillPerceivableActive;
 
 /** @public @deprecated Use "Perceivable instead of "Strong" */
 export const neutralFillStrongFocus = neutralFillPerceivableFocus;
-
-// Neutral Stroke Subtle (previously just "Neutral Stroke")
-
-const neutralStrokeSubtleName = "neutral-stroke-subtle";
-
-/** @public */
-export const neutralStrokeSubtleRestDelta = createDelta(neutralStrokeSubtleName, "rest", 8);
-
-/** @public */
-export const neutralStrokeSubtleHoverDelta = createDelta(neutralStrokeSubtleName, "hover", 12);
-
-/** @public */
-export const neutralStrokeSubtleActiveDelta = createDelta(neutralStrokeSubtleName, "active", 6);
-
-/** @public */
-export const neutralStrokeSubtleFocusDelta = createDelta(neutralStrokeSubtleName, "focus", 8);
-
-/** @public */
-export const neutralStrokeSubtleRecipe = createRecipeInteractive(neutralStrokeSubtleName,
-    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        interactiveSwatchSetAsOverlay(
-            deltaSwatchSet(
-                resolve(neutralPalette),
-                reference || resolve(fillColor),
-                resolve(neutralStrokeSubtleRestDelta),
-                resolve(neutralStrokeSubtleHoverDelta),
-                resolve(neutralStrokeSubtleActiveDelta),
-                resolve(neutralStrokeSubtleFocusDelta)
-            ),
-            reference || resolve(fillColor),
-            resolve(neutralAsOverlay)
-        )
-);
-
-const neutralStrokeSubtleSet = createSet(neutralStrokeSubtleRecipe);
-
-/** @public */
-export const neutralStrokeSubtleRest = createStateToken(neutralStrokeSubtleSet, "rest");
-
-/** @public */
-export const neutralStrokeSubtleHover = createStateToken(neutralStrokeSubtleSet, "hover");
-
-/** @public */
-export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet, "active");
-
-/** @public */
-export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus");
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeRestDelta = neutralStrokeSubtleRestDelta;
@@ -783,110 +942,3 @@ export const neutralStrokeInputActive = createStateToken(neutralStrokeInputSet, 
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputFocus = createStateToken(neutralStrokeInputSet, "focus");
-
-// Neutral Stroke Perceivable (previously "Strong")
-
-const neutralStrokePerceivableName = "neutral-stroke-perceivable";
-
-/** @public */
-export const neutralStrokePerceivableMinContrast = createMinContrast(neutralStrokePerceivableName, minContrastPerceivable);
-
-/** @public */
-export const neutralStrokePerceivableRestDelta = createDelta(neutralStrokePerceivableName, "rest", 0);
-
-/** @public */
-export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 8);
-
-/** @public */
-export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", -4);
-
-/** @public */
-export const neutralStrokePerceivableFocusDelta = createDelta(neutralStrokePerceivableName, "focus", 0);
-
-/** @public */
-export const neutralStrokePerceivableRecipe = createRecipeInteractive(neutralStrokePerceivableName,
-    (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        interactiveSwatchSetAsOverlay(
-            contrastAndDeltaSwatchSet(
-                resolve(neutralPalette),
-                reference || resolve(fillColor),
-                resolve(neutralStrokePerceivableMinContrast),
-                resolve(neutralStrokePerceivableRestDelta),
-                resolve(neutralStrokePerceivableHoverDelta),
-                resolve(neutralStrokePerceivableActiveDelta),
-                resolve(neutralStrokePerceivableFocusDelta)
-            ),
-            reference || resolve(fillColor),
-            resolve(neutralAsOverlay)
-        )
-);
-
-const neutralStrokePerceivableSet = createSet(neutralStrokePerceivableRecipe);
-
-/** @public */
-export const neutralStrokePerceivableRest = createStateToken(neutralStrokePerceivableSet, "rest");
-
-/** @public */
-export const neutralStrokePerceivableHover = createStateToken(neutralStrokePerceivableSet, "hover");
-
-/** @public */
-export const neutralStrokePerceivableActive = createStateToken(neutralStrokePerceivableSet, "active");
-
-/** @public */
-export const neutralStrokePerceivableFocus = createStateToken(neutralStrokePerceivableSet, "focus");
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongMinContrast = neutralStrokePerceivableMinContrast;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongRestDelta = neutralStrokePerceivableRestDelta;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongHoverDelta = neutralStrokePerceivableHoverDelta;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongActiveDelta = neutralStrokePerceivableActiveDelta;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongFocusDelta = neutralStrokePerceivableFocusDelta;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongRecipe = neutralStrokePerceivableRecipe;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongRest = neutralStrokePerceivableRest;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongHover = neutralStrokePerceivableHover;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongActive = neutralStrokePerceivableActive;
-
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralStrokeStrongFocus = neutralStrokePerceivableFocus;
-
-// Focus Stroke Outer
-
-const focusStrokeOuterName = "focus-stroke-outer";
-
-/** @public */
-export const focusStrokeOuterRecipe = createRecipe(focusStrokeOuterName,
-    (resolve: DesignTokenResolver): Swatch =>
-        blackOrWhiteByContrast(resolve(fillColor), resolve(minContrastReadable), true)
-);
-
-/** @public */
-export const focusStrokeOuter = createRecipeToken(focusStrokeOuterRecipe);
-
-// Focus Stroke Inner
-
-const focusStrokeInnerName = "focus-stroke-inner";
-
-/** @public */
-export const focusStrokeInnerRecipe = createRecipe(focusStrokeInnerName,
-    (resolve: DesignTokenResolver): Swatch =>
-        blackOrWhiteByContrast(resolve(focusStrokeOuter), resolve(minContrastReadable), false)
-);
-
-/** @public */
-export const focusStrokeInner = createRecipeToken(focusStrokeInnerRecipe);

--- a/packages/adaptive-ui/src/design-tokens/layer.ts
+++ b/packages/adaptive-ui/src/design-tokens/layer.ts
@@ -67,21 +67,21 @@ export const layerFillBaseLuminance = createNonCss<number>("layer-fill-base-lumi
  *
  * @public
  */
-export const layerFillDelta = createNonCss<number>("layer-fill-delta").withDefault(-3);
+export const layerFillDelta = createNonCss<number>("layer-fill-delta").withDefault(-2);
 
 /**
  * The offset from the container for "Interactive" hover state, {@link layerFillInteractiveHover}.
  *
  * @public
  */
-export const layerFillHoverDelta = createNonCss<number>("layer-fill-hover-delta").withDefault(-4);
+export const layerFillHoverDelta = createNonCss<number>("layer-fill-hover-delta").withDefault(-3);
 
 /**
  * The offset from the container for "Interactive" active state, {@link layerFillInteractiveActive}.
  *
  * @public
  */
-export const layerFillActiveDelta = createNonCss<number>("layer-fill-active-delta").withDefault(-2);
+export const layerFillActiveDelta = createNonCss<number>("layer-fill-active-delta").withDefault(-1);
 
 /**
  * The offset from the container for "Interactive" focus state, {@link layerFillInteractiveFocus}.

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,19 +1,21 @@
+import { CSSDesignToken, DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
+import { InteractiveColorRecipe } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
-import type { InteractiveTokenSet, Styles } from "../types.js";
+import type { InteractiveSet, InteractiveTokenSet, Styles } from "../types.js";
 import {
     accentFillReadableActive,
     accentFillReadableFocus,
     accentFillReadableHover,
     accentFillReadableRest,
-    accentForegroundActive,
-    accentForegroundFocus,
-    accentForegroundHover,
-    accentForegroundRest,
+    accentStrokeReadableActive,
+    accentStrokeReadableFocus,
+    accentStrokeReadableHover,
+    accentStrokeReadableRest,
     fillColor,
-    foregroundOnAccentActive,
-    foregroundOnAccentFocus,
-    foregroundOnAccentHover,
-    foregroundOnAccentRest,
+    foregroundOnAccentFillReadableActive,
+    foregroundOnAccentFillReadableFocus,
+    foregroundOnAccentFillReadableHover,
+    foregroundOnAccentFillReadableRest,
     neutralFillPerceivableActive,
     neutralFillPerceivableFocus,
     neutralFillPerceivableHover,
@@ -26,20 +28,47 @@ import {
     neutralFillSubtleFocus,
     neutralFillSubtleHover,
     neutralFillSubtleRest,
-    neutralForegroundActive,
-    neutralForegroundFocus,
-    neutralForegroundHover,
-    neutralForegroundRest,
     neutralStrokePerceivableActive,
     neutralStrokePerceivableFocus,
     neutralStrokePerceivableHover,
     neutralStrokePerceivableRest,
     neutralStrokeReadableRest,
+    neutralStrokeStrongActive,
+    neutralStrokeStrongFocus,
+    neutralStrokeStrongHover,
+    neutralStrokeStrongRecipe,
+    neutralStrokeStrongRest,
     neutralStrokeSubtleActive,
     neutralStrokeSubtleFocus,
     neutralStrokeSubtleHover,
     neutralStrokeSubtleRest,
 } from "./color.js";
+
+function createForegroundSet(
+    foregroundRecipe: DesignToken<InteractiveColorRecipe>,
+    foregroundState: keyof InteractiveSet<any>,
+    background: InteractiveTokenSet<Swatch>,
+): InteractiveTokenSet<Swatch> {
+    const foregroundBaseName = `${foregroundRecipe.name.replace("-recipe", "")}-${foregroundState}`;
+    const backgroundBaseName = background.rest.name.replace("-rest", "");
+    const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
+
+    function createState(
+        state: keyof InteractiveSet<any>,
+    ): CSSDesignToken<Swatch> {
+        return DesignToken.create<Swatch>(`${setName}-${state}`).withDefault(
+            (resolve: DesignTokenResolver) =>
+                resolve(foregroundRecipe).evaluate(resolve, resolve(background[state]))[foregroundState]
+        );
+    }
+
+    return {
+        rest: createState("rest"),
+        hover: createState("hover"),
+        active: createState("active"),
+        focus: createState("focus")
+    };
+}
 
 /**
  * @public
@@ -54,21 +83,21 @@ export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
 /**
  * @public
  */
-export const foregroundOnAccentInteractiveSet: InteractiveTokenSet<Swatch> = {
-    rest: foregroundOnAccentRest,
-    hover: foregroundOnAccentHover,
-    active: foregroundOnAccentActive,
-    focus: foregroundOnAccentFocus,
+export const foregroundOnAccentFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: foregroundOnAccentFillReadableRest,
+    hover: foregroundOnAccentFillReadableHover,
+    active: foregroundOnAccentFillReadableActive,
+    focus: foregroundOnAccentFillReadableFocus,
 };
 
 /**
  * @public
  */
-export const accentForegroundInteractiveSet: InteractiveTokenSet<Swatch> = {
-    rest: accentForegroundRest,
-    hover: accentForegroundHover,
-    active: accentForegroundActive,
-    focus: accentForegroundFocus,
+export const accentStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: accentStrokeReadableRest,
+    hover: accentStrokeReadableHover,
+    active: accentStrokeReadableActive,
+    focus: accentStrokeReadableFocus,
 };
 
 /**
@@ -104,11 +133,11 @@ export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch> =
 /**
  * @public
  */
-export const neutralForegroundInteractiveSet: InteractiveTokenSet<Swatch> = {
-    rest: neutralForegroundRest,
-    hover: neutralForegroundHover,
-    active: neutralForegroundActive,
-    focus: neutralForegroundFocus,
+export const neutralStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralStrokeStrongRest,
+    hover: neutralStrokeStrongHover,
+    active: neutralStrokeStrongActive,
+    focus: neutralStrokeStrongFocus,
 };
 
 /**
@@ -139,7 +168,7 @@ export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch>
 export const accentFillControlStyles: Styles = {
     "background-color": accentFillReadableInteractiveSet,
     "border-color": "transparent",
-    "color": foregroundOnAccentInteractiveSet,
+    "color": foregroundOnAccentFillReadableInteractiveSet,
 };
 
 /**
@@ -150,18 +179,29 @@ export const accentFillControlStyles: Styles = {
 export const neutralFillControlStyles: Styles = {
     "background-color": neutralFillSubtleInteractiveSet,
     "border-color": neutralStrokeSubtleInteractiveSet,
-    "color": neutralForegroundRest,
+    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
 };
 
 /**
- * Convenience style module for a neutral control with accessibility requirements, like a checkbox.
+ * Convenience style module for a neutral control with accessibility requirements applied to the border, like an unselected checkbox.
  *
  * @public
  */
-export const neutralPerceivableControlStyles: Styles = {
+export const neutralOutlinePerceivableControlStyles: Styles = {
     "background-color": neutralFillSubtleInteractiveSet,
     "border-color": neutralStrokePerceivableInteractiveSet,
-    "color": neutralForegroundRest,
+    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
+};
+
+/**
+ * Convenience style module for a neutral control with accessibility requirements applied to the fill, like a selected checkbox.
+ *
+ * @public
+ */
+export const neutralFillPerceivableControlStyles: Styles = {
+    "background-color": neutralFillPerceivableInteractiveSet,
+    "border-color": "transparent",
+    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillPerceivableInteractiveSet),
 };
 
 /**
@@ -172,7 +212,7 @@ export const neutralPerceivableControlStyles: Styles = {
 export const neutralOutlineControlStyles: Styles = {
     "background-color": fillColor,
     "border-color": neutralStrokePerceivableInteractiveSet,
-    "color": neutralForegroundRest,
+    "color": neutralStrokeStrongRest,
 };
 
 /**
@@ -183,7 +223,7 @@ export const neutralOutlineControlStyles: Styles = {
 export const neutralStealthControlStyles: Styles = {
     "background-color": neutralFillStealthInteractiveSet,
     "border-color": "transparent",
-    "color": neutralForegroundRest,
+    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillStealthInteractiveSet),
 };
 
 /**
@@ -193,7 +233,7 @@ export const neutralStealthControlStyles: Styles = {
  */
 export const accentForegroundReadableStyles: Styles = {
     "border-color": "transparent",
-    "color": accentForegroundInteractiveSet,
+    "color": accentStrokeReadableInteractiveSet,
 };
 
 /**
@@ -213,5 +253,5 @@ export const neutralForegroundReadableStyles: Styles = {
  */
 export const neutralForegroundStrongStyles: Styles = {
     "border-color": "transparent",
-    "color": neutralForegroundInteractiveSet,
+    "color": neutralStrokeStrongInteractiveSet,
 };


### PR DESCRIPTION
# Pull Request

## Description

- Renamed remaining "foreground" tokens
- Added support for derived foreground recipes over a background
- Moved deprecated tokens down
- Minor recipe tweaks and Explorer updates

## Reviewer Notes

In `color.ts` most of the change is moving the deprecated tokens to the bottom, but it doesn't diff correctly.

## Test Plan

I tested in Explorer and Storybnook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

I'm going to update all components to use the modules like I did for the sample with Anchor.