### PR TITLE
Update Styles to typed StylesProperty key

### DIFF
--- a/change/@adaptive-web-adaptive-ui-8ba7e929-6e65-43aa-b8f8-2a29af929af9.json
+++ b/change/@adaptive-web-adaptive-ui-8ba7e929-6e65-43aa-b8f8-2a29af929af9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update Styles to typed StylesProperty key",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -1,4 +1,4 @@
-import { fillColor, InteractiveTokenSet, Styles, Swatch } from "@adaptive-web/adaptive-ui";
+import { fillColor, InteractiveTokenSet, StyleProperty, Styles, Swatch } from "@adaptive-web/adaptive-ui";
 import { css, customElement, FASTElement, html, observable, repeat, volatile } from "@microsoft/fast-element";
 import { CSSDesignToken } from "@microsoft/fast-foundation";
 import { SwatchType } from "./swatch.js";
@@ -66,7 +66,7 @@ export class StyleExample extends FASTElement {
         let backgroundActive = fillColor;
         let backgroundFocus = fillColor;
 
-        const backgroundValue = (this.styles || {})["background-color"];
+        const backgroundValue = (this.styles || {})[StyleProperty.backgroundFill];
         if (backgroundValue) {
             if (typeof backgroundValue === "string") {
                 // ignore for now
@@ -106,7 +106,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const colorValue = (this.styles || {})["color"];
+        const colorValue = (this.styles || {})[StyleProperty.foregroundFill];
         if (colorValue) {
             if (typeof colorValue === "string") {
                 // ignore for now
@@ -146,7 +146,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const borderValue = (this.styles || {})["border-color"];
+        const borderValue = (this.styles || {})[StyleProperty.borderFill];
         if (borderValue) {
             if (typeof borderValue === "string") {
                 // ignore for now

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -968,7 +968,32 @@ export interface StyleModuleEvaluateParameters {
 }
 
 // @public
-export type Styles = Record<string, CSSDesignToken<any> | InteractiveTokenSet<any> | string>;
+export const StyleProperty: {
+    readonly backgroundFill: "backgroundFill";
+    readonly foregroundFill: "foregroundFill";
+    readonly borderFill: "borderFill";
+    readonly borderThickness: "borderThickness";
+    readonly borderStyle: "borderStyle";
+    readonly cornerRadius: "cornerRadius";
+    readonly fontFamily: "fontFamily";
+    readonly fontSize: "fontSize";
+    readonly fontWeight: "fontWeight";
+    readonly fontStyle: "fontStyle";
+    readonly letterSpacing: "letterSpacing";
+    readonly lineHeight: "lineHeight";
+    readonly padding: "padding";
+    readonly gap: "gap";
+    readonly height: "height";
+    readonly width: "width";
+    readonly layoutDirection: "layoutDirection";
+    readonly opacity: "opacity";
+};
+
+// @public
+export type StyleProperty = ValuesOf<typeof StyleProperty>;
+
+// @public
+export type Styles = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenSet<any> | CSSDirective | string>>;
 
 // @public
 export interface Swatch extends RelativeLuminance {

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,7 +1,8 @@
 import { CSSDesignToken, DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
-import type { InteractiveSet, InteractiveTokenSet, Styles } from "../types.js";
+import type { Styles } from "../modules/types.js";
+import type { InteractiveSet, InteractiveTokenSet } from "../types.js";
 import {
     accentFillReadableActive,
     accentFillReadableFocus,
@@ -166,9 +167,9 @@ export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch>
  * @public
  */
 export const accentFillControlStyles: Styles = {
-    "background-color": accentFillReadableInteractiveSet,
-    "border-color": "transparent",
-    "color": foregroundOnAccentFillReadableInteractiveSet,
+    backgroundFill: accentFillReadableInteractiveSet,
+    borderFill: "transparent",
+    foregroundFill: foregroundOnAccentFillReadableInteractiveSet,
 };
 
 /**
@@ -177,9 +178,9 @@ export const accentFillControlStyles: Styles = {
  * @public
  */
 export const neutralFillControlStyles: Styles = {
-    "background-color": neutralFillSubtleInteractiveSet,
-    "border-color": neutralStrokeSubtleInteractiveSet,
-    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
+    backgroundFill: neutralFillSubtleInteractiveSet,
+    borderFill: neutralStrokeSubtleInteractiveSet,
+    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
 };
 
 /**
@@ -188,9 +189,9 @@ export const neutralFillControlStyles: Styles = {
  * @public
  */
 export const neutralOutlinePerceivableControlStyles: Styles = {
-    "background-color": neutralFillSubtleInteractiveSet,
-    "border-color": neutralStrokePerceivableInteractiveSet,
-    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
+    backgroundFill: neutralFillSubtleInteractiveSet,
+    borderFill: neutralStrokePerceivableInteractiveSet,
+    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
 };
 
 /**
@@ -199,9 +200,9 @@ export const neutralOutlinePerceivableControlStyles: Styles = {
  * @public
  */
 export const neutralFillPerceivableControlStyles: Styles = {
-    "background-color": neutralFillPerceivableInteractiveSet,
-    "border-color": "transparent",
-    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillPerceivableInteractiveSet),
+    backgroundFill: neutralFillPerceivableInteractiveSet,
+    borderFill: "transparent",
+    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillPerceivableInteractiveSet),
 };
 
 /**
@@ -210,9 +211,9 @@ export const neutralFillPerceivableControlStyles: Styles = {
  * @public
  */
 export const neutralOutlineControlStyles: Styles = {
-    "background-color": fillColor,
-    "border-color": neutralStrokePerceivableInteractiveSet,
-    "color": neutralStrokeStrongRest,
+    backgroundFill: fillColor,
+    borderFill: neutralStrokePerceivableInteractiveSet,
+    foregroundFill: neutralStrokeStrongRest,
 };
 
 /**
@@ -221,9 +222,9 @@ export const neutralOutlineControlStyles: Styles = {
  * @public
  */
 export const neutralStealthControlStyles: Styles = {
-    "background-color": neutralFillStealthInteractiveSet,
-    "border-color": "transparent",
-    "color": createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillStealthInteractiveSet),
+    backgroundFill: neutralFillStealthInteractiveSet,
+    borderFill: "transparent",
+    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillStealthInteractiveSet),
 };
 
 /**
@@ -232,8 +233,8 @@ export const neutralStealthControlStyles: Styles = {
  * @public
  */
 export const accentForegroundReadableStyles: Styles = {
-    "border-color": "transparent",
-    "color": accentStrokeReadableInteractiveSet,
+    borderFill: "transparent",
+    foregroundFill: accentStrokeReadableInteractiveSet,
 };
 
 /**
@@ -242,8 +243,8 @@ export const accentForegroundReadableStyles: Styles = {
  * @public
  */
 export const neutralForegroundReadableStyles: Styles = {
-    "border-color": "transparent",
-    "color": neutralStrokeReadableRest,
+    borderFill: "transparent",
+    foregroundFill: neutralStrokeReadableRest,
 };
 
 /**
@@ -252,6 +253,6 @@ export const neutralForegroundReadableStyles: Styles = {
  * @public
  */
 export const neutralForegroundStrongStyles: Styles = {
-    "border-color": "transparent",
-    "color": neutralStrokeStrongInteractiveSet,
+    borderFill: "transparent",
+    foregroundFill: neutralStrokeStrongInteractiveSet,
 };

--- a/packages/adaptive-ui/src/modules/css.ts
+++ b/packages/adaptive-ui/src/modules/css.ts
@@ -1,0 +1,49 @@
+import { StyleProperty } from "./types.js";
+
+/**
+ * Converts a {@link StyleProperty} to a css property name.
+ *
+ * @param usage - The StyleProperty key.
+ * @returns The css property name.
+ * @public
+ */
+export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
+    switch (usage) {
+        case StyleProperty.backgroundFill:
+            return "background-color";
+        case StyleProperty.foregroundFill:
+            return "color";
+        case StyleProperty.borderFill:
+            return "border-color";
+        case StyleProperty.borderThickness:
+            return "border-width";
+        case StyleProperty.borderStyle:
+            return "border-style";
+        case StyleProperty.cornerRadius:
+            return "border-radius";
+        case StyleProperty.fontFamily:
+            return "font-family";
+        case StyleProperty.fontSize:
+            return "font-size";
+        case StyleProperty.fontWeight:
+            return "font-weight";
+        case StyleProperty.fontStyle:
+            return "font-style";
+        case StyleProperty.letterSpacing:
+            return "letter-spacing";
+        case StyleProperty.lineHeight:
+            return "line-height";
+        case StyleProperty.padding:
+            return "padding";
+        case StyleProperty.gap:
+            return "gap";
+        case StyleProperty.height:
+            return "height";
+        case StyleProperty.width:
+            return "width";
+        case StyleProperty.layoutDirection:
+            return "flex-direction";
+        case StyleProperty.opacity:
+            return "opacity";
+    }
+};

--- a/packages/adaptive-ui/src/modules/selector.ts
+++ b/packages/adaptive-ui/src/modules/selector.ts
@@ -16,12 +16,14 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state?: Stat
         // Use any base host condition like `[appearance='accent']`.
         let hostCondition = params.hostCondition || "";
 
-        // Add any interactive condition like `:not([disabled])`.
-        hostCondition += (params.interactivitySelector || "");
+        if (state) {
+            // Add any interactive condition like `:not([disabled])`.
+            hostCondition += (params.interactivitySelector || "");
 
-        // If this is not targeting a part, apply the state at the `:host`.
-        if (!params.part && state) {
-            hostCondition += ":" + state;
+            // If this is not targeting a part, apply the state at the `:host`.
+            if (!params.part) {
+                hostCondition += ":" + state;
+            }
         }
 
         if (hostCondition !== "") {

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -1,3 +1,7 @@
+import type { CSSDirective } from "@microsoft/fast-element";
+import type { CSSDesignToken, ValuesOf } from "@microsoft/fast-foundation";
+import { InteractiveTokenSet } from "../types.js";
+
 /**
  * Selectors for focus state.
  *
@@ -25,3 +29,43 @@ export interface StyleModuleEvaluateParameters {
     interactivitySelector?: string;
     nonInteractivitySelector?: string;
 }
+
+/**
+ * The style property, like background color or border thickness.
+ *
+ * @public
+ */
+export const StyleProperty = {
+    backgroundFill: "backgroundFill",
+    foregroundFill: "foregroundFill",
+    borderFill: "borderFill",
+    borderThickness: "borderThickness",
+    borderStyle: "borderStyle",
+    cornerRadius: "cornerRadius",
+    fontFamily: "fontFamily",
+    fontSize: "fontSize",
+    fontWeight: "fontWeight",
+    fontStyle: "fontStyle",
+    letterSpacing: "letterSpacing",
+    lineHeight: "lineHeight",
+    padding: "padding",
+    gap: "gap",
+    height: "height",
+    width: "width",
+    layoutDirection: "layoutDirection",
+    opacity: "opacity",
+} as const;
+
+/**
+ * The style property, like background color or border thickness.
+ *
+ * @public
+ */
+export type StyleProperty = ValuesOf<typeof StyleProperty>;
+
+/**
+ * A style definition, where the key is the {@link (StyleProperty:type)} or a custom key and the value is the token or final value.
+ *
+ * @public
+ */
+export type Styles = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenSet<any> | CSSDirective | string>>;

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -33,10 +33,3 @@ export interface InteractiveSet<T> {
  * @public
  */
 export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>> {}
-
-/**
- * A style definition, where the key is the css property and the value is the token.
- *
- * @public
- */
-export type Styles = Record<string, CSSDesignToken<any> | InteractiveTokenSet<any> | string>;

--- a/packages/adaptive-ui/tsconfig.json
+++ b/packages/adaptive-ui/tsconfig.json
@@ -4,7 +4,7 @@
         "baseUrl": ".",
         "importHelpers": true,
         "types": ["mocha"],
-        "lib": ["DOM", "ES2015"],
+        "lib": ["DOM", "ES2020"],
         "declarationDir": "dist/dts",
         "outDir": "dist/esm"
     },


### PR DESCRIPTION
# Pull Request

## Description

The `Styles` definitions are intended to be a declarative representation of style decisions and not another form of css. For instance, other tech needs to be able to apply styles, like in Figma. We also need to be able to render the correct property, for instance, when a background fill might represent a solid color or a gradient which requires the `background-image` property in css.

## Test Plan

Tested in Adaptive UI Explorer and Storybook. Does not feel like a large or complicated change.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Continued style module work.