### PR TITLE
Empty labels not being hidden

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-8b329238-ae80-44fe-93f1-26f5993770dc.json
+++ b/change/@adaptive-web-adaptive-web-components-8b329238-ae80-44fe-93f1-26f5993770dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "hide unused labels",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -48,7 +48,7 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -30,7 +30,7 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -29,7 +29,6 @@ export const templateStyles: ElementStyles = css`
 
     ::slotted([role="combobox"]) {
         box-sizing: border-box;
-        min-width: 250px;
         width: auto;
         border: none;
         outline: none;

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.ts
@@ -1,4 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
+import { designUnit, elevationFlyout, layerCornerRadius, layerFillFixedPlus1, strokeWidth } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -39,4 +40,13 @@ export const templateStyles: ElementStyles = css`
 /**
  * Visual styles including Adaptive UI tokens.
  */
-export const aestheticStyles: ElementStyles = css``;
+export const aestheticStyles: ElementStyles = css`
+    .loading-display,
+    .no-options-display {
+        border: calc(${strokeWidth} * 1px) solid transparent;
+        border-radius: calc(${layerCornerRadius} * 1px);
+        padding: calc(${designUnit} * 1px);
+        background: ${layerFillFixedPlus1};
+        box-shadow: ${elevationFlyout};
+    }
+`;

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -58,7 +58,7 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -63,7 +63,7 @@ export const templateStyles: ElementStyles = css`
         opacity: 0;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -41,7 +41,7 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -26,7 +26,7 @@ export const templateStyles: ElementStyles = css`
         /* position: relative; */
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -32,7 +32,7 @@ export const templateStyles: ElementStyles = css`
         -webkit-appearance: none;
     }
 
-    .label__hidden {
+    .label.label__hidden {
         display: none;
         visibility: hidden;
     }


### PR DESCRIPTION
# Pull Request

## Description
-  A number of form elements were not hiding empty labels due to selector specificity issue
- Picker "no results" display was unstyled
- Picker input had a minimum width set that could make it wider than the parent

## Checklist

### General
- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
