### PR TITLE
Clean up style module definition

### DIFF
--- a/change/@adaptive-web-adaptive-ui-5853f7b5-40b8-44f3-940d-399362cceae9.json
+++ b/change/@adaptive-web-adaptive-ui-5853f7b5-40b8-44f3-940d-399362cceae9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Clean up style module definition",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-ee19d797-05d2-4aee-853f-3c06bfff0cd4.json
+++ b/change/@adaptive-web-adaptive-web-components-ee19d797-05d2-4aee-853f-3c06bfff0cd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Clean up style module definition",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -344,6 +344,12 @@ export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>
 }
 
 // @public
+export interface InteractivityDefinition {
+    interactivitySelector?: string;
+    nonInteractivitySelector?: string;
+}
+
+// @public
 export function isDark(color: RelativeLuminance): boolean;
 
 // @public
@@ -426,8 +432,6 @@ export interface LayerRecipe {
 // @public
 export function luminanceSwatch(luminance: number): Swatch;
 
-// Warning: (ae-incompatible-release-tags) The symbol "makeSelector" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
-//
 // @public
 export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string;
 
@@ -926,8 +930,6 @@ export interface RelativeLuminance {
     readonly relativeLuminance: number;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "renderElementStyles" is marked as @public, but its signature references "StyleModuleEvaluateParameters" which is marked as @beta
-//
 // @public
 export function renderElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[];
 
@@ -953,17 +955,13 @@ export type StateSelector = "hover" | "active" | FocusSelector;
 // @public (undocumented)
 export const strokeWidth: CSSDesignToken<number>;
 
-// @beta
-export interface StyleModuleEvaluateParameters {
-    // (undocumented)
+// @public
+export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
+
+// @public
+export interface StyleModuleTarget {
     hostCondition?: string;
-    // (undocumented)
-    interactivitySelector?: string;
-    // (undocumented)
-    nonInteractivitySelector?: string;
-    // (undocumented)
     part?: string;
-    // (undocumented)
     partCondition?: string;
 }
 

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -178,7 +178,23 @@ export interface ColorRecipe<T = Swatch> {
 }
 
 // @public
+export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
+    // (undocumented)
+    conditions: TConditions;
+    // (undocumented)
+    interactivity?: InteractivityDefinition;
+    // (undocumented)
+    parts: TParts;
+}
+
+// @public
 export const componentBaseStyles = "\n    :host([hidden]) {\n        display: none !important;\n    }\n";
+
+// @public
+export type ComponentConditions = Record<string, string>;
+
+// @public
+export type ComponentParts = Record<string, string>;
 
 // @public
 export function contrast(a: RelativeLuminance, b: RelativeLuminance): number;

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -17,18 +17,50 @@ export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 export type StateSelector = "hover" | "active" | FocusSelector;
 
 /**
- * Parameters provided when rendering style modules.
+ * Parameters used to apply style modules to components.
  *
- * @remarks This may be split into `host` and `part` needs.
- * @beta
+ * @public
  */
-export interface StyleModuleEvaluateParameters {
+export interface StyleModuleTarget {
+    /**
+     * The condition to match at the host element level.
+     */
     hostCondition?: string;
+
+    /**
+     * The component part name to apply this style module.
+     */
     part?: string;
+
+    /**
+     * The condition to match at the part element level.
+     */
     partCondition?: string;
+}
+
+/**
+ * Parameters provided by a component to inform style modules of its interactivity configuration.
+ *
+ * @public
+ */
+export interface InteractivityDefinition {
+    /**
+     * The selector indicating the component or element is interactive, like `:not([disabled])`.
+     */
     interactivitySelector?: string;
+
+    /**
+     * The selector indicating the component or element is not interactive, like `[disabled]`.
+     */
     nonInteractivitySelector?: string;
 }
+
+/**
+ * Parameters used to evaluate style modules for a component.
+ *
+ * @public
+ */
+export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
 
 /**
  * The style property, like background color or border thickness.

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -17,6 +17,31 @@ export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 export type StateSelector = "hover" | "active" | FocusSelector;
 
 /**
+ * Type of the `conditions` for component {@link ComponentAnatomy}.
+ *
+ * @public
+ */
+export type ComponentConditions = Record<string, string>;
+
+/**
+ * Type of the `parts` for component {@link ComponentAnatomy}.
+ *
+ * @public
+ */
+export type ComponentParts = Record<string, string>;
+
+/**
+ * Structure describing component anatomy for modular styling.
+ *
+ * @public
+ */
+export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
+    interactivity?: InteractivityDefinition;
+    conditions: TConditions;
+    parts: TParts;
+}
+
+/**
  * Parameters used to apply style modules to components.
  *
  * @public

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type { ComposableStyles } from '@microsoft/fast-element';
 import { ElementStyles } from '@microsoft/fast-element';
 import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTAccordion } from '@microsoft/fast-foundation';
@@ -58,8 +59,11 @@ import { FASTTooltip } from '@microsoft/fast-foundation';
 import { FASTTreeItem } from '@microsoft/fast-foundation';
 import { FASTTreeView } from '@microsoft/fast-foundation';
 import { HorizontalScrollView } from '@microsoft/fast-foundation';
+import type { InteractivityDefinition } from '@adaptive-web/adaptive-ui';
 import type { ShadowRootOptions } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '@microsoft/fast-foundation';
+import type { StyleModuleTarget } from '@adaptive-web/adaptive-ui';
+import type { Styles } from '@adaptive-web/adaptive-ui';
 import type { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public
@@ -565,6 +569,7 @@ export const dataGridTemplateStyles: ElementStyles;
 export class DesignSystem {
     // Warning: (ae-forgotten-export) The symbol "ElementStaticMap" needs to be exported by the entry point index.d.ts
     constructor(_prefix: string, _registry?: CustomElementRegistry, _statics?: ElementStaticMap);
+    static assembleStyles(defaultStyles: ComposableStyles[], interactivity: InteractivityDefinition, options?: ComposeOptions<any>): ComposableStyles[];
     // Warning: (ae-forgotten-export) The symbol "PartialDesignSystem" needs to be exported by the entry point index.d.ts
     configure(options: PartialDesignSystem): this;
     defineComponents(components: Record<string, ((ds: DesignSystem) => FASTElementDefinition) | FASTElementDefinition>): void;

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -569,7 +569,7 @@ export const dataGridTemplateStyles: ElementStyles;
 export class DesignSystem {
     // Warning: (ae-forgotten-export) The symbol "ElementStaticMap" needs to be exported by the entry point index.d.ts
     constructor(_prefix: string, _registry?: CustomElementRegistry, _statics?: ElementStaticMap);
-    static assembleStyles(defaultStyles: ComposableStyles[], interactivity: InteractivityDefinition, options?: ComposeOptions<any>): ComposableStyles[];
+    static assembleStyles(defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>): ComposableStyles[];
     // Warning: (ae-forgotten-export) The symbol "PartialDesignSystem" needs to be exported by the entry point index.d.ts
     configure(options: PartialDesignSystem): this;
     defineComponents(components: Record<string, ((ds: DesignSystem) => FASTElementDefinition) | FASTElementDefinition>): void;

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -3,7 +3,7 @@ import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-el
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./checkbox.styles.js";
-import { CheckboxInteractivity, CheckboxStatics, template } from "./checkbox.template.js";
+import { CheckboxAnatomy, CheckboxStatics, template } from "./checkbox.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
@@ -27,7 +27,7 @@ export function composeCheckbox(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CheckboxInteractivity, options);
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CheckboxAnatomy.interactivity, options);
 
     return FASTCheckbox.compose({
         name: `${ds.prefix}-checkbox`,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -1,11 +1,11 @@
 import { FASTCheckbox } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from "@microsoft/fast-element";
+import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./checkbox.styles.js";
-import { CheckboxStatics, template } from "./checkbox.template.js";
+import { CheckboxInteractivity, CheckboxStatics, template } from "./checkbox.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCheckbox(
     ds: DesignSystem,
@@ -27,10 +27,12 @@ export function composeCheckbox(
         }
     }
 
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CheckboxInteractivity, options);
+
     return FASTCheckbox.compose({
         name: `${ds.prefix}-checkbox`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
@@ -1,8 +1,9 @@
+import { accentFillControlStyles, neutralOutlinePerceivableControlStyles } from "@adaptive-web/adaptive-ui";
 import checkmarkIcon from "@fluentui/svg-icons/icons/checkmark_16_regular.svg";
 import subtractIcon from "@fluentui/svg-icons/icons/subtract_16_regular.svg";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeCheckbox } from './checkbox.compose.js';
-import { CheckboxStatics } from "./checkbox.template.js";
+import { CheckboxAnatomy, CheckboxStatics } from "./checkbox.template.js";
 
 /**
  * The Checkbox custom element definition. Implements {@link @microsoft/fast-foundation#FASTCheckbox}.
@@ -18,6 +19,21 @@ export const checkboxDefinition = composeCheckbox(
         statics: {
             [CheckboxStatics.checked]: checkmarkIcon,
             [CheckboxStatics.indeterminate]: subtractIcon
-        }
+        },
+        styleModules: [
+            [
+                {
+                    part: CheckboxAnatomy.parts.control,
+                },
+                neutralOutlinePerceivableControlStyles
+            ],
+            [
+                {
+                    hostCondition: CheckboxAnatomy.conditions.checked,
+                    part: CheckboxAnatomy.parts.control,
+                },
+                accentFillControlStyles
+            ]
+        ],
     }
 );

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -1,19 +1,9 @@
 import {
-    accentFillReadableActive,
-    accentFillReadableHover,
-    accentFillReadableRest,
     controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    foregroundOnAccentRest,
-    neutralFillSubtleActive,
-    neutralFillSubtleHover,
-    neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokePerceivableActive,
-    neutralStrokePerceivableHover,
-    neutralStrokePerceivableRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -81,44 +71,13 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
+        border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${controlCornerRadius} * 1px);
-        background: ${neutralFillSubtleRest};
-        color: ${neutralForegroundRest};
         fill: currentcolor;
-    }
-
-    :host(:enabled:hover) .control {
-        background: ${neutralFillSubtleHover};
-        border-color: ${neutralStrokePerceivableHover};
-    }
-
-    :host(:enabled:active) .control {
-        background: ${neutralFillSubtleActive};
-        border-color: ${neutralStrokePerceivableActive};
     }
 
     :host(:focus-visible) .control {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
-    }
-
-    :host([aria-checked="true"]) .control,
-    :host([aria-checked="mixed"]) .control {
-        background: ${accentFillReadableRest};
-        border-color: transparent;
-        color: ${foregroundOnAccentRest};
-    }
-
-    :host([aria-checked="true"]:not(.disabled):hover) .control,
-    :host([aria-checked="mixed"]:not(.disabled):hover) .control {
-        background: ${accentFillReadableHover};
-        border-color: transparent;
-    }
-
-    :host([aria-checked="true"]:not(.disabled):active) .control,
-    :host([aria-checked="mixed"]:not(.disabled):active) .control {
-        background: ${accentFillReadableActive};
-        border-color: transparent;
     }
 
     .label {

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { checkboxTemplate, FASTCheckbox } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { InteractivityDefinition } from "@adaptive-web/adaptive-ui";
+import type { ComponentAnatomy } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -14,56 +14,24 @@ export const CheckboxStatics = {
 
 export type CheckboxStatics = ValuesOf<typeof CheckboxStatics>;
 
-// Looking for a way to make this type-=safe and extensible:
-
-type Condition = string;
-
-export type Conditions = Record<string, Condition>;
-export type Parts = Record<string, string>;
-
-interface Anatomy<TConditions extends Conditions, TParts extends Parts> {
-    interactivity?: InteractivityDefinition;
-    conditions: TConditions;
-    parts: TParts;
-}
-
-// type CheckboxConditions = {
-//     checked: Condition,
-//     indeterminate: Condition
-// };
-
-export const CheckboxConditions: Conditions = {
+export const CheckboxConditions = {
     checked: "[aria-checked='true']",
     indeterminate: "[aria-checked='mixed']"
 };
 
-type CheckboxConditions = typeof CheckboxConditions;
-
-// type CheckboxParts = {
-//     control: string,
-//     label: string
-// };
-
-export const CheckboxParts: Parts = {
+export const CheckboxParts = {
     control: "control",
     label: "label"
 };
 
-type CheckboxParts = typeof CheckboxParts;
-
-export const CheckboxInteractivity: InteractivityDefinition = { 
-    interactivitySelector: ":not([disabled])",
-    nonInteractivitySelector: "[disabled]",
-}
-
-export const CheckboxAnatomy: Anatomy<CheckboxConditions, CheckboxParts> = {
-    interactivity: CheckboxInteractivity,
+export const CheckboxAnatomy: ComponentAnatomy<typeof CheckboxConditions, typeof CheckboxParts> = {
+    interactivity: { 
+        interactivitySelector: ":not([disabled])",
+        nonInteractivitySelector: "[disabled]",
+    },
     conditions: CheckboxConditions,
     parts: CheckboxParts,
 };
-
-// Such that TypeScript knows what conditions and parts are available:
-// CheckboxAnatomy.conditions.[auto-complete here]
 
 /**
  * Default Checkbox template, {@link @microsoft/fast-foundation#checkboxTemplate}.

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
@@ -1,6 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { checkboxTemplate, FASTCheckbox } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
+import { InteractivityDefinition } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -12,6 +13,57 @@ export const CheckboxStatics = {
 } as const;
 
 export type CheckboxStatics = ValuesOf<typeof CheckboxStatics>;
+
+// Looking for a way to make this type-=safe and extensible:
+
+type Condition = string;
+
+export type Conditions = Record<string, Condition>;
+export type Parts = Record<string, string>;
+
+interface Anatomy<TConditions extends Conditions, TParts extends Parts> {
+    interactivity?: InteractivityDefinition;
+    conditions: TConditions;
+    parts: TParts;
+}
+
+// type CheckboxConditions = {
+//     checked: Condition,
+//     indeterminate: Condition
+// };
+
+export const CheckboxConditions: Conditions = {
+    checked: "[aria-checked='true']",
+    indeterminate: "[aria-checked='mixed']"
+};
+
+type CheckboxConditions = typeof CheckboxConditions;
+
+// type CheckboxParts = {
+//     control: string,
+//     label: string
+// };
+
+export const CheckboxParts: Parts = {
+    control: "control",
+    label: "label"
+};
+
+type CheckboxParts = typeof CheckboxParts;
+
+export const CheckboxInteractivity: InteractivityDefinition = { 
+    interactivitySelector: ":not([disabled])",
+    nonInteractivitySelector: "[disabled]",
+}
+
+export const CheckboxAnatomy: Anatomy<CheckboxConditions, CheckboxParts> = {
+    interactivity: CheckboxInteractivity,
+    conditions: CheckboxConditions,
+    parts: CheckboxParts,
+};
+
+// Such that TypeScript knows what conditions and parts are available:
+// CheckboxAnatomy.conditions.[auto-complete here]
 
 /**
  * Default Checkbox template, {@link @microsoft/fast-foundation#checkboxTemplate}.

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -121,7 +121,7 @@ export class DesignSystem {
      * @beta
      */
     public static assembleStyles(
-        defaultStyles: ComposableStyles[], interactivity: InteractivityDefinition, options?: ComposeOptions<any>
+        defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>
     ): ComposableStyles[] {
         const componentStyles: ComposableStyles[] = options?.styles ? 
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :


### PR DESCRIPTION
# Pull Request

## Description

Updates the style module pattern to fulfill the same requirements as the design system statics. That is, the aesthetic styles start to move into modules (colors for now) and they are registered during the default definition. 

## Reviewer Notes

I feel like this can be cleaned up, optimized, and more efficient. Looking for any thoughts in this regard, especially with defining component anatomy (parts, selectors, etc.)

## Test Plan

Visual component testing in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Continue to apply to remaining components.