### PR TITLE
Setup style module pattern for remaining components

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-6e52aa65-2d1f-4d70-a1a3-458236ea36aa.json
+++ b/change/@adaptive-web-adaptive-web-components-6e52aa65-2d1f-4d70-a1a3-458236ea36aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Setup style module pattern for remaining components",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -182,6 +182,20 @@ export const AnchorConditions: {
 // @public
 export const anchoredRegionAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const AnchoredRegionAnatomy: ComponentAnatomy<typeof AnchoredRegionConditions, typeof AnchoredRegionParts>;
+
+// @public (undocumented)
+export const AnchoredRegionConditions: {
+    loaded: string;
+};
+
+// @public (undocumented)
+export const AnchoredRegionParts: {};
+
+// @public
+export const anchoredRegionStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -260,6 +274,12 @@ export const badgeTemplateStyles: ElementStyles;
 // @public
 export const breadcrumbAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const BreadcrumbAnatomy: ComponentAnatomy<typeof BreadcrumbConditions, typeof BreadcrumbParts>;
+
+// @public (undocumented)
+export const BreadcrumbConditions: {};
+
 // @public
 export const breadcrumbItemAestheticStyles: ElementStyles;
 
@@ -295,6 +315,14 @@ export const breadcrumbItemTemplate: (ds: DesignSystem) => ElementViewTemplate<F
 
 // @public
 export const breadcrumbItemTemplateStyles: ElementStyles;
+
+// @public (undocumented)
+export const BreadcrumbParts: {
+    list: string;
+};
+
+// @public
+export const breadcrumbStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -335,6 +363,29 @@ export const buttonTemplateStyles: ElementStyles;
 // @public
 export const calendarAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const CalendarAnatomy: ComponentAnatomy<typeof CalendarConditions, typeof CalendarParts>;
+
+// @public (undocumented)
+export const CalendarConditions: {};
+
+// @public (undocumented)
+export const CalendarParts: {
+    title: string;
+    month: string;
+    year: string;
+    days: string;
+    week: string;
+    weekDay: string;
+    weekDays: string;
+    day: string;
+    date: string;
+    today: string;
+};
+
+// @public
+export const calendarStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -345,6 +396,18 @@ export const calendarTemplateStyles: ElementStyles;
 
 // @public
 export const cardAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const CardAnatomy: ComponentAnatomy<typeof CardConditions, typeof CardParts>;
+
+// @public (undocumented)
+export const CardConditions: {};
+
+// @public (undocumented)
+export const CardParts: {};
+
+// @public
+export const cardStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -683,8 +746,27 @@ export function composeTreeView(ds: DesignSystem, options?: ComposeOptions<FASTT
 // @public
 export const dataGridAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const DataGridAnatomy: ComponentAnatomy<typeof DataGridConditions, typeof DataGridParts>;
+
 // @public
 export const dataGridCellAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions, typeof DataGridCellParts>;
+
+// @public (undocumented)
+export const DataGridCellConditions: {
+    cellTypeDefault: string;
+    cellTypeColumnHeader: string;
+    cellTypeRowHeader: string;
+};
+
+// @public (undocumented)
+export const DataGridCellParts: {};
+
+// @public
+export const dataGridCellStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -694,8 +776,31 @@ export const dataGridCellTemplate: (ds: DesignSystem) => ElementViewTemplate<FAS
 // @public
 export const dataGridCellTemplateStyles: ElementStyles;
 
+// @public (undocumented)
+export const DataGridConditions: {};
+
+// @public (undocumented)
+export const DataGridParts: {};
+
 // @public
 export const dataGridRowAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const DataGridRowAnatomy: ComponentAnatomy<typeof DataGridRowConditions, typeof DataGridRowParts>;
+
+// @public (undocumented)
+export const DataGridRowConditions: {
+    rowTypeDefault: string;
+    rowTypeHeader: string;
+    rowTypeStickyHeader: string;
+    selected: string;
+};
+
+// @public (undocumented)
+export const DataGridRowParts: {};
+
+// @public
+export const dataGridRowStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -704,6 +809,9 @@ export const dataGridRowTemplate: (ds: DesignSystem) => ElementViewTemplate<FAST
 
 // @public
 export const dataGridRowTemplateStyles: ElementStyles;
+
+// @public
+export const dataGridStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -733,6 +841,22 @@ export class DesignSystem {
 // @public
 export const dialogAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const DialogAnatomy: ComponentAnatomy<typeof DialogConditions, typeof DialogParts>;
+
+// @public (undocumented)
+export const DialogConditions: {};
+
+// @public (undocumented)
+export const DialogParts: {
+    positioningRegion: string;
+    overlay: string;
+    control: string;
+};
+
+// @public
+export const dialogStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -754,7 +878,6 @@ export const DisclosureConditions: {
 
 // @public (undocumented)
 export const DisclosureParts: {
-    disclosure: string;
     invoker: string;
 };
 
@@ -772,6 +895,21 @@ export const disclosureTemplateStyles: ElementStyles;
 // @public
 export const dividerAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const DividerAnatomy: ComponentAnatomy<typeof DividerConditions, typeof DividerParts>;
+
+// @public (undocumented)
+export const DividerConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
+// @public (undocumented)
+export const DividerParts: {};
+
+// @public
+export const dividerStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -783,6 +921,21 @@ export const dividerTemplateStyles: ElementStyles;
 // @public
 export const flipperAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const FlipperAnatomy: ComponentAnatomy<typeof FlipperConditions, typeof FlipperParts>;
+
+// @public (undocumented)
+export const FlipperConditions: {
+    next: string;
+    previous: string;
+};
+
+// @public (undocumented)
+export const FlipperParts: {
+    next: string;
+    previous: string;
+};
+
 // @public
 export const FlipperStatics: {
     readonly next: "flipper-next";
@@ -791,6 +944,9 @@ export const FlipperStatics: {
 
 // @public (undocumented)
 export type FlipperStatics = ValuesOf<typeof FlipperStatics>;
+
+// @public
+export const flipperStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -803,6 +959,26 @@ export const flipperTemplateStyles: ElementStyles;
 // @public
 export const horizontalScrollAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const HorizontalScrollAnatomy: ComponentAnatomy<typeof HorizontalScrollConditions, typeof HorizontalScrollParts>;
+
+// @public (undocumented)
+export const HorizontalScrollConditions: {};
+
+// @public (undocumented)
+export const HorizontalScrollParts: {
+    scrollArea: string;
+    scrollView: string;
+    content: string;
+    scrollPrevious: string;
+    previousFlipper: string;
+    scrollNext: string;
+    nextFlipper: string;
+};
+
+// @public
+export const horizontalScrollStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -813,6 +989,12 @@ export const horizontalScrollTemplateStyles: ElementStyles;
 
 // @public
 export const listboxAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof ListboxParts>;
+
+// @public (undocumented)
+export const ListboxConditions: {};
 
 // @public
 export const listboxOptionAestheticStyles: ElementStyles;
@@ -842,6 +1024,12 @@ export const listboxOptionTemplate: (ds: DesignSystem) => ElementViewTemplate<FA
 // @public
 export const listboxOptionTemplateStyles: ElementStyles;
 
+// @public (undocumented)
+export const ListboxParts: {};
+
+// @public
+export const listboxStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -852,6 +1040,14 @@ export const listboxTemplateStyles: ElementStyles;
 
 // @public
 export const menuAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const MenuAnatomy: ComponentAnatomy<typeof MenuConditions, typeof MenuParts>;
+
+// @public (undocumented)
+export const MenuConditions: {
+    submenu: string;
+};
 
 // @public
 export const menuItemAestheticStyles: ElementStyles;
@@ -890,6 +1086,12 @@ export const menuItemTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTMen
 
 // @public
 export const menuItemTemplateStyles: ElementStyles;
+
+// @public (undocumented)
+export const MenuParts: {};
+
+// @public
+export const menuStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -941,8 +1143,20 @@ export const numberFieldTemplateStyles: ElementStyles;
 // @public
 export const pickerAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const PickerAnatomy: ComponentAnatomy<typeof PickerConditions, typeof PickerParts>;
+
+// @public (undocumented)
+export const PickerConditions: {};
+
 // @public
 export const pickerListAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const PickerListAnatomy: ComponentAnatomy<typeof PickerListConditions, typeof PickerListParts>;
+
+// @public (undocumented)
+export const PickerListConditions: {};
 
 // @public
 export const pickerListItemAestheticStyles: ElementStyles;
@@ -967,6 +1181,12 @@ export const pickerListItemTemplate: (ds: DesignSystem) => ElementViewTemplate<F
 // @public
 export const pickerListItemTemplateStyles: ElementStyles;
 
+// @public (undocumented)
+export const PickerListParts: {};
+
+// @public
+export const pickerListStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -977,6 +1197,12 @@ export const pickerListTemplateStyles: ElementStyles;
 
 // @public
 export const pickerMenuAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const PickerMenuAnatomy: ComponentAnatomy<typeof PickerMenuConditions, typeof PickerMenuParts>;
+
+// @public (undocumented)
+export const PickerMenuConditions: {};
 
 // @public
 export const pickerMenuOptionAestheticStyles: ElementStyles;
@@ -1001,6 +1227,17 @@ export const pickerMenuOptionTemplate: (ds: DesignSystem) => ElementViewTemplate
 // @public
 export const pickerMenuOptionTemplateStyles: ElementStyles;
 
+// @public (undocumented)
+export const PickerMenuParts: {
+    optionsDisplay: string;
+    headerRegion: string;
+    footerRegion: string;
+    suggestionsAvailableAlert: string;
+};
+
+// @public
+export const pickerMenuStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -1008,6 +1245,17 @@ export const pickerMenuTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTP
 
 // @public
 export const pickerMenuTemplateStyles: ElementStyles;
+
+// @public (undocumented)
+export const PickerParts: {
+    region: string;
+    noOptionsDisplay: string;
+    loadingDisplay: string;
+    loadingProgress: string;
+};
+
+// @public
+export const pickerStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1084,6 +1332,23 @@ export const RadioConditions: {
 
 // @public
 export const radioGroupAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const RadioGroupAnatomy: ComponentAnatomy<typeof RadioGroupConditions, typeof RadioGroupParts>;
+
+// @public (undocumented)
+export const RadioGroupConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
+// @public (undocumented)
+export const RadioGroupParts: {
+    positioningRegion: string;
+};
+
+// @public
+export const radioGroupStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1185,6 +1450,21 @@ export const selectTemplateStyles: ElementStyles;
 // @public
 export const skeletonAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const SkeletonAnatomy: ComponentAnatomy<typeof SkeletonConditions, typeof SkeletonParts>;
+
+// @public (undocumented)
+export const SkeletonConditions: {
+    rectangle: string;
+    circle: string;
+};
+
+// @public (undocumented)
+export const SkeletonParts: {};
+
+// @public
+export const skeletonStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -1196,8 +1476,36 @@ export const skeletonTemplateStyles: ElementStyles;
 // @public
 export const sliderAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof SliderParts>;
+
+// @public (undocumented)
+export const SliderConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
 // @public
 export const sliderLabelAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const SliderLabelAnatomy: ComponentAnatomy<typeof SliderLabelConditions, typeof SliderLabelParts>;
+
+// @public (undocumented)
+export const SliderLabelConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
+// @public (undocumented)
+export const SliderLabelParts: {
+    container: string;
+    mark: string;
+    content: string;
+};
+
+// @public
+export const sliderLabelStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1206,6 +1514,18 @@ export const sliderLabelTemplate: (ds: DesignSystem) => ElementViewTemplate<FAST
 
 // @public
 export const sliderLabelTemplateStyles: ElementStyles;
+
+// @public (undocumented)
+export const SliderParts: {
+    positioningRegion: string;
+    track: string;
+    trackStart: string;
+    thumbContainer: string;
+    thumb: string;
+};
+
+// @public
+export const sliderStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1256,6 +1576,18 @@ export const TabConditions: {};
 // @public
 export const tabPanelAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const TabPanelAnatomy: ComponentAnatomy<typeof TabPanelConditions, typeof TabPanelParts>;
+
+// @public (undocumented)
+export const TabPanelConditions: {};
+
+// @public (undocumented)
+export const TabPanelParts: {};
+
+// @public
+export const tabPanelStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -1269,6 +1601,24 @@ export const TabParts: {};
 
 // @public
 export const tabsAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const TabsAnatomy: ComponentAnatomy<typeof TabsConditions, typeof TabsParts>;
+
+// @public (undocumented)
+export const TabsConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
+// @public (undocumented)
+export const TabsParts: {
+    tablist: string;
+    tabpanel: string;
+};
+
+// @public
+export const tabsStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1345,6 +1695,23 @@ export const textFieldTemplateStyles: ElementStyles;
 // @public
 export const toolbarAestheticStyles: ElementStyles;
 
+// @public (undocumented)
+export const ToolbarAnatomy: ComponentAnatomy<typeof ToolbarConditions, typeof ToolbarParts>;
+
+// @public (undocumented)
+export const ToolbarConditions: {
+    horizontal: string;
+    vertical: string;
+};
+
+// @public (undocumented)
+export const ToolbarParts: {
+    positioningRegion: string;
+};
+
+// @public
+export const toolbarStyleModules: StyleModules;
+
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
 // @public
@@ -1355,6 +1722,21 @@ export const toolbarTemplateStyles: ElementStyles;
 
 // @public
 export const tooltipAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const TooltipAnatomy: ComponentAnatomy<typeof TooltipConditions, typeof TooltipParts>;
+
+// @public (undocumented)
+export const TooltipConditions: {
+    show: string;
+    visible: string;
+};
+
+// @public (undocumented)
+export const TooltipParts: {};
+
+// @public
+export const tooltipStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1404,6 +1786,18 @@ export const treeItemTemplateStyles: ElementStyles;
 
 // @public
 export const treeViewAestheticStyles: ElementStyles;
+
+// @public (undocumented)
+export const TreeViewAnatomy: ComponentAnatomy<typeof TreeViewConditions, typeof TreeViewParts>;
+
+// @public (undocumented)
+export const TreeViewConditions: {};
+
+// @public (undocumented)
+export const TreeViewParts: {};
+
+// @public
+export const treeViewStyleModules: StyleModules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -1,20 +1,22 @@
 import { FASTAnchoredRegion } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from "@microsoft/fast-element";
+import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./anchored-region.styles.js";
-import { template } from "./anchored-region.template.js";
+import { AnchoredRegionAnatomy, template } from "./anchored-region.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeAnchoredRegion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAnchoredRegion>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AnchoredRegionAnatomy.interactivity, options);
+
     return FASTAnchoredRegion.compose({
         name: `${ds.prefix}-anchored-region`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.definition.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeAnchoredRegion } from "./anchored-region.compose.js";
+import { styleModules } from "./anchored-region.styles.modules.js";
 
 /**
  * The Anchored Region custom element definition. Implements {@link @microsoft/fast-foundation#FASTAnchoredRegion}.
@@ -9,4 +10,9 @@ import { composeAnchoredRegion } from "./anchored-region.compose.js";
  *
  * @public
  */
-export const anchoredRegionDefinition = composeAnchoredRegion(DefaultDesignSystem);
+export const anchoredRegionDefinition = composeAnchoredRegion(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.template.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.template.ts
@@ -1,6 +1,20 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { anchoredRegionTemplate, FASTAnchoredRegion } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const AnchoredRegionConditions = {
+    loaded: "[data-loaded='loaded']",
+};
+
+export const AnchoredRegionParts = {
+};
+
+export const AnchoredRegionAnatomy: ComponentAnatomy<typeof AnchoredRegionConditions, typeof AnchoredRegionParts> = {
+    interactivity: Interactivity.never,
+    conditions: AnchoredRegionConditions,
+    parts: AnchoredRegionParts,
+};
 
 /**
  * Default Anchored Region template, {@link @microsoft/fast-foundation#anchoredRegionTemplate}.

--- a/packages/adaptive-web-components/src/components/anchored-region/index.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/index.ts
@@ -3,4 +3,12 @@ export {
     templateStyles as anchoredRegionTemplateStyles,
     aestheticStyles as anchoredRegionAestheticStyles,
 } from "./anchored-region.styles.js";
-export { template as anchoredRegionTemplate } from "./anchored-region.template.js";
+export {
+    styleModules as anchoredRegionStyleModules,
+} from "./anchored-region.styles.modules.js";
+export {
+    template as anchoredRegionTemplate,
+    AnchoredRegionAnatomy,
+    AnchoredRegionConditions,
+    AnchoredRegionParts
+} from "./anchored-region.template.js";

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -1,20 +1,22 @@
 import { FASTBreadcrumb } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from "@microsoft/fast-element";
+import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb.styles.js";
-import { template } from "./breadcrumb.template.js";
+import { BreadcrumbAnatomy, template } from "./breadcrumb.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeBreadcrumb(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBreadcrumb>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, BreadcrumbAnatomy.interactivity, options);
+
     return FASTBreadcrumb.compose({
         name: `${ds.prefix}-breadcrumb`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.definition.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeBreadcrumb } from "./breadcrumb.compose.js";
+import { styleModules } from "./breadcrumb.styles.modules.js";
 
 /**
  * The Breadcrumb custom element definition. Implements {@link @microsoft/fast-foundation#FASTBreadcrumb}.
@@ -9,4 +10,9 @@ import { composeBreadcrumb } from "./breadcrumb.compose.js";
  *
  * @public
  */
-export const breadcrumbDefinition = composeBreadcrumb(DefaultDesignSystem);
+export const breadcrumbDefinition = composeBreadcrumb(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.template.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.template.ts
@@ -1,6 +1,20 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { breadcrumbTemplate, FASTBreadcrumb } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const BreadcrumbConditions = {
+};
+
+export const BreadcrumbParts = {
+    list: "list",
+};
+
+export const BreadcrumbAnatomy: ComponentAnatomy<typeof BreadcrumbConditions, typeof BreadcrumbParts> = {
+    interactivity: Interactivity.never,
+    conditions: BreadcrumbConditions,
+    parts: BreadcrumbParts,
+};
 
 /**
  * Default Breadcrumb template, {@link @microsoft/fast-foundation#breadcrumbTemplate}.

--- a/packages/adaptive-web-components/src/components/breadcrumb/index.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as breadcrumbTemplateStyles,
     aestheticStyles as breadcrumbAestheticStyles,
 } from "./breadcrumb.styles.js";
-export { template as breadcrumbTemplate } from "./breadcrumb.template.js";
+export {
+    styleModules as breadcrumbStyleModules,
+} from "./breadcrumb.styles.modules.js";
+export { template as breadcrumbTemplate, BreadcrumbAnatomy, BreadcrumbConditions, BreadcrumbParts } from "./breadcrumb.template.js";

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -1,20 +1,22 @@
 import { FASTCalendar } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from "@microsoft/fast-element";
+import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./calendar.styles.js";
-import { template } from "./calendar.template.js";
+import { CalendarAnatomy, template } from "./calendar.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCalendar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCalendar>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CalendarAnatomy.interactivity, options);
+
     return FASTCalendar.compose({
         name: `${ds.prefix}-calendar`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/calendar/calendar.definition.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeCalendar } from "./calendar.compose.js";
+import { styleModules } from "./calendar.styles.modules.js";
 
 /**
  * The Calendar custom element definition. Implements {@link @microsoft/fast-foundation#FASTCalendar}.
@@ -9,4 +10,9 @@ import { composeCalendar } from "./calendar.compose.js";
  *
  * @public
  */
-export const calendarDefinition = composeCalendar(DefaultDesignSystem);
+export const calendarDefinition = composeCalendar(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/calendar/calendar.template.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.template.ts
@@ -1,9 +1,32 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { calendarTemplate, calendarTitleTemplate, FASTCalendar } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeDataGridCell } from "../data-grid-cell/index.js";
 import { composeDataGridRow } from "../data-grid-row/index.js";
 import { composeDataGrid } from "../data-grid/index.js";
+
+export const CalendarConditions = {
+};
+
+export const CalendarParts = {
+    title: "title",
+    month: "month",
+    year: "year",
+    days: "days",
+    week: "week",
+    weekDay: "week-day",
+    weekDays: "week-days",
+    day: "day",
+    date: "date",
+    today: "today",
+};
+
+export const CalendarAnatomy: ComponentAnatomy<typeof CalendarConditions, typeof CalendarParts> = {
+    interactivity: Interactivity.never,
+    conditions: CalendarConditions,
+    parts: CalendarParts,
+};
 
 /**
  * Default Calendar template, {@link @microsoft/fast-foundation#calendarTemplate}.

--- a/packages/adaptive-web-components/src/components/calendar/index.ts
+++ b/packages/adaptive-web-components/src/components/calendar/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as calendarTemplateStyles,
     aestheticStyles as calendarAestheticStyles,
 } from "./calendar.styles.js";
-export { template as calendarTemplate } from "./calendar.template.js";
+export {
+    styleModules as calendarStyleModules,
+} from "./calendar.styles.modules.js";
+export { template as calendarTemplate, CalendarAnatomy, CalendarConditions, CalendarParts } from "./calendar.template.js";

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -1,20 +1,22 @@
 import { FASTCard } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from "@microsoft/fast-element";
+import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./card.styles.js";
-import { template } from "./card.template.js";
+import { CardAnatomy, template } from "./card.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeCard(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCard>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CardAnatomy.interactivity, options);
+
     return FASTCard.compose({
         name: `${ds.prefix}-card`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/card/card.definition.ts
+++ b/packages/adaptive-web-components/src/components/card/card.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeCard } from "./card.compose.js";
+import { styleModules } from "./card.styles.modules.js";
 
 /**
  * The Card custom element definition. Implements {@link @microsoft/fast-foundation#FASTCard}.
@@ -9,4 +10,9 @@ import { composeCard } from "./card.compose.js";
  *
  * @public
  */
-export const cardDefinition = composeCard(DefaultDesignSystem);
+export const cardDefinition = composeCard(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/card/card.template.ts
+++ b/packages/adaptive-web-components/src/components/card/card.template.ts
@@ -1,6 +1,19 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { cardTemplate, FASTCard } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const CardConditions = {
+};
+
+export const CardParts = {
+};
+
+export const CardAnatomy: ComponentAnatomy<typeof CardConditions, typeof CardParts> = {
+    interactivity: Interactivity.never,
+    conditions: CardConditions,
+    parts: CardParts,
+};
 
 /**
  * Default Card template, {@link @microsoft/fast-foundation#cardTemplate}.

--- a/packages/adaptive-web-components/src/components/card/index.ts
+++ b/packages/adaptive-web-components/src/components/card/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as cardTemplateStyles,
     aestheticStyles as cardAestheticStyles,
 } from "./card.styles.js";
-export { template as cardTemplate } from "./card.template.js";
+export {
+    styleModules as cardStyleModules,
+} from "./card.styles.modules.js";
+export { template as cardTemplate, CardAnatomy, CardConditions, CardParts } from "./card.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDataGridCell } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid-cell.styles.js";
-import { template } from "./data-grid-cell.template.js";
+import { DataGridCellAnatomy, template } from "./data-grid-cell.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGridCell(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridCell>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridCellAnatomy.interactivity, options);
+
     return FASTDataGridCell.compose({
         name: `${ds.prefix}-data-grid-cell`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.definition.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDataGridCell } from "./data-grid-cell.compose.js";
+import { styleModules } from "./data-grid-cell.styles.modules.js";
 
 /**
  * The Data Grid Cell custom element definition. Implements {@link @microsoft/fast-foundation#FASTDataGridCell}.
@@ -9,4 +10,9 @@ import { composeDataGridCell } from "./data-grid-cell.compose.js";
  *
  * @public
  */
-export const dataGridCellDefinition = composeDataGridCell(DefaultDesignSystem);
+export const dataGridCellDefinition = composeDataGridCell(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
@@ -1,6 +1,22 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dataGridCellTemplate, FASTDataGridCell } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const DataGridCellConditions = {
+    cellTypeDefault: "[cell-type='default']",
+    cellTypeColumnHeader: "[cell-type='columnheader']",
+    cellTypeRowHeader: "[cell-type='rowheader']",
+};
+
+export const DataGridCellParts = {
+};
+
+export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions, typeof DataGridCellParts> = {
+    interactivity: Interactivity.never,
+    conditions: DataGridCellConditions,
+    parts: DataGridCellParts,
+};
 
 /**
  * Default Data Grid Cell template, {@link @microsoft/fast-foundation#dataGridCellTemplate}.

--- a/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/index.ts
@@ -3,4 +3,12 @@ export {
     templateStyles as dataGridCellTemplateStyles,
     aestheticStyles as dataGridCellAestheticStyles,
 } from "./data-grid-cell.styles.js";
-export { template as dataGridCellTemplate } from "./data-grid-cell.template.js";
+export {
+    styleModules as dataGridCellStyleModules,
+} from "./data-grid-cell.styles.modules.js";
+export {
+    template as dataGridCellTemplate,
+    DataGridCellAnatomy,
+    DataGridCellConditions,
+    DataGridCellParts
+} from "./data-grid-cell.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDataGridRow } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid-row.styles.js";
-import { template } from "./data-grid-row.template.js";
+import { DataGridRowAnatomy, template } from "./data-grid-row.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGridRow(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridRow>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy.interactivity, options);
+
     return FASTDataGridRow.compose({
         name: `${ds.prefix}-data-grid-row`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.definition.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDataGridRow } from "./data-grid-row.compose.js";
+import { styleModules } from "./data-grid-row.styles.modules.js";
 
 /**
  * The Data Grid Cell custom element definition. Implements {@link @microsoft/fast-foundation#FASTDataGridRow}.
@@ -9,4 +10,9 @@ import { composeDataGridRow } from "./data-grid-row.compose.js";
  *
  * @public
  */
-export const dataGridRowDefinition = composeDataGridRow(DefaultDesignSystem);
+export const dataGridRowDefinition = composeDataGridRow(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.template.ts
@@ -1,7 +1,24 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dataGridRowTemplate, FASTDataGridRow } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeDataGridCell } from "../data-grid-cell/index.js";
+
+export const DataGridRowConditions = {
+    rowTypeDefault: "[row-type='default']",
+    rowTypeHeader: "[row-type='header']",
+    rowTypeStickyHeader: "[row-type='stick-header']",
+    selected: "[aria-selected='true']",
+};
+
+export const DataGridRowParts = {
+};
+
+export const DataGridRowAnatomy: ComponentAnatomy<typeof DataGridRowConditions, typeof DataGridRowParts> = {
+    interactivity: Interactivity.never,
+    conditions: DataGridRowConditions,
+    parts: DataGridRowParts,
+};
 
 /**
  * Default Data Grid Row template, {@link @microsoft/fast-foundation#dataGridRowTemplate}.

--- a/packages/adaptive-web-components/src/components/data-grid-row/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as dataGridRowTemplateStyles,
     aestheticStyles as dataGridRowAestheticStyles,
 } from "./data-grid-row.styles.js";
-export { template as dataGridRowTemplate } from "./data-grid-row.template.js";
+export {
+    styleModules as dataGridRowStyleModules,
+} from "./data-grid-row.styles.modules.js";
+export { template as dataGridRowTemplate, DataGridRowAnatomy, DataGridRowConditions, DataGridRowParts } from "./data-grid-row.template.js";

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDataGrid } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid.styles.js";
-import { template } from "./data-grid.template.js";
+import { DataGridAnatomy, template } from "./data-grid.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDataGrid(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGrid>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridAnatomy.interactivity, options);
+
     return FASTDataGrid.compose({
         name: `${ds.prefix}-data-grid`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.definition.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDataGrid } from "./data-grid.compose.js";
+import { styleModules } from "./data-grid.styles.modules.js";
 
 /**
  * The Data Grid custom element definition. Implements {@link @microsoft/fast-foundation#FASTDataGrid}.
@@ -9,4 +10,9 @@ import { composeDataGrid } from "./data-grid.compose.js";
  *
  * @public
  */
-export const dataGridDefinition = composeDataGrid(DefaultDesignSystem);
+export const dataGridDefinition = composeDataGrid(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.template.ts
@@ -1,7 +1,20 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dataGridTemplate, FASTDataGrid } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeDataGridRow } from '../data-grid-row/index.js';
+
+export const DataGridConditions = {
+};
+
+export const DataGridParts = {
+};
+
+export const DataGridAnatomy: ComponentAnatomy<typeof DataGridConditions, typeof DataGridParts> = {
+    interactivity: Interactivity.never,
+    conditions: DataGridConditions,
+    parts: DataGridParts,
+};
 
 /**
  * Default Data Grid template, {@link @microsoft/fast-foundation#dataGridTemplate}.

--- a/packages/adaptive-web-components/src/components/data-grid/index.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as dataGridTemplateStyles,
     aestheticStyles as dataGridAestheticStyles,
 } from "./data-grid.styles.js";
-export { template as dataGridTemplate } from "./data-grid.template.js";
+export {
+    styleModules as dataGridStyleModules,
+} from "./data-grid.styles.modules.js";
+export { template as dataGridTemplate, DataGridAnatomy, DataGridConditions, DataGridParts } from "./data-grid.template.js";

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDialog } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./dialog.styles.js";
-import { template } from "./dialog.template.js";
+import { DialogAnatomy, template } from "./dialog.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDialog(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDialog>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DialogAnatomy.interactivity, options);
+
     return FASTDialog.compose({
         name: `${ds.prefix}-dialog`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/dialog/dialog.definition.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDialog } from "./dialog.compose.js";
+import { styleModules } from "./dialog.styles.modules.js";
 
 /**
  * The Dialog custom element definition. Implements {@link @microsoft/fast-foundation#FASTDialog}.
@@ -9,4 +10,9 @@ import { composeDialog } from "./dialog.compose.js";
  *
  * @public
  */
-export const dialogDefinition = composeDialog(DefaultDesignSystem);
+export const dialogDefinition = composeDialog(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/dialog/dialog.template.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.template.ts
@@ -1,6 +1,22 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dialogTemplate, FASTDialog } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const DialogConditions = {
+};
+
+export const DialogParts = {
+    positioningRegion: "positioning-region",
+    overlay: "overlay",
+    control: "control",
+};
+
+export const DialogAnatomy: ComponentAnatomy<typeof DialogConditions, typeof DialogParts> = {
+    interactivity: Interactivity.never,
+    conditions: DialogConditions,
+    parts: DialogParts,
+};
 
 /**
  * Default Dialog template, {@link @microsoft/fast-foundation#dialogTemplate}.

--- a/packages/adaptive-web-components/src/components/dialog/index.ts
+++ b/packages/adaptive-web-components/src/components/dialog/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as dialogTemplateStyles,
     aestheticStyles as dialogAestheticStyles,
 } from "./dialog.styles.js";
-export { template as dialogTemplate } from "./dialog.template.js";
+export {
+    styleModules as dialogStyleModules,
+} from "./dialog.styles.modules.js";
+export { template as dialogTemplate, DialogAnatomy, DialogConditions, DialogParts } from "./dialog.template.js";

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDisclosure } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./disclosure.styles.js";
-import { template } from "./disclosure.template.js";
+import { DisclosureAnatomy, template } from "./disclosure.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDisclosure(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDisclosure>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DisclosureAnatomy.interactivity, options);
+
     return FASTDisclosure.compose({
         name: `${ds.prefix}-disclosure`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.definition.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDisclosure } from "./disclosure.compose.js";
+import { styleModules } from "./disclosure.styles.modules.js";
 
 /**
  * The Disclosure custom element definition. Implements {@link @microsoft/fast-foundation#FASTDisclosure}.
@@ -9,4 +10,9 @@ import { composeDisclosure } from "./disclosure.compose.js";
  *
  * @public
  */
-export const disclosureDefinition = composeDisclosure(DefaultDesignSystem);
+export const disclosureDefinition = composeDisclosure(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
@@ -1,6 +1,21 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { disclosureTemplate, FASTDisclosure } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const DisclosureConditions = {
+    expanded: "[expanded]",
+};
+
+export const DisclosureParts = {
+    invoker: "invoker",
+};
+
+export const DisclosureAnatomy: ComponentAnatomy<typeof DisclosureConditions, typeof DisclosureParts> = {
+    interactivity: Interactivity.never,
+    conditions: DisclosureConditions,
+    parts: DisclosureParts,
+};
 
 /**
  * Default Disclosure template, {@link @microsoft/fast-foundation#disclosureTemplate}.

--- a/packages/adaptive-web-components/src/components/disclosure/index.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as disclosureTemplateStyles,
     aestheticStyles as disclosureAestheticStyles,
 } from "./disclosure.styles.js";
-export { template as disclosureTemplate } from "./disclosure.template.js";
+export {
+    styleModules as disclosureStyleModules,
+} from "./disclosure.styles.modules.js";
+export { template as disclosureTemplate, DisclosureAnatomy, DisclosureConditions, DisclosureParts } from "./disclosure.template.js";

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -1,20 +1,22 @@
 import { FASTDivider } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./divider.styles.js";
-import { template } from "./divider.template.js";
+import { DividerAnatomy, template } from "./divider.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeDivider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDivider>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DividerAnatomy.interactivity, options);
+
     return FASTDivider.compose({
         name: `${ds.prefix}-divider`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/divider/divider.definition.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeDivider } from "./divider.compose.js";
+import { styleModules } from "./divider.styles.modules.js";
 
 /**
  * The Divider custom element definition. Implements {@link @microsoft/fast-foundation#FASTDivider}.
@@ -9,4 +10,9 @@ import { composeDivider } from "./divider.compose.js";
  *
  * @public
  */
-export const dividerDefinition = composeDivider(DefaultDesignSystem);
+export const dividerDefinition = composeDivider(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/divider/divider.template.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.template.ts
@@ -1,6 +1,21 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dividerTemplate, FASTDivider } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui"; 
 import { DesignSystem } from "../../design-system.js";
+
+export const DividerConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const DividerParts = {
+};
+
+export const DividerAnatomy: ComponentAnatomy<typeof DividerConditions, typeof DividerParts> = {
+    interactivity: Interactivity.never,
+    conditions: DividerConditions,
+    parts: DividerParts,
+};
 
 /**
  * Default Divider template, {@link @microsoft/fast-foundation#dividerTemplate}.

--- a/packages/adaptive-web-components/src/components/divider/index.ts
+++ b/packages/adaptive-web-components/src/components/divider/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as dividerTemplateStyles,
     aestheticStyles as dividerAestheticStyles,
 } from "./divider.styles.js";
-export { template as dividerTemplate } from "./divider.template.js";
+export {
+    styleModules as dividerStyleModules,
+} from "./divider.styles.modules.js";
+export { template as dividerTemplate, DividerAnatomy, DividerConditions, DividerParts } from "./divider.template.js";

--- a/packages/adaptive-web-components/src/components/flipper/index.ts
+++ b/packages/adaptive-web-components/src/components/flipper/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as flipperTemplateStyles,
     aestheticStyles as flipperAestheticStyles,
 } from "./flipper.styles.js";
-export { template as flipperTemplate, FlipperStatics } from "./flipper.template.js";
+export {
+    styleModules as flipperStyleModules,
+} from "./flipper.styles.modules.js";
+export { template as flipperTemplate, FlipperAnatomy, FlipperConditions, FlipperParts, FlipperStatics } from "./flipper.template.js";

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -1,20 +1,22 @@
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./horizontal-scroll.styles.js";
-import { template } from "./horizontal-scroll.template.js";
+import { HorizontalScrollAnatomy, template } from "./horizontal-scroll.template.js";
 import { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeHorizontalScroll(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveHorizontalScroll>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, HorizontalScrollAnatomy.interactivity, options);
+
     return AdaptiveHorizontalScroll.compose({
         name: `${ds.prefix}-horizontal-scroll`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.definition.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeHorizontalScroll } from "./horizontal-scroll.compose.js";
+import { styleModules } from "./horizontal-scroll.styles.modules.js";
 
 /**
  * The Horizontal Scroll custom element definition. Implements {@link @microsoft/fast-foundation#FASTHorizontalScroll}.
@@ -9,4 +10,9 @@ import { composeHorizontalScroll } from "./horizontal-scroll.compose.js";
  *
  * @public
  */
-export const horizontalScrollDefinition = composeHorizontalScroll(DefaultDesignSystem);
+export const horizontalScrollDefinition = composeHorizontalScroll(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.template.ts
@@ -9,8 +9,28 @@ import {
     tagFor,
     TemplateElementDependency,
 } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeFlipper } from "../flipper/index.js";
+
+export const HorizontalScrollConditions = {
+};
+
+export const HorizontalScrollParts = {
+    scrollArea: "scroll-area",
+    scrollView: "scroll-view",
+    content: "content",
+    scrollPrevious: "scroll-previous",
+    previousFlipper: "previous-flipper",
+    scrollNext: "scroll-next",
+    nextFlipper: "next-flipper",
+};
+
+export const HorizontalScrollAnatomy: ComponentAnatomy<typeof HorizontalScrollConditions, typeof HorizontalScrollParts> = {
+    interactivity: Interactivity.never,
+    conditions: HorizontalScrollConditions,
+    parts: HorizontalScrollParts,
+};
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/
 

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/index.ts
@@ -3,5 +3,13 @@ export {
     templateStyles as horizontalScrollTemplateStyles,
     aestheticStyles as horizontalScrollAestheticStyles,
 } from "./horizontal-scroll.styles.js";
-export { template as horizontalScrollTemplate } from "./horizontal-scroll.template.js";
+export {
+    styleModules as horizontalScrollStyleModules,
+} from "./horizontal-scroll.styles.modules.js";
+export {
+    template as horizontalScrollTemplate,
+    HorizontalScrollAnatomy,
+    HorizontalScrollConditions,
+    HorizontalScrollParts
+} from "./horizontal-scroll.template.js";
 export { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";

--- a/packages/adaptive-web-components/src/components/listbox/index.ts
+++ b/packages/adaptive-web-components/src/components/listbox/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as listboxTemplateStyles,
     aestheticStyles as listboxAestheticStyles,
 } from "./listbox.styles.js";
-export { template as listboxTemplate } from "./listbox.template.js";
+export {
+    styleModules as listboxStyleModules,
+} from "./listbox.styles.modules.js";
+export { template as listboxTemplate, ListboxAnatomy, ListboxConditions, ListboxParts } from "./listbox.template.js";

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -1,20 +1,22 @@
 import { FASTListboxElement } from "@microsoft/fast-foundation";
-import { FASTElementDefinition } from '@microsoft/fast-element';
+import { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./listbox.styles.js";
-import { template } from "./listbox.template.js";
+import { ListboxAnatomy, template } from "./listbox.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeListbox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxElement>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ListboxAnatomy.interactivity, options);
+
     return FASTListboxElement.compose({
         name: `${ds.prefix}-listbox`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/listbox/listbox.definition.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeListbox } from "./listbox.compose.js";
+import { styleModules } from "./listbox.styles.modules.js";
 
 /**
  * The Listbox custom element definition. Implements {@link @microsoft/fast-foundation#FASTListboxElement}.
@@ -9,4 +10,9 @@ import { composeListbox } from "./listbox.compose.js";
  *
  * @public
  */
-export const listboxDefinition = composeListbox(DefaultDesignSystem);
+export const listboxDefinition = composeListbox(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
@@ -1,6 +1,19 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTListboxElement, listboxTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const ListboxConditions = {
+};
+
+export const ListboxParts = {
+};
+
+export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof ListboxParts> = {
+    interactivity: Interactivity.disabledAttribute,
+    conditions: ListboxConditions,
+    parts: ListboxParts,
+};
 
 /**
  * Default Listbox template, {@link @microsoft/fast-foundation#listboxTemplate}.

--- a/packages/adaptive-web-components/src/components/menu/index.ts
+++ b/packages/adaptive-web-components/src/components/menu/index.ts
@@ -3,5 +3,8 @@ export {
     templateStyles as menuTemplateStyles,
     aestheticStyles as menuAestheticStyles,
 } from "./menu.styles.js";
-export { template as menuTemplate } from "./menu.template.js";
+export {
+    styleModules as menuStyleModules,
+} from "./menu.styles.modules.js";
+export { template as menuTemplate, MenuAnatomy, MenuConditions, MenuParts } from "./menu.template.js";
 export { AdaptiveMenu } from "./menu.js";

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -1,20 +1,22 @@
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveMenu } from "./menu.js";
 import { aestheticStyles, templateStyles } from "./menu.styles.js";
-import { template } from "./menu.template.js";
+import { MenuAnatomy, template } from "./menu.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeMenu(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveMenu>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, MenuAnatomy.interactivity, options);
+
     return AdaptiveMenu.compose({
         name: `${ds.prefix}-menu`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/menu/menu.definition.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeMenu } from "./menu.compose.js";
+import { styleModules } from "./menu.styles.modules.js";
 
 /**
  * The Menu custom element definition. Implements {@link @microsoft/fast-foundation#FASTMenu}.
@@ -9,4 +10,9 @@ import { composeMenu } from "./menu.compose.js";
  *
  * @public
  */
-export const menuDefinition = composeMenu(DefaultDesignSystem);
+export const menuDefinition = composeMenu(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/menu/menu.template.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.template.ts
@@ -1,6 +1,20 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTMenu, menuTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const MenuConditions = {
+    submenu: "[slot='submenu']",
+};
+
+export const MenuParts = {
+};
+
+export const MenuAnatomy: ComponentAnatomy<typeof MenuConditions, typeof MenuParts> = {
+    interactivity: Interactivity.never,
+    conditions: MenuConditions,
+    parts: MenuParts,
+};
 
 /**
  * Default Menu template, {@link @microsoft/fast-foundation#menuTemplate}.

--- a/packages/adaptive-web-components/src/components/picker-list/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as pickerListTemplateStyles,
     aestheticStyles as pickerListAestheticStyles,
 } from "./picker-list.styles.js";
-export { template as pickerListTemplate } from "./picker-list.template.js";
+export {
+    styleModules as pickerListStyleModules,
+} from "./picker-list.styles.modules.js";
+export { template as pickerListTemplate, PickerListAnatomy, PickerListConditions, PickerListParts } from "./picker-list.template.js";

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -16,7 +16,7 @@ export function composePickerList(
     return FASTPickerList.compose({
         name: `${ds.prefix}-picker-list`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/picker-menu/index.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as pickerMenuTemplateStyles,
     aestheticStyles as pickerMenuAestheticStyles,
 } from "./picker-menu.styles.js";
-export { template as pickerMenuTemplate } from "./picker-menu.template.js";
+export {
+    styleModules as pickerMenuStyleModules,
+} from "./picker-menu.styles.modules.js";
+export { template as pickerMenuTemplate, PickerMenuAnatomy, PickerMenuConditions, PickerMenuParts } from "./picker-menu.template.js";

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -1,20 +1,22 @@
 import { FASTPickerMenu } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker-menu.styles.js";
-import { template } from "./picker-menu.template.js";
+import { PickerMenuAnatomy, template } from "./picker-menu.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePickerMenu(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenu>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerMenuAnatomy.interactivity, options);
+
     return FASTPickerMenu.compose({
         name: `${ds.prefix}-picker-menu`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.definition.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composePickerMenu } from "./picker-menu.compose.js";
+import { styleModules } from "./picker-menu.styles.modules.js";
 
 /**
  * The Picker Menu custom element definition. Implements {@link @microsoft/fast-foundation#FASTPickerMenu}.
@@ -9,4 +10,9 @@ import { composePickerMenu } from "./picker-menu.compose.js";
  *
  * @public
  */
-export const pickerMenuDefinition = composePickerMenu(DefaultDesignSystem);
+export const pickerMenuDefinition = composePickerMenu(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.template.ts
@@ -1,6 +1,23 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTPickerMenu, pickerMenuTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const PickerMenuConditions = {
+};
+
+export const PickerMenuParts = {
+    optionsDisplay: "options-display",
+    headerRegion: "header-region",
+    footerRegion: "footer-region",
+    suggestionsAvailableAlert: "suggestions-available-alert",
+};
+
+export const PickerMenuAnatomy: ComponentAnatomy<typeof PickerMenuConditions, typeof PickerMenuParts> = {
+    interactivity: Interactivity.never,
+    conditions: PickerMenuConditions,
+    parts: PickerMenuParts,
+};
 
 /**
  * Default Picker Menu template, {@link @microsoft/fast-foundation#pickerMenuTemplate}.

--- a/packages/adaptive-web-components/src/components/picker/index.ts
+++ b/packages/adaptive-web-components/src/components/picker/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as pickerTemplateStyles,
     aestheticStyles as pickerAestheticStyles,
 } from "./picker.styles.js";
-export { template as pickerTemplate } from "./picker.template.js";
+export {
+    styleModules as pickerStyleModules,
+} from "./picker.styles.modules.js";
+export { template as pickerTemplate, PickerAnatomy, PickerConditions, PickerParts } from "./picker.template.js";

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -1,20 +1,22 @@
 import { FASTPicker } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker.styles.js";
-import { template } from "./picker.template.js";
+import { PickerAnatomy, template } from "./picker.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composePicker(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPicker>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerAnatomy.interactivity, options);
+
     return FASTPicker.compose({
         name: `${ds.prefix}-picker`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/picker/picker.definition.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composePicker } from "./picker.compose.js";
+import { styleModules } from "./picker.styles.modules.js";
 
 /**
  * The Picker custom element definition. Implements {@link @microsoft/fast-foundation#FASTPicker}.
@@ -9,4 +10,9 @@ import { composePicker } from "./picker.compose.js";
  *
  * @public
  */
-export const pickerDefinition = composePicker(DefaultDesignSystem);
+export const pickerDefinition = composePicker(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/picker/picker.template.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.template.ts
@@ -1,5 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTPicker, pickerTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeAnchoredRegion } from "../anchored-region/index.js";
 import { composePickerList } from "../picker-list/index.js";
@@ -7,6 +8,22 @@ import { composePickerMenu } from '../picker-menu/index.js';
 import { composePickerListItem } from '../picker-list-item/index.js';
 import { composePickerMenuOption } from '../picker-menu-option/index.js';
 import { composeProgressRing } from '../progress-ring/index.js';
+
+export const PickerConditions = {
+};
+
+export const PickerParts = {
+    region: "region",
+    noOptionsDisplay: "no-options-display",
+    loadingDisplay: "loading-display",
+    loadingProgress: "loading-progress",
+};
+
+export const PickerAnatomy: ComponentAnatomy<typeof PickerConditions, typeof PickerParts> = {
+    interactivity: Interactivity.never,
+    conditions: PickerConditions,
+    parts: PickerParts,
+};
 
 /**
  * Default Picker template, {@link @microsoft/fast-foundation#pickerTemplate}.

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -16,7 +16,7 @@ export function composeProgressRing(
     return FASTProgressRing.compose({
         name: `${ds.prefix}-progress-ring`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -16,7 +16,7 @@ export function composeProgress(
     return FASTProgress.compose({
         name: `${ds.prefix}-progress`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/radio-group/index.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as radioGroupTemplateStyles,
     aestheticStyles as radioGroupAestheticStyles,
 } from "./radio-group.styles.js";
-export { template as radioGroupTemplate } from "./radio-group.template.js";
+export {
+    styleModules as radioGroupStyleModules,
+} from "./radio-group.styles.modules.js";
+export { template as radioGroupTemplate, RadioGroupAnatomy, RadioGroupConditions, RadioGroupParts } from "./radio-group.template.js";

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -1,20 +1,22 @@
 import { FASTRadioGroup } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./radio-group.styles.js";
-import { template } from "./radio-group.template.js";
+import { RadioGroupAnatomy, template } from "./radio-group.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeRadioGroup(
     ds: DesignSystem,
     options?: ComposeOptions<FASTRadioGroup>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, RadioGroupAnatomy.interactivity, options);
+
     return FASTRadioGroup.compose({
         name: `${ds.prefix}-radio-group`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.definition.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeRadioGroup } from "./radio-group.compose.js";
+import { styleModules } from "./radio-group.styles.modules.js";
 
 /**
  * The Radio Group custom element definition. Implements {@link @microsoft/fast-foundation#FASTRadioGroup}.
@@ -9,4 +10,9 @@ import { composeRadioGroup } from "./radio-group.compose.js";
  *
  * @public
  */
-export const radioGroupDefinition = composeRadioGroup(DefaultDesignSystem);
+export const radioGroupDefinition = composeRadioGroup(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.template.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.template.ts
@@ -1,6 +1,22 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTRadioGroup, radioGroupTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const RadioGroupConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const RadioGroupParts = {
+    positioningRegion: "positioning-region",
+};
+
+export const RadioGroupAnatomy: ComponentAnatomy<typeof RadioGroupConditions, typeof RadioGroupParts> = {
+    interactivity: Interactivity.disabledAttribute,
+    conditions: RadioGroupConditions,
+    parts: RadioGroupParts,
+};
 
 /**
  * Default Radio Group template, {@link @microsoft/fast-foundation#radioGroupTemplate}.

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -25,7 +25,7 @@ export function composeSelect(
     return AdaptiveSelect.compose({
         name: `${ds.prefix}-select`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/skeleton/index.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as skeletonTemplateStyles,
     aestheticStyles as skeletonAestheticStyles,
 } from "./skeleton.styles.js";
-export { template as skeletonTemplate } from "./skeleton.template.js";
+export {
+    styleModules as skeletonStyleModules,
+} from "./skeleton.styles.modules.js";
+export { template as skeletonTemplate, SkeletonAnatomy, SkeletonConditions, SkeletonParts } from "./skeleton.template.js";

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -1,20 +1,22 @@
 import { FASTSkeleton } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./skeleton.styles.js";
-import { template } from "./skeleton.template.js";
+import { SkeletonAnatomy, template } from "./skeleton.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSkeleton(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSkeleton>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SkeletonAnatomy.interactivity, options);
+
     return FASTSkeleton.compose({
         name: `${ds.prefix}-skeleton`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.definition.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeSkeleton } from "./skeleton.compose.js";
+import { styleModules } from "./skeleton.styles.modules.js";
 
 /**
  * The Skeleton custom element definition. Implements {@link @microsoft/fast-foundation#FASTSkeleton}.
@@ -9,4 +10,9 @@ import { composeSkeleton } from "./skeleton.compose.js";
  *
  * @public
  */
-export const skeletonDefinition = composeSkeleton(DefaultDesignSystem);
+export const skeletonDefinition = composeSkeleton(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.template.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.template.ts
@@ -1,6 +1,21 @@
 import { ElementViewTemplate, html, when } from "@microsoft/fast-element";
 import type { FASTSkeleton } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const SkeletonConditions = {
+    rectangle: "[shape='rect']",
+    circle: "[shape='circle']",
+};
+
+export const SkeletonParts = {
+};
+
+export const SkeletonAnatomy: ComponentAnatomy<typeof SkeletonConditions, typeof SkeletonParts> = {
+    interactivity: Interactivity.never,
+    conditions: SkeletonConditions,
+    parts: SkeletonParts,
+};
 
 /**
  * Default Skeleton template, {@link @microsoft/fast-foundation#skeletonTemplate}.

--- a/packages/adaptive-web-components/src/components/slider-label/index.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as sliderLabelTemplateStyles,
     aestheticStyles as sliderLabelAestheticStyles,
 } from "./slider-label.styles.js";
-export { template as sliderLabelTemplate } from "./slider-label.template.js";
+export {
+    styleModules as sliderLabelStyleModules,
+} from "./slider-label.styles.modules.js";
+export { template as sliderLabelTemplate, SliderLabelAnatomy, SliderLabelConditions, SliderLabelParts } from "./slider-label.template.js";

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -1,20 +1,22 @@
 import { FASTSliderLabel } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./slider-label.styles.js";
-import { template } from "./slider-label.template.js";
+import { SliderLabelAnatomy, template } from "./slider-label.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSliderLabel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSliderLabel>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SliderLabelAnatomy.interactivity, options);
+
     return FASTSliderLabel.compose({
         name: `${ds.prefix}-slider-label`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.definition.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeSliderLabel } from "./slider-label.compose.js";
+import { styleModules } from "./slider-label.styles.modules.js";
 
 /**
  * The Slider Label custom element definition. Implements {@link "@microsoft/fast-foundation#FASTSliderLabel}.
@@ -9,4 +10,9 @@ import { composeSliderLabel } from "./slider-label.compose.js";
  *
  * @public
  */
-export const sliderLabelDefinition = composeSliderLabel(DefaultDesignSystem);
+export const sliderLabelDefinition = composeSliderLabel(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.template.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.template.ts
@@ -1,7 +1,25 @@
 import { ElementViewTemplate, html, when } from "@microsoft/fast-element";
 // import { sliderLabelTemplate } from "@microsoft/fast-foundation";
 import type { FASTSliderLabel } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const SliderLabelConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const SliderLabelParts = {
+    container: "container",
+    mark: "mark",
+    content: "content",
+};
+
+export const SliderLabelAnatomy: ComponentAnatomy<typeof SliderLabelConditions, typeof SliderLabelParts> = {
+    interactivity: Interactivity.never,
+    conditions: SliderLabelConditions,
+    parts: SliderLabelParts,
+};
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/
 

--- a/packages/adaptive-web-components/src/components/slider/index.ts
+++ b/packages/adaptive-web-components/src/components/slider/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as sliderTemplateStyles,
     aestheticStyles as sliderAestheticStyles,
 } from "./slider.styles.js";
-export { template as sliderTemplate } from "./slider.template.js";
+export {
+    styleModules as sliderStyleModules,
+} from "./slider.styles.modules.js";
+export { template as sliderTemplate, SliderAnatomy, SliderConditions, SliderParts } from "./slider.template.js";

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -1,20 +1,22 @@
 import { FASTSlider } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./slider.styles.js";
-import { template } from "./slider.template.js";
+import { SliderAnatomy, template } from "./slider.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeSlider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSlider>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SliderAnatomy.interactivity, options);
+
     return FASTSlider.compose({
         name: `${ds.prefix}-slider`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/slider/slider.definition.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeSlider } from "./slider.compose.js";
+import { styleModules } from "./slider.styles.modules.js";
 
 /**
  * The Slider custom element definition. Implements {@link @microsoft/fast-foundation#FASTSlider}.
@@ -9,4 +10,9 @@ import { composeSlider } from "./slider.compose.js";
  *
  * @public
  */
-export const sliderDefinition = composeSlider(DefaultDesignSystem);
+export const sliderDefinition = composeSlider(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/slider/slider.template.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.template.ts
@@ -1,7 +1,27 @@
 import { ElementViewTemplate, html, ref } from "@microsoft/fast-element";
 // import { sliderTemplate } from "@microsoft/fast-foundation";
 import { FASTSlider, staticallyCompose } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const SliderConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const SliderParts = {
+    positioningRegion: "positioning-region",
+    track: "track",
+    trackStart: "track-start",
+    thumbContainer: "thumb-container",
+    thumb: "thumb",
+};
+
+export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof SliderParts> = {
+    interactivity: Interactivity.never,
+    conditions: SliderConditions,
+    parts: SliderParts,
+};
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/
 

--- a/packages/adaptive-web-components/src/components/tab-panel/index.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as tabPanelTemplateStyles,
     aestheticStyles as tabPanelAestheticStyles,
 } from "./tab-panel.styles.js";
-export { template as tabPanelTemplate } from "./tab-panel.template.js";
+export {
+    styleModules as tabPanelStyleModules,
+} from "./tab-panel.styles.modules.js";
+export { template as tabPanelTemplate, TabPanelAnatomy,TabPanelConditions, TabPanelParts } from "./tab-panel.template.js";

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -1,20 +1,22 @@
 import { FASTTabPanel } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tab-panel.styles.js";
-import { template } from "./tab-panel.template.js";
+import { TabPanelAnatomy, template } from "./tab-panel.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTabPanel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabPanel>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TabPanelAnatomy.interactivity, options);
+
     return FASTTabPanel.compose({
         name: `${ds.prefix}-tab-panel`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.definition.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeTabPanel } from "./tab-panel.compose.js";
+import { styleModules } from "./tab-panel.styles.modules.js";
 
 /**
  * The Tab Panel custom element definition. Implements {@link @microsoft/fast-foundation#FASTTabPanel}.
@@ -9,4 +10,9 @@ import { composeTabPanel } from "./tab-panel.compose.js";
  *
  * @public
  */
-export const tabPanelDefinition = composeTabPanel(DefaultDesignSystem);
+export const tabPanelDefinition = composeTabPanel(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.template.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.template.ts
@@ -1,6 +1,19 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTabPanel, tabPanelTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const TabPanelConditions = {
+};
+
+export const TabPanelParts = {
+};
+
+export const TabPanelAnatomy: ComponentAnatomy<typeof TabPanelConditions, typeof TabPanelParts> = {
+    interactivity: Interactivity.never,
+    conditions: TabPanelConditions,
+    parts: TabPanelParts,
+};
 
 /**
  * Default Tab Panel template, {@link @microsoft/fast-foundation#tabPanelTemplate}.

--- a/packages/adaptive-web-components/src/components/tabs/index.ts
+++ b/packages/adaptive-web-components/src/components/tabs/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as tabsTemplateStyles,
     aestheticStyles as tabsAestheticStyles,
 } from "./tabs.styles.js";
-export { template as tabsTemplate } from "./tabs.template.js";
+export {
+    styleModules as tabsStyleModules,
+} from "./tabs.styles.modules.js";
+export { template as tabsTemplate, TabsAnatomy, TabsConditions, TabsParts } from "./tabs.template.js";

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -1,20 +1,22 @@
 import { FASTTabs } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tabs.styles.js";
-import { template } from "./tabs.template.js";
+import { TabsAnatomy, template } from "./tabs.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTabs(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabs>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TabsAnatomy.interactivity, options);
+
     return FASTTabs.compose({
         name: `${ds.prefix}-tabs`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/tabs/tabs.definition.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeTabs } from "./tabs.compose.js";
+import { styleModules } from "./tabs.styles.modules.js";
 
 /**
  * The Tabs custom element definition. Implements {@link @microsoft/fast-foundation#FASTTabs}.
@@ -9,4 +10,9 @@ import { composeTabs } from "./tabs.compose.js";
  *
  * @public
  */
-export const tabsDefinition = composeTabs(DefaultDesignSystem);
+export const tabsDefinition = composeTabs(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/tabs/tabs.template.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.template.ts
@@ -1,6 +1,23 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTabs, tabsTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const TabsConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const TabsParts = {
+    tablist: "tablist",
+    tabpanel: "tabpanel",
+};
+
+export const TabsAnatomy: ComponentAnatomy<typeof TabsConditions, typeof TabsParts> = {
+    interactivity: Interactivity.never,
+    conditions: TabsConditions,
+    parts: TabsParts,
+};
 
 /**
  * Default Tabs template, {@link @microsoft/fast-foundation#tabsTemplate}.

--- a/packages/adaptive-web-components/src/components/toolbar/index.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as toolbarTemplateStyles,
     aestheticStyles as toolbarAestheticStyles,
 } from "./toolbar.styles.js";
-export { template as toolbarTemplate } from "./toolbar.template.js";
+export {
+    styleModules as toolbarStyleModules,
+} from "./toolbar.styles.modules.js";
+export { template as toolbarTemplate, ToolbarAnatomy, ToolbarConditions, ToolbarParts } from "./toolbar.template.js";

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -1,20 +1,22 @@
 import { FASTToolbar } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./toolbar.styles.js";
-import { template } from "./toolbar.template.js";
+import { template, ToolbarAnatomy } from "./toolbar.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeToolbar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTToolbar>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ToolbarAnatomy.interactivity, options);
+
     return FASTToolbar.compose({
         name: `${ds.prefix}-toolbar`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.definition.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeToolbar } from "./toolbar.compose.js";
+import { styleModules } from "./toolbar.styles.modules.js";
 
 /**
  * The Toolbar custom element definition. Implements {@link @microsoft/fast-foundation#FASTToolbar}.
@@ -12,6 +13,7 @@ import { composeToolbar } from "./toolbar.compose.js";
 export const toolbarDefinition = composeToolbar(
 	DefaultDesignSystem,
 	{
+		styleModules,
 		shadowOptions: {
 			delegatesFocus: true
 		}

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
@@ -1,6 +1,22 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTToolbar, toolbarTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const ToolbarConditions = {
+    horizontal: "[orientation='horizontal']",
+    vertical: "[orientation='vertical']",
+};
+
+export const ToolbarParts = {
+    positioningRegion: "positioning-region",
+};
+
+export const ToolbarAnatomy: ComponentAnatomy<typeof ToolbarConditions, typeof ToolbarParts> = {
+    interactivity: Interactivity.never,
+    conditions: ToolbarConditions,
+    parts: ToolbarParts,
+};
 
 /**
  * Default Toolbar template, {@link @microsoft/fast-foundation#toolbarTemplate}.

--- a/packages/adaptive-web-components/src/components/tooltip/index.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as tooltipTemplateStyles,
     aestheticStyles as tooltipAestheticStyles,
 } from "./tooltip.styles.js";
-export { template as tooltipTemplate } from "./tooltip.template.js";
+export {
+    styleModules as tooltipStyleModules,
+} from "./tooltip.styles.modules.js";
+export { template as tooltipTemplate, TooltipAnatomy, TooltipConditions, TooltipParts } from "./tooltip.template.js";

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -1,20 +1,22 @@
 import { FASTTooltip } from '@microsoft/fast-foundation';
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tooltip.styles.js";
-import { template } from "./tooltip.template.js";
+import { template, TooltipAnatomy } from "./tooltip.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTooltip(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTooltip>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TooltipAnatomy.interactivity, options);
+
     return FASTTooltip.compose({
         name: `${ds.prefix}-tooltip`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.definition.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeTooltip } from "./tooltip.compose.js";
+import { styleModules } from "./tooltip.styles.modules.js";
 
 /**
  * The Tooltip custom element definition. Implements {@link @microsoft/fast-foundation#FASTTooltip}.
@@ -9,4 +10,9 @@ import { composeTooltip } from "./tooltip.compose.js";
  *
  * @public
  */
-export const tooltipDefinition = composeTooltip(DefaultDesignSystem);
+export const tooltipDefinition = composeTooltip(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.template.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.template.ts
@@ -1,6 +1,21 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTooltip, tooltipTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const TooltipConditions = {
+    show: "[show='true']",
+    visible: "[visible]",
+};
+
+export const TooltipParts = {
+};
+
+export const TooltipAnatomy: ComponentAnatomy<typeof TooltipConditions, typeof TooltipParts> = {
+    interactivity: Interactivity.never,
+    conditions: TooltipConditions,
+    parts: TooltipParts,
+};
 
 /**
  * Default Tooltip template, {@link @microsoft/fast-foundation#tooltipTemplate}.

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -25,7 +25,7 @@ export function composeTreeItem(
     return FASTTreeItem.compose({
         name: `${ds.prefix}-tree-item`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/tree-view/index.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/index.ts
@@ -3,4 +3,7 @@ export {
     templateStyles as treeViewTemplateStyles,
     aestheticStyles as treeViewAestheticStyles,
 } from "./tree-view.styles.js";
-export { template as treeViewTemplate } from "./tree-view.template.js";
+export {
+    styleModules as treeViewStyleModules,
+} from "./tree-view.styles.modules.js";
+export { template as treeViewTemplate, TreeViewAnatomy, TreeViewConditions, TreeViewParts } from "./tree-view.template.js";

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -1,20 +1,22 @@
 import { FASTTreeView } from "@microsoft/fast-foundation";
-import type { FASTElementDefinition } from '@microsoft/fast-element';
+import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
-import type { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tree-view.styles.js";
-import { template } from "./tree-view.template.js";
+import { template, TreeViewAnatomy } from "./tree-view.template.js";
 
-const styles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
 export function composeTreeView(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTreeView>
 ): FASTElementDefinition {
+    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TreeViewAnatomy.interactivity, options);
+
     return FASTTreeView.compose({
         name: `${ds.prefix}-tree-view`,
         template: options?.template?.(ds) ?? template(ds),
-        styles: options?.styles ?? styles,
+        styles,
         registry: ds.registry,
         elementOptions: options?.elementOptions,
         shadowOptions: options?.shadowOptions

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.definition.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.definition.ts
@@ -1,5 +1,6 @@
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeTreeView } from "./tree-view.compose.js";
+import { styleModules } from "./tree-view.styles.modules.js";
 
 /**
  * The tree view custom element definition. Implements {@link @microsoft/fast-foundation#FASTTreeView}.
@@ -9,4 +10,9 @@ import { composeTreeView } from "./tree-view.compose.js";
  *
  * @public
  */
-export const treeViewDefinition = composeTreeView(DefaultDesignSystem);
+export const treeViewDefinition = composeTreeView(
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
+);

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.modules.ts
@@ -1,0 +1,11 @@
+import {
+    StyleModules,
+} from "@adaptive-web/adaptive-ui";
+
+/**
+ * Visual styles composed by modules.
+ * 
+ * @public
+ */
+export const styleModules: StyleModules = [
+];

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.template.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.template.ts
@@ -1,6 +1,19 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTreeView, treeViewTemplate } from "@microsoft/fast-foundation";
+import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
+
+export const TreeViewConditions = {
+};
+
+export const TreeViewParts = {
+};
+
+export const TreeViewAnatomy: ComponentAnatomy<typeof TreeViewConditions, typeof TreeViewParts> = {
+    interactivity: Interactivity.never,
+    conditions: TreeViewConditions,
+    parts: TreeViewParts,
+};
 
 /**
  * Default Tree View template, {@link @microsoft/fast-foundation#treeViewTemplate}.


### PR DESCRIPTION
# Pull Request

## Description

This follows #70 and sets up the style module pattern for all remaining components. Note that the style module definitions are all empty for now and I'll follow with subsequent PRs to migrate logical portions at a time.

## Reviewer Notes

Same as with #70, the changes are all the same in the respective files for each component. A few individual files were missing some of the conventions which has been addressed here as well.

## Test Plan

Test in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Individual aesthetic styles migrated to style modules.