### PR TITLE
Add customization example placeholder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,4 @@ A set of examples for how to use and customize Adaptive Web Components (more com
 ## Getting Started
 
 - [Using components with any framework](use-adaptive-components)
+- [Customizing a component definition](customize-component)

--- a/examples/customize-component/README.md
+++ b/examples/customize-component/README.md
@@ -1,0 +1,9 @@
+# Customizing a Component
+
+Illustrates how to customize the definition of a component before registering it.
+
+TODO: Coming soon, placeholder example to minimize diffs.
+
+## Key features
+
+- TODO

--- a/examples/customize-component/index.html
+++ b/examples/customize-component/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AWC - Customize Components</title>
+    <style>
+        html {
+            padding: 20px;
+            background-color: var(--fill-color);
+            font-family: sans-serif;
+        }
+        adaptive-card {
+            height: 500px;
+            width: 400px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            padding: 20px;
+        }
+    </style>
+    <script type="module" src="/src/index.ts"></script>
+</head>
+
+<body>
+    
+</body>
+
+</html>

--- a/examples/customize-component/package.json
+++ b/examples/customize-component/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@adaptive-web/example-customize-component",
+    "version": "0.0.1",
+    "description": "A simple example of customizing a component definition",
+    "type": "module",
+    "private": true,
+    "license": "MIT",
+    "author": {
+        "name": "Adaptive Web Community",
+        "url": "https://github.com/adaptive-web-community"
+    },
+    "bugs": {
+        "url": "https://github.com/adaptive-web-community/adaptive-web-components/issues"
+    },
+    "homepage": "https://github.com/adaptive-web-community/adaptive-web-components#readme",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/adaptive-web-community/adaptive-web-components.git",
+        "directory": "examples/customize-component"
+    },
+    "scripts": {
+        "build": "tsc && vite build",
+        "clean": "rimraf dist",
+        "start": "vite --open"
+    },
+    "dependencies": {
+        "@adaptive-web/adaptive-web-components": "0.1.2"
+    },
+    "devDependencies": {
+        "vite-plugin-svgo": "^1.3.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.7.0",
+        "vite": "^4.1.1"
+    }
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -1,0 +1,8 @@
+import { AdaptiveDesignSystem } from '@adaptive-web/adaptive-web-components';
+import { DesignToken } from "@microsoft/fast-foundation";
+
+AdaptiveDesignSystem.defineComponents({
+    
+});
+
+DesignToken.registerDefaultStyleTarget();

--- a/examples/customize-component/tsconfig.json
+++ b/examples/customize-component/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "moduleResolution": "nodenext",
+        "outDir": "dist/esm"
+    },
+    "include": ["src"]
+}

--- a/examples/customize-component/vite.config.js
+++ b/examples/customize-component/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+import svg from 'vite-plugin-svgo'
+
+export default defineConfig({
+	// Turn off all plugins, effectively just using the inlining capability.
+	// Many icon libraries, like Fluent System Icons, are already optimized and the defaults can have negative consequences.
+	plugins: [svg({plugins:[]})]
+});


### PR DESCRIPTION
# Pull Request

## Description

Adding an example for customizing a component definition. I want to do the actual work as part of an Adaptive UI update, but I don't want to crowd that PR with the base of the example.

## Reviewer Notes

Mostly a copy of the other existing example.

## Test Plan

Not applicable yet.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Make the updates in Adaptive UI that will be illustrated in this example.