### PR TITLE
Migrated type ramp to style modules

### DIFF
--- a/change/@adaptive-web-adaptive-ui-56e70be2-b8c2-42a4-93e2-f9bf15dfa4b4.json
+++ b/change/@adaptive-web-adaptive-ui-56e70be2-b8c2-42a4-93e2-f9bf15dfa4b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Migrated type ramp to style modules",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-578c06ad-4e1e-4d6e-a522-e0a5aa54fe58.json
+++ b/change/@adaptive-web-adaptive-web-components-578c06ad-4e1e-4d6e-a522-e0a5aa54fe58.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Migrated type ramp to style modules",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/init-ds.ts
+++ b/examples/customize-component/src/init-ds.ts
@@ -2,4 +2,4 @@
 
 import { neutralFillDiscernibleControlStyles, selectableSelectedStyles } from "@adaptive-web/adaptive-ui";
 
-selectableSelectedStyles.alias = neutralFillDiscernibleControlStyles;
+selectableSelectedStyles.appendComposed(neutralFillDiscernibleControlStyles);

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -66,7 +66,7 @@ export class StyleExample extends FASTElement {
         let backgroundActive = fillColor;
         let backgroundFocus = fillColor;
 
-        const backgroundValue = (this.styles?.properties || {})[StyleProperty.backgroundFill];
+        const backgroundValue = (this.styles?.effectiveProperties || {})[StyleProperty.backgroundFill];
         if (backgroundValue) {
             if (typeof backgroundValue === "string") {
                 // ignore for now
@@ -106,7 +106,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const colorValue = (this.styles?.properties || {})[StyleProperty.foregroundFill];
+        const colorValue = (this.styles?.effectiveProperties || {})[StyleProperty.foregroundFill];
         if (colorValue) {
             if (typeof colorValue === "string") {
                 // ignore for now
@@ -146,7 +146,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const borderValue = (this.styles?.properties || {})[StyleProperty.borderFill];
+        const borderValue = (this.styles?.effectiveProperties || {})[StyleProperty.borderFill];
         if (borderValue) {
             if (typeof borderValue === "string") {
                 // ignore for now

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -1462,7 +1462,7 @@ export const typeRampBaseFontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampBaseLineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampBaseStyles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1477,7 +1477,7 @@ export const typeRampMinus1FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampMinus1LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampMinus1Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1492,7 +1492,7 @@ export const typeRampMinus2FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampMinus2LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampMinus2Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1507,7 +1507,7 @@ export const typeRampPlus1FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus1LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus1Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1522,7 +1522,7 @@ export const typeRampPlus2FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus2LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus2Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1537,7 +1537,7 @@ export const typeRampPlus3FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus3LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus3Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1552,7 +1552,7 @@ export const typeRampPlus4FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus4LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus4Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1567,7 +1567,7 @@ export const typeRampPlus5FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus5LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus5Styles: Styles;
 
 // @public @deprecated (undocumented)
@@ -1582,7 +1582,7 @@ export const typeRampPlus6FontVariations: CSSDesignToken<string>;
 // @public (undocumented)
 export const typeRampPlus6LineHeight: CSSDesignToken<string>;
 
-// @public (undocumented)
+// @public
 export const typeRampPlus6Styles: Styles;
 
 // @public

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -607,6 +607,9 @@ export function isDark(color: RelativeLuminance): boolean;
 // @public (undocumented)
 export const itemStyles: Styles;
 
+// @public (undocumented)
+export const labelTextStyles: Styles;
+
 // @public
 export const LayerBaseLuminance: Readonly<{
     readonly LightMode: 0.95;
@@ -1391,6 +1394,7 @@ export const StyleProperty: {
     readonly fontSize: "fontSize";
     readonly fontWeight: "fontWeight";
     readonly fontStyle: "fontStyle";
+    readonly fontVariationSettings: "fontVariationSettings";
     readonly letterSpacing: "letterSpacing";
     readonly lineHeight: "lineHeight";
     readonly padding: "padding";
@@ -1407,14 +1411,14 @@ export type StyleProperty = ValuesOf<typeof StyleProperty>;
 // @public
 export class Styles {
     // (undocumented)
-    get alias(): Styles;
-    set alias(alias: Styles);
-    // (undocumented)
-    static fromAlias(styles: Styles): Styles;
-    // (undocumented)
+    appendComposed(styles: Styles): void;
+    clearComposed(): void;
+    static compose(...styles: Styles[]): Styles;
+    get composed(): Styles[] | undefined;
+    get effectiveProperties(): StyleProperties;
     static fromProperties(properties: StyleProperties): Styles;
-    // (undocumented)
-    get properties(): StyleProperties;
+    get properties(): StyleProperties | undefined;
+    set properties(properties: StyleProperties | undefined);
 }
 
 // @public
@@ -1446,7 +1450,7 @@ export class SwatchRGB implements Swatch {
     toColorString(): string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const typeRampBase: CSSDirective;
 
 // @public (undocumented)
@@ -1459,6 +1463,9 @@ export const typeRampBaseFontVariations: CSSDesignToken<string>;
 export const typeRampBaseLineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampBaseStyles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampMinus1: CSSDirective;
 
 // @public (undocumented)
@@ -1471,6 +1478,9 @@ export const typeRampMinus1FontVariations: CSSDesignToken<string>;
 export const typeRampMinus1LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampMinus1Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampMinus2: CSSDirective;
 
 // @public (undocumented)
@@ -1483,6 +1493,9 @@ export const typeRampMinus2FontVariations: CSSDesignToken<string>;
 export const typeRampMinus2LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampMinus2Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus1: CSSDirective;
 
 // @public (undocumented)
@@ -1495,6 +1508,9 @@ export const typeRampPlus1FontVariations: CSSDesignToken<string>;
 export const typeRampPlus1LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampPlus1Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus2: CSSDirective;
 
 // @public (undocumented)
@@ -1507,6 +1523,9 @@ export const typeRampPlus2FontVariations: CSSDesignToken<string>;
 export const typeRampPlus2LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampPlus2Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus3: CSSDirective;
 
 // @public (undocumented)
@@ -1519,6 +1538,9 @@ export const typeRampPlus3FontVariations: CSSDesignToken<string>;
 export const typeRampPlus3LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampPlus3Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus4: CSSDirective;
 
 // @public (undocumented)
@@ -1531,6 +1553,9 @@ export const typeRampPlus4FontVariations: CSSDesignToken<string>;
 export const typeRampPlus4LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampPlus4Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus5: CSSDirective;
 
 // @public (undocumented)
@@ -1543,6 +1568,9 @@ export const typeRampPlus5FontVariations: CSSDesignToken<string>;
 export const typeRampPlus5LineHeight: CSSDesignToken<string>;
 
 // @public (undocumented)
+export const typeRampPlus5Styles: Styles;
+
+// @public @deprecated (undocumented)
 export const typeRampPlus6: CSSDirective;
 
 // @public (undocumented)
@@ -1553,6 +1581,9 @@ export const typeRampPlus6FontVariations: CSSDesignToken<string>;
 
 // @public (undocumented)
 export const typeRampPlus6LineHeight: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const typeRampPlus6Styles: Styles;
 
 // @public
 export const WcagContrastLevel: {

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -30,6 +30,36 @@ import {
     neutralStrokeSubtleRest,
 } from "./color.js";
 import { createNonCss } from "./create.js";
+import {
+    bodyFont,
+    typeRampBaseFontSize,
+    typeRampBaseFontVariations,
+    typeRampBaseLineHeight,
+    typeRampMinus1FontSize,
+    typeRampMinus1FontVariations,
+    typeRampMinus1LineHeight,
+    typeRampMinus2FontSize,
+    typeRampMinus2FontVariations,
+    typeRampMinus2LineHeight,
+    typeRampPlus1FontSize,
+    typeRampPlus1FontVariations,
+    typeRampPlus1LineHeight,
+    typeRampPlus2FontSize,
+    typeRampPlus2FontVariations,
+    typeRampPlus2LineHeight,
+    typeRampPlus3FontSize,
+    typeRampPlus3FontVariations,
+    typeRampPlus3LineHeight,
+    typeRampPlus4FontSize,
+    typeRampPlus4FontVariations,
+    typeRampPlus4LineHeight,
+    typeRampPlus5FontSize,
+    typeRampPlus5FontVariations,
+    typeRampPlus5LineHeight,
+    typeRampPlus6FontSize,
+    typeRampPlus6FontVariations,
+    typeRampPlus6LineHeight,
+} from "./type.js";
 
 /**
  * Creates a set of foreground tokens applied over the background tokens.
@@ -349,31 +379,174 @@ export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromPropert
 });
 
 /**
+ * Convenience style module combining all font values for the `base` type ramp.
+ *
  * @public
  */
-export const actionStyles: Styles = Styles.fromAlias(neutralFillSubtleControlStyles);
+export const typeRampBaseStyles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampBaseFontSize,
+    lineHeight: typeRampBaseLineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampBaseFontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `minus 1` type ramp.
+ *
+ * @public
+ */
+export const typeRampMinus1Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampMinus1FontSize,
+    lineHeight: typeRampMinus1LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampMinus1FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `minus 2` type ramp.
+ *
+ * @public
+ */
+export const typeRampMinus2Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampMinus2FontSize,
+    lineHeight: typeRampMinus2LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampMinus2FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 1` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus1Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus1FontSize,
+    lineHeight: typeRampPlus1LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus1FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 2` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus2Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus2FontSize,
+    lineHeight: typeRampPlus2LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus2FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 3` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus3Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus3FontSize,
+    lineHeight: typeRampPlus3LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus3FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 4` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus4Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus4FontSize,
+    lineHeight: typeRampPlus4LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus4FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 5` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus5Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus5FontSize,
+    lineHeight: typeRampPlus5LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus5FontVariations,
+});
+
+/**
+ * Convenience style module combining all font values for the `plus 6` type ramp.
+ *
+ * @public
+ */
+export const typeRampPlus6Styles: Styles = Styles.fromProperties({
+    fontFamily: bodyFont,
+    fontSize: typeRampPlus6FontSize,
+    lineHeight: typeRampPlus6LineHeight,
+    fontWeight: "initial",
+    fontVariationSettings: typeRampPlus6FontVariations,
+});
 
 /**
  * @public
  */
-export const inputStyles: Styles = Styles.fromAlias(neutralOutlineDiscernibleControlStyles);
+export const actionStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralFillSubtleControlStyles
+);
 
 /**
  * @public
  */
-export const selectableSelectedStyles: Styles = Styles.fromAlias(accentFillReadableControlStyles);
+export const inputStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralOutlineDiscernibleControlStyles
+);
 
 /**
  * @public
  */
-export const selectableUnselectedStyles: Styles = Styles.fromAlias(neutralOutlineDiscernibleControlStyles);
+export const selectableSelectedStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    accentFillReadableControlStyles
+);
 
 /**
  * @public
  */
-export const itemStyles: Styles = Styles.fromAlias(neutralFillStealthControlStyles);
+export const selectableUnselectedStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralOutlineDiscernibleControlStyles
+);
 
 /**
  * @public
  */
-export const plainTextStyles: Styles = Styles.fromAlias(neutralForegroundStrongElementStyles);
+export const itemStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralFillStealthControlStyles
+);
+
+/**
+ * @public
+ */
+export const plainTextStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralForegroundStrongElementStyles
+);
+
+/**
+ * @public
+ */
+export const labelTextStyles: Styles = Styles.compose(
+    typeRampBaseStyles,
+    neutralForegroundStrongElementStyles
+);

--- a/packages/adaptive-ui/src/modules/css.ts
+++ b/packages/adaptive-ui/src/modules/css.ts
@@ -29,6 +29,8 @@ export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
             return "font-weight";
         case StyleProperty.fontStyle:
             return "font-style";
+        case StyleProperty.fontVariationSettings:
+            return "font-variation-settings";
         case StyleProperty.letterSpacing:
             return "letter-spacing";
         case StyleProperty.lineHeight:

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -44,7 +44,7 @@ function propertyInteractive<T = string>(
 }
 
 function createElementStyleModules(styles: Styles): StyleModuleEvaluate[] {
-    const modules: StyleModuleEvaluate[] = Object.entries(styles.properties).map(([key, value]) => {
+    const modules: StyleModuleEvaluate[] = Object.entries(styles.effectiveProperties).map(([key, value]) => {
         const property = stylePropertyToCssProperty(key as StyleProperty);
         if (typeof value === "string" || value instanceof CSSDesignToken) {
             return propertySingle(property, value);

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -126,6 +126,7 @@ export const StyleProperty = {
     fontSize: "fontSize",
     fontWeight: "fontWeight",
     fontStyle: "fontStyle",
+    fontVariationSettings: "fontVariationSettings",
     letterSpacing: "letterSpacing",
     lineHeight: "lineHeight",
     padding: "padding",

--- a/packages/adaptive-ui/src/type/type-ramp.ts
+++ b/packages/adaptive-ui/src/type/type-ramp.ts
@@ -30,7 +30,10 @@ import {
     typeRampPlus6LineHeight,
 } from "../design-tokens/type.js";
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampBase = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampBaseFontSize};
@@ -39,7 +42,10 @@ export const typeRampBase = css.partial`
     font-variation-settings: ${typeRampBaseFontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampMinus1 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampMinus1FontSize};
@@ -48,7 +54,10 @@ export const typeRampMinus1 = css.partial`
     font-variation-settings: ${typeRampMinus1FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampMinus2 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampMinus2FontSize};
@@ -57,7 +66,10 @@ export const typeRampMinus2 = css.partial`
     font-variation-settings: ${typeRampMinus2FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus1 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus1FontSize};
@@ -66,7 +78,10 @@ export const typeRampPlus1 = css.partial`
     font-variation-settings: ${typeRampPlus1FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus2 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus2FontSize};
@@ -75,7 +90,10 @@ export const typeRampPlus2 = css.partial`
     font-variation-settings: ${typeRampPlus2FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus3 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus3FontSize};
@@ -84,7 +102,10 @@ export const typeRampPlus3 = css.partial`
     font-variation-settings: ${typeRampPlus3FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus4 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus4FontSize};
@@ -93,7 +114,10 @@ export const typeRampPlus4 = css.partial`
     font-variation-settings: ${typeRampPlus4FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus5 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus5FontSize};
@@ -102,7 +126,10 @@ export const typeRampPlus5 = css.partial`
     font-variation-settings: ${typeRampPlus5FontVariations};
 `;
 
-/** @public */
+/**
+ * @public
+ * @deprecated Use style modules instead.
+ */
 export const typeRampPlus6 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus6FontSize};

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
@@ -1,6 +1,7 @@
 import {
     accentForegroundReadableControlStyles,
     neutralForegroundStrongElementStyles,
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 import { AccordionItemAnatomy } from "./accordion-item.template.js";
@@ -11,6 +12,11 @@ import { AccordionItemAnatomy } from "./accordion-item.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
     [
         {
             part: AccordionItemAnatomy.parts.button,

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -5,7 +5,6 @@ import {
     focusStrokeWidth,
     neutralStrokeSubtleRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { density, heightNumber } from "../../styles/index.js";
 
@@ -34,6 +33,7 @@ export const templateStyles: ElementStyles = css`
         grid-row: 1;
         outline: none;
         cursor: pointer;
+        font: inherit;
     }
 
     .button::before {
@@ -105,13 +105,11 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-        ${typeRampBase}
     }
 
     .button {
         padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
         height: calc(${heightNumber} * 1px);
-        font-family: inherit;
     }
 
     :host(:not([disabled])) .button:focus-visible::before {

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { neutralStrokeSubtleRest, strokeWidth, typeRampBase } from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -17,6 +17,5 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-        ${typeRampBase}
     }
 `;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css } from "@microsoft/fast-element";
 import type { ElementStyles } from "@microsoft/fast-element";
@@ -25,6 +24,7 @@ export const templateStyles: ElementStyles = css`
         align-items: center;
         white-space: nowrap;
         outline: none;
+        font: inherit;
         text-decoration: none;
     }
 
@@ -46,7 +46,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
-        ${typeRampBase}
     }
 
     .control {

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.modules.ts
@@ -1,6 +1,7 @@
 import {
     accentFillReadableControlStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { AvatarAnatomy } from "./avatar.template.js";
 
@@ -10,6 +11,11 @@ import { AvatarAnatomy } from "./avatar.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        typeRampBaseStyles
+    ],
     [
         {
             part: AvatarAnatomy.parts.backplate,

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -1,4 +1,3 @@
-import { typeRampBase } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -43,7 +42,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         max-width: calc(${heightNumber} * 1px);
-        ${typeRampBase}
     }
 
     .backplate {

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
@@ -1,6 +1,7 @@
 import {
     neutralFillReadableControlStyles,
     StyleModules,
+    typeRampMinus1Styles,
 } from "@adaptive-web/adaptive-ui";
 import { BadgeAnatomy } from "./badge.template.js";
 
@@ -10,6 +11,11 @@ import { BadgeAnatomy } from "./badge.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        typeRampMinus1Styles
+    ],
     [
         {
             part: BadgeAnatomy.parts.control,

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -3,7 +3,6 @@ import {
     controlCornerRadius,
     designUnit,
     strokeWidth,
-    typeRampMinus1,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -19,10 +18,6 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        ${typeRampMinus1}
-    }
-
     .control {
         border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${controlCornerRadius} * 1px);

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -2,6 +2,7 @@ import {
     accentForegroundReadableControlStyles,
     plainTextStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { BreadcrumbItemAnatomy } from "./breadcrumb-item.template.js";
 
@@ -11,6 +12,11 @@ import { BreadcrumbItemAnatomy } from "./breadcrumb-item.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        typeRampBaseStyles
+    ],
     [
         {
             part: BreadcrumbItemAnatomy.parts.control,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -3,7 +3,6 @@ import {
     focusStrokeWidth,
     neutralForegroundRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { heightNumber } from "../../styles/index.js";
 
@@ -46,7 +45,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         min-width: calc(${heightNumber} * 1px);
-        ${typeRampBase}
     }
 
     .listitem {

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -5,7 +5,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { density, heightNumber } from "../../styles/index.js";
 
@@ -24,6 +23,7 @@ export const templateStyles: ElementStyles = css`
         align-items: center;
         white-space: nowrap;
         outline: none;
+        font: inherit;
     }
 
     .control::-moz-focus-inner {
@@ -53,7 +53,6 @@ export const aestheticStyles: ElementStyles = css`
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
         border-radius: calc(${controlCornerRadius} * 1px);
-        ${typeRampBase}
     }
 
     .control {
@@ -62,7 +61,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: inherit;
         white-space: nowrap;
         fill: currentcolor;
-        font-family: inherit;
     }
 
     .control.icon-only {

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -4,10 +4,8 @@ import {
     designUnit,
     fillColor,
     foregroundOnAccentRest,
-    neutralForegroundRest,
     neutralStrokeReadableRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { baseHeightMultiplier, density } from "../../styles/index.js";
@@ -42,9 +40,7 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         --calendar-cell-size: calc((${baseHeightMultiplier} + 2 + ${density}) * ${designUnit} * 1px);
         --calendar-gap: 2px;
-        color: ${neutralForegroundRest};
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     .title {

--- a/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    labelTextStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles,
     StyleModules,
@@ -11,6 +12,12 @@ import { CheckboxAnatomy } from "./checkbox.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            part: CheckboxAnatomy.parts.label,
+        },
+        labelTextStyles
+    ],
     [
         {
             part: CheckboxAnatomy.parts.control,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -3,9 +3,7 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralForegroundRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -82,8 +80,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .label {
         padding-inline-start: calc(${designUnit} * 2px + 2px);
-        color: ${neutralForegroundRest};
-        ${typeRampBase}
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -6,7 +6,6 @@ import {
     focusStrokeWidth,
     layerFillFixedPlus1,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -39,6 +38,7 @@ export const templateStyles: ElementStyles = css`
         background: transparent;
         border: none;
         color: inherit;
+        font: inherit;
     }
 
     .selected-value:focus-visible {
@@ -84,7 +84,6 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-within) {
@@ -104,7 +103,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .selected-value {
-        font-family: inherit;
         flex: 1 1 auto;
         text-align: start;
     }

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -4,9 +4,7 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralForegroundRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -26,9 +24,7 @@ export const aestheticStyles: ElementStyles = css`
         border: transparent calc(${strokeWidth} * 1px) solid;
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) calc(${designUnit} * 3px);
-        color: ${neutralForegroundRest};
         fill: currentcolor;
-        ${typeRampBase}
         white-space: nowrap;
     }
 

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
@@ -1,6 +1,9 @@
 import {
+    accentFillReadableControlStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
+import { DisclosureAnatomy } from "./disclosure.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +11,15 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        typeRampBaseStyles
+    ],
+    [
+        {
+            part: DisclosureAnatomy.parts.invoker
+        },
+        accentFillReadableControlStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -46,7 +45,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 2.25px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -6,7 +6,6 @@ import {
     neutralFillStealthActive,
     neutralStrokeReadableRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -137,7 +136,6 @@ export const aestheticStyles: ElementStyles = css`
         padding: 0 12px;
         grid-column-gap: 8px;
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host([aria-expanded="true"]) {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
@@ -1,7 +1,8 @@
 import {
     inputStyles,
-    plainTextStyles,
+    labelTextStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { NumberFieldAnatomy } from "./number-field.template.js";
 
@@ -13,9 +14,14 @@ import { NumberFieldAnatomy } from "./number-field.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        typeRampBaseStyles
+    ],
+    [
+        {
             part: NumberFieldAnatomy.parts.label
         },
-        plainTextStyles
+        labelTextStyles
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -77,10 +76,6 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        ${typeRampBase}
-    }
-
     .label {
         margin-bottom: 4px;
     }
@@ -101,8 +96,6 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         height: calc(100% - 4px);
         padding: 0 calc(${designUnit} * 2px + 1px);
-        font-size: inherit;
-        line-height: inherit;
     }
 
     .step-up,

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -35,7 +34,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -26,6 +25,7 @@ export const templateStyles: ElementStyles = css`
         border: none;
         outline: none;
         user-select: none;
+        font: inherit;
     }
 `;
 
@@ -42,7 +42,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
         padding: calc(${designUnit} * 1px) calc(${designUnit} * 2px);
-        ${typeRampBase}
     }
 
     :host(:not([disabled]):focus-within) {

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -6,7 +6,6 @@ import {
     focusStrokeWidth,
     foregroundOnAccentRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -37,7 +36,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    labelTextStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles,
     StyleModules,
@@ -11,6 +12,12 @@ import { RadioAnatomy } from "./radio.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            part: RadioAnatomy.parts.label,
+        },
+        labelTextStyles
+    ],
     [
         {
             part: RadioAnatomy.parts.control,

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -2,9 +2,7 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralForegroundRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -82,8 +80,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .label {
         padding-inline-start: calc(${designUnit} * 2px + 2px);
-        color: ${neutralForegroundRest};
-        ${typeRampBase}
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -1,8 +1,9 @@
 import {
     inputStyles,
     neutralFillStealthControlStyles,
-    plainTextStyles,
+    labelTextStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { SearchAnatomy } from "./search.template.js";
 
@@ -14,9 +15,14 @@ import { SearchAnatomy } from "./search.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        typeRampBaseStyles
+    ],
+    [
+        {
             part: SearchAnatomy.parts.label
         },
-        plainTextStyles
+        labelTextStyles
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -1,7 +1,7 @@
 import {
     inputStyles,
-    neutralFillStealthControlStyles,
     labelTextStyles,
+    neutralFillStealthControlStyles,
     StyleModules,
     typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
@@ -26,6 +25,7 @@ export const templateStyles: ElementStyles = css`
 
     .control {
         -webkit-appearance: none;
+        font: inherit;
     }
 
     .control::-webkit-search-cancel-button {
@@ -37,6 +37,7 @@ export const templateStyles: ElementStyles = css`
         background: transparent;
         border: none;
         outline: none;
+        font: inherit;
     }
 
     .clear-button__hidden {
@@ -82,7 +83,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        ${typeRampBase}
         fill: currentcolor;
     }
 
@@ -112,7 +112,6 @@ export const aestheticStyles: ElementStyles = css`
         border: none;
         background: transparent;
         color: inherit;
-        font-family: inherit;
     }
 
     .control:focus-visible {
@@ -126,6 +125,5 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 `;

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -6,7 +6,6 @@ import {
     focusStrokeWidth,
     layerFillFixedPlus1,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -85,7 +84,6 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
@@ -1,5 +1,6 @@
 import {
     StyleModules,
+    typeRampMinus1Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        typeRampMinus1Styles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -1,4 +1,4 @@
-import { designUnit, neutralStrokeSubtleRest, typeRampMinus1 } from "@adaptive-web/adaptive-ui";
+import { designUnit, neutralStrokeSubtleRest } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -64,10 +64,6 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        ${typeRampMinus1}
-    }
-
     .mark {
         background: ${neutralStrokeSubtleRest};
     }

--- a/packages/adaptive-web-components/src/components/switch/switch.stories.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.stories.ts
@@ -18,6 +18,7 @@ const storyTemplate = html<StoryArgs<FASTSwitch>>`
 export default {
     title: "Components/Switch",
     args: {
+        storyContent: "Switch",
         checked: false,
         disabled: false,
         readOnly: false,

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    labelTextStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles,
     StyleModules,
@@ -11,6 +12,12 @@ import { SwitchAnatomy } from "./switch.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            part: SwitchAnatomy.parts.label,
+        },
+        labelTextStyles
+    ],
     [
         {
             part: SwitchAnatomy.parts.switch,

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -3,9 +3,7 @@ import {
     fillColor,
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralForegroundRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -50,11 +48,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         gap: 8px;
-        ${typeRampBase}
-    }
-
-    .label {
-        color: ${neutralForegroundRest};
     }
 
     .switch {

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
@@ -1,4 +1,4 @@
-import { designUnit, typeRampBase } from "@adaptive-web/adaptive-ui";
+import { designUnit } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density } from "../../styles/index.js";
 
@@ -18,6 +18,5 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         box-sizing: border-box;
         padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
-        ${typeRampBase}
     }
 `;

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
@@ -37,7 +36,6 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
@@ -1,7 +1,8 @@
 import {
     inputStyles,
-    plainTextStyles,
+    labelTextStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { TextAreaAnatomy } from "./text-area.template.js";
 
@@ -13,9 +14,14 @@ import { TextAreaAnatomy } from "./text-area.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        typeRampBaseStyles
+    ],
+    [
+        {
             part: TextAreaAnatomy.parts.label
         },
-        plainTextStyles
+        labelTextStyles
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -32,6 +31,7 @@ export const templateStyles: ElementStyles = css`
     }
 
     .control {
+        font: inherit;
         resize: none;
     }
 
@@ -57,10 +57,6 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        ${typeRampBase}
-    }
-
     .label {
         margin-bottom: 4px;
     }

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
@@ -1,7 +1,8 @@
 import {
     inputStyles,
-    plainTextStyles,
+    labelTextStyles,
     StyleModules,
+    typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { TextFieldAnatomy } from "./text-field.template.js";
 
@@ -13,9 +14,14 @@ import { TextFieldAnatomy } from "./text-field.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        typeRampBaseStyles
+    ],
+    [
+        {
             part: TextFieldAnatomy.parts.label
         },
-        plainTextStyles
+        labelTextStyles
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -4,7 +4,6 @@ import {
     focusStrokeOuter,
     focusStrokeWidth,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -25,6 +24,7 @@ export const templateStyles: ElementStyles = css`
 
     .control {
         -webkit-appearance: none;
+        font: inherit;
     }
 
     .label.label__hidden {
@@ -54,7 +54,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        ${typeRampBase}
         fill: currentcolor;
     }
 
@@ -84,7 +83,6 @@ export const aestheticStyles: ElementStyles = css`
         border: none;
         background: transparent;
         color: inherit;
-        font-family: inherit;
     }
 
     .control:focus-visible {

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        plainTextStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -2,10 +2,8 @@ import {
     controlCornerRadius,
     elevationTooltip,
     neutralFillSubtleRest,
-    neutralForegroundRest,
     neutralStrokeSubtleRest,
     strokeWidth,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -39,8 +37,6 @@ export const aestheticStyles: ElementStyles = css`
         border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
         border-radius: calc(${controlCornerRadius} * 1px);
         background: ${neutralFillSubtleRest};
-        color: ${neutralForegroundRest};
-        ${typeRampBase}
         white-space: nowrap;
         box-shadow: ${elevationTooltip};
     }

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -9,7 +9,6 @@ import {
     neutralFillSubtleRest,
     strokeWidth,
     Swatch,
-    typeRampBase,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
@@ -114,7 +113,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 2px + 8px);
         fill: currentcolor;
-        ${typeRampBase}
     }
 
     :host(:focus-visible) .control {


### PR DESCRIPTION
# Pull Request

## Description

(I'll rebase this once my previous PR is merged)

Migrated the type ramp styles to use style modules for all components.

## Reviewer Notes

Some styles were setup to inherit the font from the host. I think this is strongest since it covers multiple elements at once, and allows for directing specific element overrides. For instance, I added a `label` style that creates a single place for adjusting all component labels together.

## Test Plan

Reviewed in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component