### PR TITLE
Renamed `perceivable` colors to `discernible`

### DIFF
--- a/change/@adaptive-web-adaptive-ui-0e25b2fa-fbfd-400a-aeb2-0b107b41be45.json
+++ b/change/@adaptive-web-adaptive-ui-0e25b2fa-fbfd-400a-aeb2-0b107b41be45.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Renamed `perceivable` colors to `discernible`",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-9c8db456-1c6f-4206-bb3a-8839633fc09b.json
+++ b/change/@adaptive-web-adaptive-web-components-9c8db456-1c6f-4206-bb3a-8839633fc09b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Renamed `perceivable` colors to `discernible`",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -3,11 +3,11 @@ import {
     accentForegroundReadableStyles,
     fillColor,
     neutralFillControlStyles,
-    neutralFillPerceivableControlStyles,
+    neutralFillDiscernibleControlStyles,
     neutralForegroundReadableStyles,
     neutralForegroundStrongStyles,
     neutralOutlineControlStyles,
-    neutralOutlinePerceivableControlStyles,
+    neutralOutlineDiscernibleControlStyles,
     neutralStealthControlStyles,
     neutralStrokeReadableRest,
     neutralStrokeSubtleRest,
@@ -66,11 +66,11 @@ const formComponents = html<ColorBlock>`
         Text field
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralOutlinePerceivableControlStyles}">
+    <app-style-example :styles="${x => neutralOutlineDiscernibleControlStyles}">
         Checkbox (unchecked)
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillPerceivableControlStyles}">
+    <app-style-example :styles="${x => neutralFillDiscernibleControlStyles}">
         Checkbox (checked)
     </app-style-example>
 

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -452,7 +452,7 @@ export function luminanceSwatch(luminance: number): Swatch;
 export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string;
 
 // @public (undocumented)
-export const minContrastPerceivable: DesignToken<number>;
+export const minContrastDiscernible: DesignToken<number>;
 
 // @public (undocumented)
 export const minContrastReadable: DesignToken<number>;
@@ -474,6 +474,39 @@ export const neutralFillActiveDelta: DesignToken<number>;
 
 // @public
 export const neutralFillControlStyles: Styles;
+
+// @public (undocumented)
+export const neutralFillDiscernibleActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleActiveDelta: DesignToken<number>;
+
+// @public
+export const neutralFillDiscernibleControlStyles: Styles;
+
+// @public (undocumented)
+export const neutralFillDiscernibleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
 export const neutralFillFocus: CSSDesignToken<Swatch>;
@@ -513,39 +546,6 @@ export const neutralFillInputRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputRestDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralFillPerceivableActive: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableActiveDelta: DesignToken<number>;
-
-// @public
-export const neutralFillPerceivableControlStyles: Styles;
-
-// @public (undocumented)
-export const neutralFillPerceivableFocus: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableFocusDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralFillPerceivableHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableHoverDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableRecipe: DesignToken<InteractiveColorRecipe>;
-
-// @public (undocumented)
-export const neutralFillPerceivableRest: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralFillPerceivableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
 export const neutralFillRecipe: DesignToken<InteractiveColorRecipe>;
@@ -716,7 +716,7 @@ export const neutralForegroundStrongStyles: Styles;
 export const neutralOutlineControlStyles: Styles;
 
 // @public
-export const neutralOutlinePerceivableControlStyles: Styles;
+export const neutralOutlineDiscernibleControlStyles: Styles;
 
 // @public (undocumented)
 export const neutralPalette: DesignToken<Palette<Swatch>>;
@@ -729,6 +729,36 @@ export const neutralStrokeActive: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDividerRecipe: DesignToken<ColorRecipe<Swatch>>;
@@ -777,36 +807,6 @@ export const neutralStrokeInputRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputRestDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableActive: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableActiveDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableFocus: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableFocusDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableHoverDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableRecipe: DesignToken<InteractiveColorRecipe>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableRest: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralStrokePerceivableRestDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeReadableActive: CSSDesignToken<Swatch>;

--- a/packages/adaptive-ui/src/design-tokens/README.md
+++ b/packages/adaptive-ui/src/design-tokens/README.md
@@ -30,9 +30,9 @@ Has a subtle color at rest, typically with a slight increase or decrease on hove
 
 Has no accessibility configuration relative to its context.
 
-#### Perceivable
+#### Discernible
 
-Considered to be perceivable from a contrast perspective. Intended for use as a component bounding outline or for large text.
+Considered to be discernible from a contrast perspective. Intended for use as a component bounding outline or for large text.
 
 Meets accessibility requirements for 3:1 contrast relative to its context in AA mode. Increases to 4.5:1 in AAA mode.
 
@@ -62,7 +62,7 @@ Strokes are intended for lines, icons, or text. Because of the smaller coverage 
 
 The combinations of recipes currently implemented:
 
-|                    | Safety | Stealth | Subtle | Perceivable (3:1) | Readable (4.5:1) | Strong |
+|                    | Safety | Stealth | Subtle | Discernible (3:1) | Readable (4.5:1) | Strong |
 | ------------------ | ------ | ------- | ------ | ----------------- | ---------------- | ------ |
 | Neutral fill       | -      | ✓       | ✓      | ✓                | o                | -      |
 | Neutral stroke     | o      | o       | ✓      | ✓                | ✓                | ✓      |

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -58,7 +58,7 @@ function createRecipeToken(recipeToken: DesignToken<ColorRecipe>): CSSDesignToke
  * Convenience values for WCAG contrast requirements.
  *
  * @public
- * @deprecated Use `minContrastPerceivable` or `minContrastReadable` tokens instead
+ * @deprecated Use `minContrastDiscernible` or `minContrastReadable` tokens instead
  */
 export const ContrastTarget = Object.freeze({
     /**
@@ -89,7 +89,7 @@ export type WcagContrastLevel = ValuesOf<typeof WcagContrastLevel>;
 export const wcagContrastLevel = createNonCss<WcagContrastLevel>("wcag-contrast-level").withDefault("aa");
 
 /** @public */
-export const minContrastPerceivable = createNonCss<number>("min-contrast-perceivable").withDefault(
+export const minContrastDiscernible = createNonCss<number>("min-contrast-discernible").withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(wcagContrastLevel) === "aa" ? 3 : 4.5
 );
@@ -418,53 +418,53 @@ export const neutralFillStealthActive = createStateToken(neutralFillStealthSet, 
 /** @public */
 export const neutralFillStealthFocus = createStateToken(neutralFillStealthSet, "focus");
 
-// Neutral Fill Perceivable (previously "Strong")
+// Neutral Fill Discernible (previously "Strong")
 
-const neutralFillPerceivableName = "neutral-fill-perceivable";
-
-/** @public */
-export const neutralFillPerceivableRestDelta = createDelta(neutralFillPerceivableName, "rest", 0);
+const neutralFillDiscernibleName = "neutral-fill-discernible";
 
 /** @public */
-export const neutralFillPerceivableHoverDelta = createDelta(neutralFillPerceivableName, "hover", 8);
+export const neutralFillDiscernibleRestDelta = createDelta(neutralFillDiscernibleName, "rest", 0);
 
 /** @public */
-export const neutralFillPerceivableActiveDelta = createDelta(neutralFillPerceivableName, "active", -5);
+export const neutralFillDiscernibleHoverDelta = createDelta(neutralFillDiscernibleName, "hover", 8);
 
 /** @public */
-export const neutralFillPerceivableFocusDelta = createDelta(neutralFillPerceivableName, "focus", 0);
+export const neutralFillDiscernibleActiveDelta = createDelta(neutralFillDiscernibleName, "active", -5);
 
 /** @public */
-export const neutralFillPerceivableRecipe = createRecipeInteractive(neutralFillPerceivableName,
+export const neutralFillDiscernibleFocusDelta = createDelta(neutralFillDiscernibleName, "focus", 0);
+
+/** @public */
+export const neutralFillDiscernibleRecipe = createRecipeInteractive(neutralFillDiscernibleName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(minContrastPerceivable),
-                resolve(neutralFillPerceivableRestDelta),
-                resolve(neutralFillPerceivableHoverDelta),
-                resolve(neutralFillPerceivableActiveDelta),
-                resolve(neutralFillPerceivableFocusDelta)
+                resolve(minContrastDiscernible),
+                resolve(neutralFillDiscernibleRestDelta),
+                resolve(neutralFillDiscernibleHoverDelta),
+                resolve(neutralFillDiscernibleActiveDelta),
+                resolve(neutralFillDiscernibleFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralFillPerceivableSet = createSet(neutralFillPerceivableRecipe);
+const neutralFillDiscernibleSet = createSet(neutralFillDiscernibleRecipe);
 
 /** @public */
-export const neutralFillPerceivableRest = createStateToken(neutralFillPerceivableSet, "rest");
+export const neutralFillDiscernibleRest = createStateToken(neutralFillDiscernibleSet, "rest");
 
 /** @public */
-export const neutralFillPerceivableHover = createStateToken(neutralFillPerceivableSet, "hover");
+export const neutralFillDiscernibleHover = createStateToken(neutralFillDiscernibleSet, "hover");
 
 /** @public */
-export const neutralFillPerceivableActive = createStateToken(neutralFillPerceivableSet, "active");
+export const neutralFillDiscernibleActive = createStateToken(neutralFillDiscernibleSet, "active");
 
 /** @public */
-export const neutralFillPerceivableFocus = createStateToken(neutralFillPerceivableSet, "focus");
+export const neutralFillDiscernibleFocus = createStateToken(neutralFillDiscernibleSet, "focus");
 
 // Neutral Stroke Subtle (previously just "Neutral Stroke")
 
@@ -513,53 +513,53 @@ export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet
 /** @public */
 export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus");
 
-// Neutral Stroke Perceivable (previously "Strong")
+// Neutral Stroke Discernible (previously "Strong")
 
-const neutralStrokePerceivableName = "neutral-stroke-perceivable";
-
-/** @public */
-export const neutralStrokePerceivableRestDelta = createDelta(neutralStrokePerceivableName, "rest", 0);
+const neutralStrokeDiscernibleName = "neutral-stroke-discernible";
 
 /** @public */
-export const neutralStrokePerceivableHoverDelta = createDelta(neutralStrokePerceivableName, "hover", 8);
+export const neutralStrokeDiscernibleRestDelta = createDelta(neutralStrokeDiscernibleName, "rest", 0);
 
 /** @public */
-export const neutralStrokePerceivableActiveDelta = createDelta(neutralStrokePerceivableName, "active", -4);
+export const neutralStrokeDiscernibleHoverDelta = createDelta(neutralStrokeDiscernibleName, "hover", 8);
 
 /** @public */
-export const neutralStrokePerceivableFocusDelta = createDelta(neutralStrokePerceivableName, "focus", 0);
+export const neutralStrokeDiscernibleActiveDelta = createDelta(neutralStrokeDiscernibleName, "active", -4);
 
 /** @public */
-export const neutralStrokePerceivableRecipe = createRecipeInteractive(neutralStrokePerceivableName,
+export const neutralStrokeDiscernibleFocusDelta = createDelta(neutralStrokeDiscernibleName, "focus", 0);
+
+/** @public */
+export const neutralStrokeDiscernibleRecipe = createRecipeInteractive(neutralStrokeDiscernibleName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
             contrastAndDeltaSwatchSet(
                 resolve(neutralPalette),
                 reference || resolve(fillColor),
-                resolve(minContrastPerceivable),
-                resolve(neutralStrokePerceivableRestDelta),
-                resolve(neutralStrokePerceivableHoverDelta),
-                resolve(neutralStrokePerceivableActiveDelta),
-                resolve(neutralStrokePerceivableFocusDelta)
+                resolve(minContrastDiscernible),
+                resolve(neutralStrokeDiscernibleRestDelta),
+                resolve(neutralStrokeDiscernibleHoverDelta),
+                resolve(neutralStrokeDiscernibleActiveDelta),
+                resolve(neutralStrokeDiscernibleFocusDelta)
             ),
             reference || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
 
-const neutralStrokePerceivableSet = createSet(neutralStrokePerceivableRecipe);
+const neutralStrokeDiscernibleSet = createSet(neutralStrokeDiscernibleRecipe);
 
 /** @public */
-export const neutralStrokePerceivableRest = createStateToken(neutralStrokePerceivableSet, "rest");
+export const neutralStrokeDiscernibleRest = createStateToken(neutralStrokeDiscernibleSet, "rest");
 
 /** @public */
-export const neutralStrokePerceivableHover = createStateToken(neutralStrokePerceivableSet, "hover");
+export const neutralStrokeDiscernibleHover = createStateToken(neutralStrokeDiscernibleSet, "hover");
 
 /** @public */
-export const neutralStrokePerceivableActive = createStateToken(neutralStrokePerceivableSet, "active");
+export const neutralStrokeDiscernibleActive = createStateToken(neutralStrokeDiscernibleSet, "active");
 
 /** @public */
-export const neutralStrokePerceivableFocus = createStateToken(neutralStrokePerceivableSet, "focus");
+export const neutralStrokeDiscernibleFocus = createStateToken(neutralStrokeDiscernibleSet, "focus");
 
 // Focus Stroke Outer
 
@@ -773,19 +773,19 @@ export const neutralFillInputFocus = createStateToken(neutralFillInputSet, "focu
 
 const neutralFillSecondaryName = "neutral-fill-secondary";
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryRestDelta = createDelta(neutralFillSecondaryName, "rest", 3);
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryHoverDelta = createDelta(neutralFillSecondaryName, "hover", 2);
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryActiveDelta = createDelta(neutralFillSecondaryName, "active", 1);
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryFocusDelta = createDelta(neutralFillSecondaryName, "focus", 3);
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryRecipe = createRecipeInteractive(neutralFillSecondaryName,
     (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
         interactiveSwatchSetAsOverlay(
@@ -805,44 +805,44 @@ export const neutralFillSecondaryRecipe = createRecipeInteractive(neutralFillSec
 /** @deprecated */
 const neutralFillSecondarySet = createSet(neutralFillSecondaryRecipe);
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryRest = createStateToken(neutralFillSecondarySet, "rest");
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryHover = createStateToken(neutralFillSecondarySet, "hover");
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryActive = createStateToken(neutralFillSecondarySet, "active");
 
-/** @public @deprecated Use "Subtle" or "Perceivable" instead */
+/** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryFocus = createStateToken(neutralFillSecondarySet, "focus");
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongRestDelta = neutralFillPerceivableRestDelta;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongRestDelta = neutralFillDiscernibleRestDelta;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongHoverDelta = neutralFillPerceivableHoverDelta;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongHoverDelta = neutralFillDiscernibleHoverDelta;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongActiveDelta = neutralFillPerceivableActiveDelta;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongActiveDelta = neutralFillDiscernibleActiveDelta;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongFocusDelta = neutralFillPerceivableFocusDelta;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongFocusDelta = neutralFillDiscernibleFocusDelta;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongRecipe = neutralFillPerceivableRecipe;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongRecipe = neutralFillDiscernibleRecipe;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongRest = neutralFillPerceivableRest;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongRest = neutralFillDiscernibleRest;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongHover = neutralFillPerceivableHover;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongHover = neutralFillDiscernibleHover;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongActive = neutralFillPerceivableActive;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongActive = neutralFillDiscernibleActive;
 
-/** @public @deprecated Use "Perceivable instead of "Strong" */
-export const neutralFillStrongFocus = neutralFillPerceivableFocus;
+/** @public @deprecated Use "Discernible instead of "Strong" */
+export const neutralFillStrongFocus = neutralFillDiscernibleFocus;
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeRestDelta = neutralStrokeSubtleRestDelta;

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -17,10 +17,10 @@ import {
     foregroundOnAccentFillReadableFocus,
     foregroundOnAccentFillReadableHover,
     foregroundOnAccentFillReadableRest,
-    neutralFillPerceivableActive,
-    neutralFillPerceivableFocus,
-    neutralFillPerceivableHover,
-    neutralFillPerceivableRest,
+    neutralFillDiscernibleActive,
+    neutralFillDiscernibleFocus,
+    neutralFillDiscernibleHover,
+    neutralFillDiscernibleRest,
     neutralFillStealthActive,
     neutralFillStealthFocus,
     neutralFillStealthHover,
@@ -29,10 +29,10 @@ import {
     neutralFillSubtleFocus,
     neutralFillSubtleHover,
     neutralFillSubtleRest,
-    neutralStrokePerceivableActive,
-    neutralStrokePerceivableFocus,
-    neutralStrokePerceivableHover,
-    neutralStrokePerceivableRest,
+    neutralStrokeDiscernibleActive,
+    neutralStrokeDiscernibleFocus,
+    neutralStrokeDiscernibleHover,
+    neutralStrokeDiscernibleRest,
     neutralStrokeReadableRest,
     neutralStrokeStrongActive,
     neutralStrokeStrongFocus,
@@ -124,11 +124,11 @@ export const neutralFillSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
 /**
  * @public
  */
-export const neutralFillPerceivableInteractiveSet: InteractiveTokenSet<Swatch> = {
-    rest: neutralFillPerceivableRest,
-    hover: neutralFillPerceivableHover,
-    active: neutralFillPerceivableActive,
-    focus: neutralFillPerceivableFocus,
+export const neutralFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralFillDiscernibleRest,
+    hover: neutralFillDiscernibleHover,
+    active: neutralFillDiscernibleActive,
+    focus: neutralFillDiscernibleFocus,
 };
 
 /**
@@ -154,11 +154,11 @@ export const neutralStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
 /**
  * @public
  */
-export const neutralStrokePerceivableInteractiveSet: InteractiveTokenSet<Swatch> = {
-    rest: neutralStrokePerceivableRest,
-    hover: neutralStrokePerceivableHover,
-    active: neutralStrokePerceivableActive,
-    focus: neutralStrokePerceivableFocus,
+export const neutralStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+    rest: neutralStrokeDiscernibleRest,
+    hover: neutralStrokeDiscernibleHover,
+    active: neutralStrokeDiscernibleActive,
+    focus: neutralStrokeDiscernibleFocus,
 };
 
 /**
@@ -188,9 +188,9 @@ export const neutralFillControlStyles: Styles = {
  *
  * @public
  */
-export const neutralOutlinePerceivableControlStyles: Styles = {
+export const neutralOutlineDiscernibleControlStyles: Styles = {
     backgroundFill: neutralFillSubtleInteractiveSet,
-    borderFill: neutralStrokePerceivableInteractiveSet,
+    borderFill: neutralStrokeDiscernibleInteractiveSet,
     foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
 };
 
@@ -199,10 +199,10 @@ export const neutralOutlinePerceivableControlStyles: Styles = {
  *
  * @public
  */
-export const neutralFillPerceivableControlStyles: Styles = {
-    backgroundFill: neutralFillPerceivableInteractiveSet,
+export const neutralFillDiscernibleControlStyles: Styles = {
+    backgroundFill: neutralFillDiscernibleInteractiveSet,
     borderFill: "transparent",
-    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillPerceivableInteractiveSet),
+    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillDiscernibleInteractiveSet),
 };
 
 /**
@@ -212,7 +212,7 @@ export const neutralFillPerceivableControlStyles: Styles = {
  */
 export const neutralOutlineControlStyles: Styles = {
     backgroundFill: fillColor,
-    borderFill: neutralStrokePerceivableInteractiveSet,
+    borderFill: neutralStrokeDiscernibleInteractiveSet,
     foregroundFill: neutralStrokeStrongRest,
 };
 

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
@@ -1,4 +1,4 @@
-import { accentFillControlStyles, neutralOutlinePerceivableControlStyles } from "@adaptive-web/adaptive-ui";
+import { accentFillControlStyles, neutralOutlineDiscernibleControlStyles } from "@adaptive-web/adaptive-ui";
 import checkmarkIcon from "@fluentui/svg-icons/icons/checkmark_16_regular.svg";
 import subtractIcon from "@fluentui/svg-icons/icons/subtract_16_regular.svg";
 import { DefaultDesignSystem } from "../../design-system.js";
@@ -25,7 +25,7 @@ export const checkboxDefinition = composeCheckbox(
                 {
                     part: CheckboxAnatomy.parts.control,
                 },
-                neutralOutlinePerceivableControlStyles
+                neutralOutlineDiscernibleControlStyles
             ],
             [
                 {

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -10,9 +10,9 @@ import {
     neutralFillSubtleHover,
     neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokePerceivableActive,
-    neutralStrokePerceivableHover,
-    neutralStrokePerceivableRest,
+    neutralStrokeDiscernibleActive,
+    neutralStrokeDiscernibleHover,
+    neutralStrokeDiscernibleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -81,7 +81,7 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeDiscernibleRest};
         border-radius: 50%;
         background: ${neutralFillSubtleRest};
         color: ${neutralForegroundRest};
@@ -90,12 +90,12 @@ export const aestheticStyles: ElementStyles = css`
 
     :host(:enabled:hover) .control {
         background: ${neutralFillSubtleHover};
-        border-color: ${neutralStrokePerceivableHover};
+        border-color: ${neutralStrokeDiscernibleHover};
     }
 
     :host(:enabled:active) .control {
         background: ${neutralFillSubtleActive};
-        border-color: ${neutralStrokePerceivableActive};
+        border-color: ${neutralStrokeDiscernibleActive};
     }
 
     :host(:focus-visible) .control {

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -5,7 +5,7 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     neutralForegroundRest,
-    neutralStrokePerceivableRest,
+    neutralStrokeDiscernibleRest,
     neutralStrokeSubtleActive,
     neutralStrokeSubtleHover,
 } from "@adaptive-web/adaptive-ui";
@@ -156,7 +156,7 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .track {
-        background: ${neutralStrokePerceivableRest};
+        background: ${neutralStrokeDiscernibleRest};
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -13,9 +13,9 @@ import {
     neutralFillSubtleHover,
     neutralFillSubtleRest,
     neutralForegroundRest,
-    neutralStrokePerceivableActive,
-    neutralStrokePerceivableHover,
-    neutralStrokePerceivableRest,
+    neutralStrokeDiscernibleActive,
+    neutralStrokeDiscernibleHover,
+    neutralStrokeDiscernibleRest,
     strokeWidth,
     typeRampBase,
 } from "@adaptive-web/adaptive-ui";
@@ -74,19 +74,19 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc(((${heightNumber} / 2) + ${designUnit}) * 2px);
         height: calc(((${heightNumber} / 2) + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokePerceivableRest};
+        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeDiscernibleRest};
         border-radius: calc(${heightNumber} * 1px);
         padding: 4px;
         background: ${neutralFillSubtleRest};
     }
 
     :host(:enabled:hover) .switch {
-        border-color: ${neutralStrokePerceivableHover};
+        border-color: ${neutralStrokeDiscernibleHover};
         background: ${neutralFillSubtleHover};
     }
 
     :host(:enabled:active) .switch {
-        border-color: ${neutralStrokePerceivableActive};
+        border-color: ${neutralStrokeDiscernibleActive};
         background: ${neutralFillSubtleActive};
     }
 


### PR DESCRIPTION
# Pull Request

## Description

Update "Perceivable" color recipes to "Discernible".

Perceivable identifies that something can be perceived, but does not convey the idea of clarity or distinction that we intend by these accessible color recipes.

## Reviewer Notes

This is one big find and replace.

## Test Plan

Tested the Explorer site and Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.
