### PR TITLE
Finish semantic color recipe system and foundation style modules

### DIFF
--- a/change/@adaptive-web-adaptive-ui-68e8e03e-6a83-4f42-acfd-d32ac1791795.json
+++ b/change/@adaptive-web-adaptive-ui-68e8e03e-6a83-4f42-acfd-d32ac1791795.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Finish semantic color recipe system and foundation style modules",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-45ec4d64-27db-48f6-b201-997549877931.json
+++ b/change/@adaptive-web-adaptive-web-components-45ec4d64-27db-48f6-b201-997549877931.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Finish semantic color recipe system and foundation style modules",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -1,16 +1,21 @@
 import {
-    accentFillControlStyles,
-    accentForegroundReadableStyles,
+    accentFillDiscernibleControlStyles,
+    accentFillReadableControlStyles,
+    accentFillStealthControlStyles,
+    accentFillSubtleControlStyles,
+    accentForegroundReadableControlStyles,
+    accentOutlineDiscernibleControlStyles,
     fillColor,
-    neutralFillControlStyles,
+    neutralDividerDiscernibleElementStyles,
+    neutralDividerSubtleElementStyles,
     neutralFillDiscernibleControlStyles,
-    neutralForegroundReadableStyles,
-    neutralForegroundStrongStyles,
-    neutralOutlineControlStyles,
+    neutralFillReadableControlStyles,
+    neutralFillStealthControlStyles,
+    neutralFillSubtleControlStyles,
+    neutralForegroundReadableElementStyles,
+    neutralForegroundStrongElementStyles,
     neutralOutlineDiscernibleControlStyles,
-    neutralStealthControlStyles,
     neutralStrokeReadableRest,
-    neutralStrokeSubtleRest,
     SwatchRGB,
 } from "@adaptive-web/adaptive-ui";
 import { parseColorHexRGB } from "@microsoft/fast-colors";
@@ -30,52 +35,68 @@ import "./style-example.js";
 import "./swatch.js";
 
 const backplateComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => accentFillControlStyles}">
-        Accent fill
+    <app-style-example :styles="${x => accentFillReadableControlStyles}">
+        Accent readable
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillControlStyles}">
-        Neutral fill
+    <app-style-example :styles="${x => accentFillStealthControlStyles}">
+        Accent stealth
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralOutlineControlStyles}">
-        Neutral outline
+    <app-style-example :styles="${x => accentFillSubtleControlStyles}">
+        Accent subtle
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralStealthControlStyles}">
+    <app-style-example :styles="${x => neutralFillReadableControlStyles}">
+        Neutral readable
+    </app-style-example>
+
+    <app-style-example :styles="${x => neutralFillStealthControlStyles}">
         Neutral stealth
+    </app-style-example>
+
+    <app-style-example :styles="${x => neutralFillSubtleControlStyles}">
+        Neutral subtle
     </app-style-example>
 `;
 
 const textComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => neutralForegroundStrongStyles}">
-        Neutral
+    <app-style-example :styles="${x => accentForegroundReadableControlStyles}">
+        Accent control
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralForegroundReadableStyles}">
-        Hint / placeholder
+    <app-style-example :styles="${x => neutralForegroundStrongElementStyles}">
+        Neutral element
     </app-style-example>
 
-    <app-style-example :styles="${x => accentForegroundReadableStyles}">
-        Accent
+    <app-style-example :styles="${x => neutralForegroundReadableElementStyles}">
+        Hint / placeholder element
     </app-style-example>
 `;
 
 const formComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => neutralFillControlStyles}">
-        Text field
+    <app-style-example :styles="${x => accentOutlineDiscernibleControlStyles}">
+        Accent outline
+    </app-style-example>
+
+    <app-style-example :styles="${x => accentFillDiscernibleControlStyles}">
+        Accent discernible
     </app-style-example>
 
     <app-style-example :styles="${x => neutralOutlineDiscernibleControlStyles}">
-        Checkbox (unchecked)
+        Neutral outline
     </app-style-example>
 
     <app-style-example :styles="${x => neutralFillDiscernibleControlStyles}">
-        Checkbox (checked)
+        Neutral discernible
     </app-style-example>
 
-    <app-style-example :styles="${{"color": neutralStrokeSubtleRest}}">
-        Divider
+    <app-style-example :styles="${x => neutralDividerSubtleElementStyles}">
+        Divider subtle
+    </app-style-example>
+
+    <app-style-example :styles="${x => neutralDividerDiscernibleElementStyles}">
+        Divider discernible
     </app-style-example>
 `;
 

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -24,8 +24,26 @@ export const accentFillActive: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const accentFillActiveDelta: DesignToken<number>;
 
+// @public (undocumented)
+export const accentFillDiscernibleActive: CSSDesignToken<Swatch>;
+
 // @public
-export const accentFillControlStyles: Styles;
+export const accentFillDiscernibleControlStyles: Styles;
+
+// @public (undocumented)
+export const accentFillDiscernibleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillDiscernibleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentFillDiscernibleRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillFocus: CSSDesignToken<Swatch>;
@@ -42,19 +60,22 @@ export const accentFillHoverDelta: DesignToken<number>;
 // @public (undocumented)
 export const accentFillReadableActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillReadableActiveDelta: DesignToken<number>;
+
+// @public
+export const accentFillReadableControlStyles: Styles;
 
 // @public (undocumented)
 export const accentFillReadableFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const accentFillReadableHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -66,7 +87,7 @@ export const accentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const accentFillReadableRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentFillReadableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -77,6 +98,48 @@ export const accentFillRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentFillStealthActive: CSSDesignToken<Swatch>;
+
+// @public
+export const accentFillStealthControlStyles: Styles;
+
+// @public (undocumented)
+export const accentFillStealthFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillStealthHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentFillStealthRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillSubtleActive: CSSDesignToken<Swatch>;
+
+// @public
+export const accentFillSubtleControlStyles: Styles;
+
+// @public (undocumented)
+export const accentFillSubtleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillSubtleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentFillSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentFillSubtleRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundActive: CSSDesignToken<Swatch>;
@@ -97,7 +160,7 @@ export const accentForegroundHover: CSSDesignToken<Swatch>;
 export const accentForegroundHoverDelta: DesignToken<number>;
 
 // @public
-export const accentForegroundReadableStyles: Styles;
+export const accentForegroundReadableControlStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const accentForegroundRecipe: DesignToken<InteractiveColorRecipe>;
@@ -108,25 +171,46 @@ export const accentForegroundRest: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const accentForegroundRestDelta: DesignToken<number>;
 
+// @public
+export const accentOutlineDiscernibleControlStyles: Styles;
+
 // @public (undocumented)
 export const accentPalette: DesignToken<Palette<Swatch>>;
 
 // @public (undocumented)
-export const accentStrokeReadableActive: CSSDesignToken<Swatch>;
+export const accentStrokeDiscernibleActive: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
+export const accentStrokeDiscernibleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeDiscernibleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeDiscernibleRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableActive: CSSDesignToken<Swatch>;
+
+// @public @deprecated (undocumented)
 export const accentStrokeReadableActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const accentStrokeReadableFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentStrokeReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const accentStrokeReadableHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -138,8 +222,80 @@ export const accentStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const accentStrokeReadableRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const accentStrokeReadableRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const accentStrokeSafetyActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSafetyFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSafetyHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeSafetyRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStealthActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStealthFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStealthHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeStealthRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStrongActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStrongFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStrongHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeStrongRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSubtleActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSubtleFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSubtleHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const accentStrokeSubtleRest: CSSDesignToken<Swatch>;
 
 // @public
 export class BasePalette<T extends Swatch> implements Palette<T> {
@@ -169,12 +325,23 @@ export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference:
     focus: Swatch;
 };
 
+// @public
+export const blackOrWhiteDiscernibleRecipe: DesignToken<InteractiveColorRecipeBySet>;
+
+// @public
+export const blackOrWhiteReadableRecipe: DesignToken<InteractiveColorRecipeBySet>;
+
 // @public (undocumented)
 export const bodyFont: CSSDesignToken<string>;
 
 // @public
 export interface ColorRecipe<T = Swatch> {
     evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
+}
+
+// @public
+export interface ColorRecipeBySet<T = InteractiveSwatchSet> {
+    evaluate(resolver: DesignTokenResolver, reference: InteractiveSwatchSet): T;
 }
 
 // @public
@@ -200,7 +367,7 @@ export type ComponentParts = Record<string, string>;
 export function contrast(a: RelativeLuminance, b: RelativeLuminance): number;
 
 // @public
-export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection): InteractiveSwatchSet;
+export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
 
 // @public
 export function contrastSwatch(palette: Palette, reference: Swatch, minContrast: number, direction?: PaletteDirection): Swatch;
@@ -218,7 +385,7 @@ export const controlCornerRadius: CSSDesignToken<number>;
 export function deltaSwatch(palette: Palette, reference: Swatch, delta: number, direction?: PaletteDirection): Swatch;
 
 // @public
-export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection): InteractiveSwatchSet;
+export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
 
 // @public (undocumented)
 export const designUnit: CSSDesignToken<number>;
@@ -279,6 +446,54 @@ export const elevationTooltipSize: DesignToken<number>;
 // @public (undocumented)
 export const fillColor: CSSDesignToken<Swatch>;
 
+// @public (undocumented)
+export const fillDiscernibleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillDiscernibleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillDiscernibleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillDiscernibleRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillReadableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillReadableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillReadableRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillStealthActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillStealthFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillStealthHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillStealthRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillSubtleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillSubtleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillSubtleRestDelta: DesignToken<number>;
+
 // @public
 export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 
@@ -303,22 +518,22 @@ export const fontWeight: CSSDesignToken<number>;
 // @public @deprecated (undocumented)
 export const foregroundOnAccentActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableRest: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
@@ -338,6 +553,10 @@ export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, mi
 
 // @public
 export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet> {
+}
+
+// @public
+export interface InteractiveColorRecipeBySet extends ColorRecipeBySet {
 }
 
 // @public
@@ -458,6 +677,12 @@ export const minContrastDiscernible: DesignToken<number>;
 export const minContrastReadable: DesignToken<number>;
 
 // @public (undocumented)
+export const minContrastSafety: DesignToken<number>;
+
+// @public (undocumented)
+export const minContrastSubtle: DesignToken<number>;
+
+// @public (undocumented)
 export const neutralAsOverlay: DesignToken<boolean>;
 
 // @public (undocumented)
@@ -466,19 +691,22 @@ export const neutralBaseColor: CSSDesignToken<string>;
 // @public (undocumented)
 export const neutralBaseSwatch: DesignToken<Swatch>;
 
+// @public
+export const neutralDividerDiscernibleElementStyles: Styles;
+
+// @public
+export const neutralDividerSubtleElementStyles: Styles;
+
 // @public @deprecated (undocumented)
 export const neutralFillActive: CSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillActiveDelta: DesignToken<number>;
 
-// @public
-export const neutralFillControlStyles: Styles;
-
 // @public (undocumented)
 export const neutralFillDiscernibleActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillDiscernibleActiveDelta: DesignToken<number>;
 
 // @public
@@ -487,13 +715,13 @@ export const neutralFillDiscernibleControlStyles: Styles;
 // @public (undocumented)
 export const neutralFillDiscernibleFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillDiscernibleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralFillDiscernibleHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -505,7 +733,7 @@ export const neutralFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralFillDiscernibleRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillDiscernibleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -547,6 +775,27 @@ export const neutralFillInputRest: CSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const neutralFillInputRestDelta: DesignToken<number>;
 
+// @public (undocumented)
+export const neutralFillReadableActive: CSSDesignToken<Swatch>;
+
+// @public
+export const neutralFillReadableControlStyles: Styles;
+
+// @public (undocumented)
+export const neutralFillReadableFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillReadableHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const neutralFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralFillReadableRest: CSSDesignToken<Swatch>;
+
 // @public @deprecated (undocumented)
 export const neutralFillRecipe: DesignToken<InteractiveColorRecipe>;
 
@@ -586,19 +835,22 @@ export const neutralFillSecondaryRestDelta: DesignToken<number>;
 // @public (undocumented)
 export const neutralFillStealthActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStealthActiveDelta: DesignToken<number>;
+
+// @public
+export const neutralFillStealthControlStyles: Styles;
 
 // @public (undocumented)
 export const neutralFillStealthFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStealthFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralFillStealthHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStealthHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -610,7 +862,7 @@ export const neutralFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralFillStealthRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillStealthRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -643,19 +895,22 @@ export const neutralFillStrongRestDelta: DesignToken<number>;
 // @public (undocumented)
 export const neutralFillSubtleActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSubtleActiveDelta: DesignToken<number>;
+
+// @public
+export const neutralFillSubtleControlStyles: Styles;
 
 // @public (undocumented)
 export const neutralFillSubtleFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralFillSubtleHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -667,7 +922,7 @@ export const neutralFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralFillSubtleRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralFillSubtleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -698,7 +953,7 @@ export const neutralForegroundHoverDelta: DesignToken<number>;
 export const neutralForegroundMinContrast: DesignToken<number>;
 
 // @public
-export const neutralForegroundReadableStyles: Styles;
+export const neutralForegroundReadableElementStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipe>;
@@ -710,19 +965,13 @@ export const neutralForegroundRest: CSSDesignToken<Swatch>;
 export const neutralForegroundRestDelta: DesignToken<number>;
 
 // @public
-export const neutralForegroundStrongStyles: Styles;
-
-// @public
-export const neutralOutlineControlStyles: Styles;
+export const neutralForegroundStrongElementStyles: Styles;
 
 // @public
 export const neutralOutlineDiscernibleControlStyles: Styles;
 
 // @public (undocumented)
 export const neutralPalette: DesignToken<Palette<Swatch>>;
-
-// @public
-export const neutralStealthControlStyles: Styles;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeActive: CSSDesignToken<Swatch>;
@@ -733,19 +982,19 @@ export const neutralStrokeActiveDelta: DesignToken<number>;
 // @public (undocumented)
 export const neutralStrokeDiscernibleActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeDiscernibleFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeDiscernibleHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -757,7 +1006,7 @@ export const neutralStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>
 // @public (undocumented)
 export const neutralStrokeDiscernibleRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -811,19 +1060,19 @@ export const neutralStrokeInputRestDelta: DesignToken<number>;
 // @public (undocumented)
 export const neutralStrokeReadableActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeReadableActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeReadableFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeReadableHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -835,7 +1084,7 @@ export const neutralStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralStrokeReadableRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeReadableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
@@ -848,27 +1097,63 @@ export const neutralStrokeRest: CSSDesignToken<Swatch>;
 export const neutralStrokeRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
+export const neutralStrokeSafetyActive: CSSDesignToken<Swatch>;
 
 // @public (undocumented)
+export const neutralStrokeSafetyFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSafetyHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokeSafetyRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStealthActive: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStealthFocus: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStealthHover: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
+
+// @public (undocumented)
+export const neutralStrokeStealthRest: CSSDesignToken<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
+
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeStrongFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeStrongHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongMinContrast: DesignToken<number>;
 
 // @public (undocumented)
@@ -877,25 +1162,25 @@ export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralStrokeStrongRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeStrongRestDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeSubtleActive: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeSubtleActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeSubtleFocus: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const neutralStrokeSubtleHover: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -907,7 +1192,7 @@ export const neutralStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 // @public (undocumented)
 export const neutralStrokeSubtleRest: CSSDesignToken<Swatch>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const neutralStrokeSubtleRestDelta: DesignToken<number>;
 
 // @public
@@ -970,6 +1255,81 @@ export const StandardFontWeight: {
 
 // @public
 export type StateSelector = "hover" | "active" | FocusSelector;
+
+// @public (undocumented)
+export const strokeDiscernibleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeDiscernibleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeDiscernibleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeDiscernibleRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeReadableActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeReadableFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeReadableRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSafetyActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSafetyFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSafetyHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSafetyRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStealthActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStealthFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStealthHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStealthRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStrongActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStrongFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStrongHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStrongMinContrast: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStrongRestDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSubtleActiveDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSubtleFocusDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSubtleRestDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const strokeWidth: CSSDesignToken<number>;

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -3,7 +3,7 @@ import { InteractiveSet } from "../types.js";
 import { Swatch } from "./swatch.js";
 
 /**
- * A recipe that evaluates a single color value.
+ * A recipe that evaluates based on a single optional reference color value.
  *
  * @public
  */
@@ -12,7 +12,7 @@ export interface ColorRecipe<T = Swatch> {
      * Evaluate a color recipe.
      *
      * @param resolver - A function that resolves design tokens
-     * @param reference - The reference color, implementation defaults to `fillColor`, but sometimes overridden for nested color recipes
+     * @param reference - The reference color, implementation defaults to `fillColor`, but allows for overriding for nested color recipes
      */
     evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
 }
@@ -30,3 +30,28 @@ export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet
  * @public
  */
 export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {}
+
+/**
+ * A recipe that evaluates based on an interactive set of color values.
+ * 
+ * @remarks
+ * This offers more control than {@link ColorRecipe} for cases where the recipe needs to take the full set into consideration.
+ *
+ * @public
+ */
+export interface ColorRecipeBySet<T = InteractiveSwatchSet> {
+    /**
+     * Evaluate a color recipe set.
+     *
+     * @param resolver - A function that resolves design tokens
+     * @param reference - The reference set, since there is no equivalent to `fillColor` here, it must be provided
+     */
+    evaluate(resolver: DesignTokenResolver, reference: InteractiveSwatchSet): T;
+}
+
+/**
+ * A recipe that evaluates a color value for rest, hover, active, and focus states.
+ *
+ * @public
+ */
+export interface InteractiveColorRecipeBySet extends ColorRecipeBySet {}

--- a/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
@@ -1,6 +1,6 @@
 import { Palette, PaletteDirection, resolvePaletteDirection } from "../palette.js";
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { Swatch, SwatchRGB } from "../swatch.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
@@ -13,6 +13,7 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param activeDelta - The active state offset from `reference`
  * @param focusDelta - The focus state offset from `reference`
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
+ * @param zeroAsTransparent - Treat a zero offset as transparent, defaults to true
  * @returns The interactive set of Swatches
  *
  * @public
@@ -24,15 +25,25 @@ export function deltaSwatchSet(
     hoverDelta: number,
     activeDelta: number,
     focusDelta: number,
-    direction: PaletteDirection = directionByIsDark(reference)
+    direction: PaletteDirection = directionByIsDark(reference),
+    zeroAsTransparent: boolean = true,
 ): InteractiveSwatchSet {
     const referenceIndex = palette.closestIndexOf(reference);
     const dir = resolvePaletteDirection(direction);
 
+    function getSwatch(delta: number): Swatch {
+        const swatch = palette.get(referenceIndex + dir * delta) as SwatchRGB;
+        if (zeroAsTransparent === true && delta === 0) {
+            return SwatchRGB.asOverlay(swatch, swatch);
+        } else {
+            return swatch;
+        }
+    }
+
     return {
-        rest: palette.get(referenceIndex + dir * restDelta),
-        hover: palette.get(referenceIndex + dir * hoverDelta),
-        active: palette.get(referenceIndex + dir * activeDelta),
-        focus: palette.get(referenceIndex + dir * focusDelta),
+        rest: getSwatch(restDelta),
+        hover: getSwatch(hoverDelta),
+        active: getSwatch(activeDelta),
+        focus: getSwatch(focusDelta),
     };
 }

--- a/packages/adaptive-ui/src/color/swatch.ts
+++ b/packages/adaptive-ui/src/color/swatch.ts
@@ -82,7 +82,7 @@ export class SwatchRGB implements Swatch {
      * @returns The color value in string format
      */
     toColorString() {
-        return this.color.a < 1 ? this.color.toStringWebRGBA() : this.color.toStringHexRGB();
+        return this.color.a === 0 ? "transparent" : this.color.a < 1 ? this.color.toStringWebRGBA() : this.color.toStringHexRGB();
     }
 
     /**

--- a/packages/adaptive-ui/src/color/utilities/conditional.ts
+++ b/packages/adaptive-ui/src/color/utilities/conditional.ts
@@ -1,0 +1,27 @@
+import { InteractiveSwatchSet } from "../recipe.js";
+import { SwatchRGB } from "../swatch.js";
+import { _white } from "./color-constants.js";
+
+/**
+ * Return an interactive set of the provided tokens or a no-op "transparent" set of tokens.
+ *
+ * @param set - The swatch set to return if the condition is true.
+ * @param condition - The condition.
+ * @returns The provided swatch set or a "transparent" swatch set.
+ */
+export function conditionalSwatchSet(
+    set: InteractiveSwatchSet,
+    condition: boolean
+): InteractiveSwatchSet {
+    if (condition) {
+        return set;
+    }
+
+    const transparent = SwatchRGB.asOverlay(_white, _white);
+    return {
+        rest: transparent,
+        hover: transparent,
+        active: transparent,
+        focus: transparent,
+    };
+}

--- a/packages/adaptive-ui/src/design-tokens/README.md
+++ b/packages/adaptive-ui/src/design-tokens/README.md
@@ -1,12 +1,14 @@
 # Design Tokens
 
-This directory defines a specific set of design tokens that are generally useful for building components and experiences. Token values can be updated to reflect your visual design. We've found you can get a long way with these foundational tokens, but they don't provide for every possible visual design you might have.
+This directory defines a specific set of design tokens that are generally useful for building components and experiences. Token values can be updated to reflect your visual design.
+
+We've found you can get a long way with these foundational tokens. If you have a design that necessitates more control, you can easily create your own tokens and sets. Extending the foundation will speed your adoption.
 
 These predefined tokens exist both because they are a good foundation, as well as they have already been published and are in use by consuming design systems. This package is evolving to provide more control in defining your complete token needs.
 
 ## Color
 
-Color has specific requirements for accessibility. The updated color token model is designed to provide the flexibility you need in crafting your visual design, while ensuring that design will always meet contrast requirements. As a bonus, it adds automatic support for increased contrast preferences.
+Color has specific requirements for accessibility. This color token model is designed to provide the flexibility you need in crafting your visual design, while ensuring that design will always meet contrast requirements. This includes bonuses like automatic support for dark mode and increased contrast preferences.
 
 Most color tokens come as an interactive set for rest, hover, active, and focus states.
 
@@ -38,13 +40,13 @@ Meets accessibility requirements for 3:1 contrast relative to its context in AA 
 
 #### Readable
 
-Considered to be readable from a contrast perspective. Safe for use on small text, though probably reads more like "hint" or "placeholder" text.
+Considered to be readable from a contrast perspective. Safe for use on small text. With a low saturation palette (neutral) this will read as "hint" or "placeholder" text.
 
 Meets accessibility requirements for 4.5:1 contrast relative to its context in AA mode. Increases to 7:1 in AAA mode.
 
 #### Strong
 
-Considered to be readable from a contrast perspective. Intended for use on small text, with more contrast than "Readable".
+Considered to be readable from a contrast perspective. Intended for use on small or body text, having more contrast than "Readable", and tends to appear as "black".
 
 ### Application
 
@@ -64,13 +66,11 @@ The combinations of recipes currently implemented:
 
 |                    | Safety | Stealth | Subtle | Discernible (3:1) | Readable (4.5:1) | Strong |
 | ------------------ | ------ | ------- | ------ | ----------------- | ---------------- | ------ |
-| Neutral fill       | -      | ✓       | ✓      | ✓                | o                | -      |
-| Neutral stroke     | o      | o       | ✓      | ✓                | ✓                | ✓      |
-| Accent fill        | -      | o       | o      | o                 | ✓                | -      |
-| Accent stroke      | o      | o       | o      | o                 | ✓                | -      |
+| Neutral fill       | -      | ✓       | ✓      | ✓                | ✓                | -      |
+| Neutral stroke     | ✓      | ✓       | ✓      | ✓                | ✓                | ✓      |
+| Accent fill        | -      | ✓       | ✓      | ✓                 | ✓                | -      |
+| Accent stroke      | ✓      | ✓       | ✓      | ✓                 | ✓                | ✓      |
 
 ✓ = implemented
-
-o = coming soon
 
 \- = not applicable

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,23 +1,33 @@
 import { CSSDesignToken, DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
-import { InteractiveColorRecipe } from "../color/recipe.js";
+import { InteractiveColorRecipe, InteractiveColorRecipeBySet, InteractiveSwatchSet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
 import type { Styles } from "../modules/types.js";
 import type { InteractiveSet, InteractiveTokenSet } from "../types.js";
 import {
+    accentFillDiscernibleInteractiveSet,
     accentFillReadableInteractiveSet,
+    accentFillStealthInteractiveSet,
+    accentFillSubtleInteractiveSet,
+    accentStrokeDiscernibleInteractiveSet,
     accentStrokeReadableInteractiveSet,
-    fillColor,
-    foregroundOnAccentFillReadableInteractiveSet,
+    accentStrokeReadableRecipe,
+    accentStrokeSafetyInteractiveSet,
+    blackOrWhiteDiscernibleRecipe,
+    blackOrWhiteReadableRecipe,
     neutralFillDiscernibleInteractiveSet,
+    neutralFillReadableInteractiveSet,
     neutralFillStealthInteractiveSet,
     neutralFillSubtleInteractiveSet,
     neutralStrokeDiscernibleInteractiveSet,
+    neutralStrokeDiscernibleRest,
     neutralStrokeReadableRest,
+    neutralStrokeSafetyInteractiveSet,
     neutralStrokeStrongInteractiveSet,
     neutralStrokeStrongRecipe,
     neutralStrokeStrongRest,
-    neutralStrokeSubtleInteractiveSet,
+    neutralStrokeSubtleRest,
 } from "./color.js";
+import { createNonCss } from "./create.js";
 
 function createForegroundSet(
     foregroundRecipe: DesignToken<InteractiveColorRecipe>,
@@ -45,98 +55,280 @@ function createForegroundSet(
     };
 }
 
+function createForegroundSetBySet(
+    foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>,
+    background: InteractiveTokenSet<Swatch>,
+): InteractiveTokenSet<Swatch> {
+    const foregroundBaseName = foregroundRecipe.name.replace("-recipe", "");
+    const backgroundBaseName = background.rest.name.replace("-rest", "");
+    const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
+
+    const set = createNonCss<InteractiveSwatchSet>(`${setName}-value`).withDefault(
+        (resolve: DesignTokenResolver) =>
+            {
+                const backgroundSet: InteractiveSwatchSet = {
+                    rest: resolve(background.rest),
+                    hover: resolve(background.hover),
+                    active: resolve(background.active),
+                    focus: resolve(background.focus),
+                }
+                return resolve(foregroundRecipe).evaluate(resolve, backgroundSet);
+            }
+    );
+
+    function createState(
+        state: keyof InteractiveSet<any>,
+    ): CSSDesignToken<Swatch> {
+        return DesignToken.create<Swatch>(`${setName}-${state}`).withDefault(
+            (resolve: DesignTokenResolver) =>
+                resolve(set)[state]
+        );
+    }
+
+    return {
+        rest: createState("rest"),
+        hover: createState("hover"),
+        active: createState("active"),
+        focus: createState("focus")
+    };
+}
+
+function backgroundAndForeground(background: InteractiveTokenSet<Swatch>, foregroundRecipe: DesignToken<InteractiveColorRecipe>): Styles {
+    return {
+        backgroundFill: background,
+        foregroundFill: createForegroundSet(foregroundRecipe, "rest",  background),
+    };
+}
+
+function backgroundAndForegroundBySet(
+    background: InteractiveTokenSet<Swatch>,
+    foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>
+): Styles {
+    return {
+        backgroundFill: background,
+        foregroundFill: createForegroundSetBySet(foregroundRecipe,  background),
+    };
+}
+
 /**
- * Convenience style module for an accent-filled control.
+ * Convenience style module for an accent-filled stealth control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - accent stealth background
+ * - accent readable foreground (a11y)
+ * - accent safety border
  *
  * @public
  */
-export const accentFillControlStyles: Styles = {
-    backgroundFill: accentFillReadableInteractiveSet,
+export const accentFillStealthControlStyles: Styles = {
+    ...backgroundAndForeground(accentFillStealthInteractiveSet, accentStrokeReadableRecipe),
+    borderFill: accentStrokeSafetyInteractiveSet,
+};
+
+/**
+ * Convenience style module for an accent-filled subtle control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - accent subtle background
+ * - accent readable foreground (a11y)
+ * - accent subtle border
+ *
+ * @public
+ */
+export const accentFillSubtleControlStyles: Styles = {
+    ...backgroundAndForeground(accentFillSubtleInteractiveSet, accentStrokeReadableRecipe),
+    borderFill: accentStrokeSafetyInteractiveSet,
+};
+
+/**
+ * Convenience style module for an accent-filled discernible control (interactive).
+ *
+ * By default, the background meets accessibility for non-text elements, useful for a checked checkbox:
+ * - accent discernible background (a11y)
+ * - accent discernible foreground
+ * - no border
+ *
+ * @public
+ */
+export const accentFillDiscernibleControlStyles: Styles = {
+    ...backgroundAndForegroundBySet(accentFillDiscernibleInteractiveSet, blackOrWhiteDiscernibleRecipe),
+    borderFill: "transparent", // TODO Remove "transparent" borders, this is a hack for the Explorer app.
+};
+
+/**
+ * Convenience style module for an accent-filled readable control (interactive).
+ *
+ * By default, the fill meets accessibility for text elements, producing an inverted foreground, useful for a button or similar:
+ * - accent readable background
+ * - black or white foreground (a11y)
+ * - no border
+ *
+ * @public
+ */
+export const accentFillReadableControlStyles: Styles = {
+    ...backgroundAndForegroundBySet(accentFillReadableInteractiveSet, blackOrWhiteReadableRecipe),
     borderFill: "transparent",
-    foregroundFill: foregroundOnAccentFillReadableInteractiveSet,
 };
 
 /**
- * Convenience style module for a neutral stealth control.
+ * Convenience style module for an accent-outlined discernible control (interactive).
+ *
+ * By default, the outline meets accessibility for non-text elements, useful for an unchecked checkbox:
+ * - no background
+ * - accent readable foreground
+ * - accent discernible border
  *
  * @public
  */
-export const neutralStealthControlStyles: Styles = {
-    backgroundFill: neutralFillStealthInteractiveSet,
-    borderFill: "transparent",
-    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillStealthInteractiveSet),
+export const accentOutlineDiscernibleControlStyles: Styles = {
+    borderFill: accentStrokeDiscernibleInteractiveSet,
+    foregroundFill: accentStrokeReadableInteractiveSet,
 };
 
 /**
- * Convenience style module for a neutral control with accessibility requirements applied to the fill, like a selected checkbox.
+ * Convenience style module for an accent-colored text or icon control (interactive).
+ *
+ * By default, the foreground color meets accessibility, useful for a button, link, or similar:
+ * - no background
+ * - accent readable foreground (a11y)
+ * - no border
  *
  * @public
  */
-export const neutralFillDiscernibleControlStyles: Styles = {
-    backgroundFill: neutralFillDiscernibleInteractiveSet,
-    borderFill: "transparent",
-    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillDiscernibleInteractiveSet),
-};
-
-/**
- * Convenience style module for a neutral-filled control.
- *
- * @public
- */
-export const neutralFillControlStyles: Styles = {
-    backgroundFill: neutralFillSubtleInteractiveSet,
-    borderFill: neutralStrokeSubtleInteractiveSet,
-    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
-};
-
-/**
- * Convenience style module for a neutral control with accessibility requirements applied to the border, like an unselected checkbox.
- *
- * @public
- */
-export const neutralOutlineDiscernibleControlStyles: Styles = {
-    backgroundFill: neutralFillSubtleInteractiveSet,
-    borderFill: neutralStrokeDiscernibleInteractiveSet,
-    foregroundFill: createForegroundSet(neutralStrokeStrongRecipe, "rest", neutralFillSubtleInteractiveSet),
-};
-
-/**
- * Convenience style module for a neutral-outlined control.
- *
- * @public
- */
-export const neutralOutlineControlStyles: Styles = {
-    backgroundFill: fillColor,
-    borderFill: neutralStrokeDiscernibleInteractiveSet,
-    foregroundFill: neutralStrokeStrongRest,
-};
-
-/**
- * Convenience style module for accent-colored text or icons.
- *
- * @public
- */
-export const accentForegroundReadableStyles: Styles = {
+export const accentForegroundReadableControlStyles: Styles = {
     borderFill: "transparent",
     foregroundFill: accentStrokeReadableInteractiveSet,
 };
 
 /**
- * Convenience style module for neutral-colored hint or placeholder text or icons.
+ * Convenience style module for a neutral-filled stealth control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - neutral stealth background
+ * - neutral strong foreground (a11y)
+ * - neutral safety border
  *
  * @public
  */
-export const neutralForegroundReadableStyles: Styles = {
+export const neutralFillStealthControlStyles: Styles = {
+    ...backgroundAndForeground(neutralFillStealthInteractiveSet, neutralStrokeStrongRecipe),
+    borderFill: neutralStrokeSafetyInteractiveSet,
+};
+
+/**
+ * Convenience style module for a neutral-filled subtle control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - neutral subtle background
+ * - neutral strong foreground (a11y)
+ * - neutral subtle border
+ *
+ * @public
+ */
+export const neutralFillSubtleControlStyles: Styles = {
+    ...backgroundAndForeground(neutralFillSubtleInteractiveSet, neutralStrokeStrongRecipe),
+    borderFill: neutralStrokeSafetyInteractiveSet,
+};
+
+/**
+ * Convenience style module for a neutral-filled discernible control (interactive).
+ *
+ * By default, the background meets accessibility for non-text elements, useful for a checked checkbox:
+ * - neutral discernible background (a11y)
+ * - neutral discernible foreground
+ * - no border
+ *
+ * @public
+ */
+export const neutralFillDiscernibleControlStyles: Styles = {
+    ...backgroundAndForegroundBySet(neutralFillDiscernibleInteractiveSet, blackOrWhiteDiscernibleRecipe),
+    borderFill: "transparent",
+};
+
+/**
+ * Convenience style module for a neutral-filled readable control (interactive).
+ *
+ * By default, the fill meets accessibility for text elements, producing an inverted foreground, useful for a button or similar:
+ * - neutral readable background
+ * - neutral strong foreground (a11y)
+ * - no border
+ *
+ * @public
+ */
+export const neutralFillReadableControlStyles: Styles = {
+    ...backgroundAndForeground(neutralFillReadableInteractiveSet, neutralStrokeStrongRecipe),
+    borderFill: "transparent",
+};
+
+/**
+ * Convenience style module for a neutral-outlined discernible control (interactive).
+ *
+ * By default, the outline meets accessibility for non-text elements, useful for an unchecked checkbox:
+ * - no background
+ * - neutral strong foreground
+ * - neutral discernible border
+ *
+ * @public
+ */
+export const neutralOutlineDiscernibleControlStyles: Styles = {
+    borderFill: neutralStrokeDiscernibleInteractiveSet,
+    foregroundFill: neutralStrokeStrongInteractiveSet,
+};
+
+/**
+ * Convenience style module for neutral-colored hint or placeholder text or icons (not interactive).
+ *
+ * By default, the foreground color meets accessibility, useful for hint, placeholder, or secondary text:
+ * - no background
+ * - neutral readable foreground (a11y)
+ * - no border
+ *
+ * @public
+ */
+export const neutralForegroundReadableElementStyles: Styles = {
     borderFill: "transparent",
     foregroundFill: neutralStrokeReadableRest,
 };
 
 /**
- * Convenience style module for neutral-colored main text or icons.
+ * Convenience style module for neutral-colored regular text or icons (not interactive).
+ *
+ * By default, the foreground color meets accessibility, useful for regular text:
+ * - no background
+ * - neutral strong foreground (a11y)
+ * - no border
  *
  * @public
  */
-export const neutralForegroundStrongStyles: Styles = {
+export const neutralForegroundStrongElementStyles: Styles = {
     borderFill: "transparent",
-    foregroundFill: neutralStrokeStrongInteractiveSet,
+    foregroundFill: neutralStrokeStrongRest,
+};
+
+/**
+ * Convenience style module for neutral-colored divider for presentation role.
+ *
+ * By default, the foreground color does not meet accessibility, useful for presentation only:
+ * - no background
+ * - neutral subtle foreground
+ * - no border
+ *
+ * @public
+ */
+export const neutralDividerSubtleElementStyles: Styles = {
+    foregroundFill: neutralStrokeSubtleRest,
+};
+
+/**
+ * Convenience style module for neutral-colored divider for separator role.
+ *
+ * By default, the foreground color meets accessibility, useful for semantic separation:
+ * - no background
+ * - neutral discernible foreground (a11y)
+ * - no border
+ *
+ * @public
+ */
+export const neutralDividerDiscernibleElementStyles: Styles = {
+    foregroundFill: neutralStrokeDiscernibleRest,
 };

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -3,8 +3,7 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralFillControlStyles,
-    neutralForegroundRest,
+    neutralFillSubtleControlStyles,
     renderElementStyles,
     strokeWidth,
     typeRampBase,
@@ -58,7 +57,6 @@ export const aestheticStyles: ElementStyles = css`
         gap: 10px;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         border-radius: calc(${controlCornerRadius} * 1px);
-        color: ${neutralForegroundRest};
         fill: currentcolor;
     }
 
@@ -83,4 +81,4 @@ const moduleParams: StyleModuleEvaluateParameters = {
  * 
  * @internal
  */
-export const moduleStyles = renderElementStyles(neutralFillControlStyles, moduleParams);
+export const moduleStyles = renderElementStyles(neutralFillSubtleControlStyles, moduleParams);

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
@@ -1,4 +1,4 @@
-import { accentFillControlStyles, neutralOutlineDiscernibleControlStyles } from "@adaptive-web/adaptive-ui";
+import { accentFillReadableControlStyles, neutralOutlineDiscernibleControlStyles } from "@adaptive-web/adaptive-ui";
 import checkmarkIcon from "@fluentui/svg-icons/icons/checkmark_16_regular.svg";
 import subtractIcon from "@fluentui/svg-icons/icons/subtract_16_regular.svg";
 import { DefaultDesignSystem } from "../../design-system.js";
@@ -32,7 +32,7 @@ export const checkboxDefinition = composeCheckbox(
                     hostCondition: CheckboxAnatomy.conditions.checked,
                     part: CheckboxAnatomy.parts.control,
                 },
-                accentFillControlStyles
+                accentFillReadableControlStyles
             ]
         ],
     }


### PR DESCRIPTION
# Pull Request

## Description

#54 introduced the concept of semantic color recipes, associating accessible contrast requirements with component usage patterns. At that time I identified the patterns that exist, but only migrated existing recipes to the new pattern names.

This PR adds the remaining patterns and recipes identified there. It also builds the associated foundational style modules.

## Reviewer Notes

I tried to make the diff easier to understand (#68) but it still isn't lining up correctly.

One of the most significant changes might be consolidating the delta tokens. As I was introducing new patterns, duplicated for accent and neutral palettes, I wanted to incorporate another systems aspect that the decision around the variation in color between the interactive states could be consolidated. This will help with a future update that will enable more color palettes like a secondary accent, success, error, etc.

## Test Plan

I ran through the Explorer and component Storybook. Explorer has been updated to use all new style modules, but the components still mostly don't use the modules. That will come in a subsequent PR.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

The most immediate need is to update the component aesthetic styling to style modules. This is in process in another branch, but I needed more of the patterns in place to finish that implementation.