### PR TITLE
Bring design tokens and styles closer to design token community group guidelines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
     "extends": ["@microsoft/eslint-config-fast-dna"],
-    "ignorePatterns": ["dist", "*.spec.ts"]
+    "ignorePatterns": ["dist", "*.spec.ts"],
+    "rules": {
+        "max-len": "warn"
+    }
 }

--- a/change/@adaptive-web-adaptive-ui-f0fd0cb6-8f91-4965-ab74-e15faa0b4a19.json
+++ b/change/@adaptive-web-adaptive-ui-f0fd0cb6-8f91-4965-ab74-e15faa0b4a19.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Bridge token structure between Adaptive UI and DT community group",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-e5498ff0-2dad-4771-8726-a873b912dd26.json
+++ b/change/@adaptive-web-adaptive-web-components-e5498ff0-2dad-4771-8726-a873b912dd26.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Migrate border styling to modules",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -1,9 +1,9 @@
 import {
     accentFillReadableControlStyles,
-    accentStrokeReadableInteractiveSet,
+    accentStrokeReadable,
     accentStrokeReadableRecipe,
     createForegroundSet,
-    neutralFillSubtleInteractiveSet,
+    neutralFillSubtle,
     Styles,
 } from '@adaptive-web/adaptive-ui';
 import {
@@ -35,9 +35,9 @@ AdaptiveDesignSystem.defineComponents({
 
 // Define a custom style module.
 const accentOutlineReadableControlStyles: Styles = Styles.fromProperties({
-    backgroundFill: neutralFillSubtleInteractiveSet,
-    borderFill: accentStrokeReadableInteractiveSet,
-    foregroundFill: createForegroundSet(accentStrokeReadableRecipe, "rest", neutralFillSubtleInteractiveSet),
+    backgroundFill: neutralFillSubtle,
+    borderFill: accentStrokeReadable,
+    foregroundFill: createForegroundSet(accentStrokeReadableRecipe, "rest", neutralFillSubtle),
 });
 
 const myDS = new DesignSystem("my");

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -1,6 +1,5 @@
-import { fillColor, InteractiveTokenSet, StyleProperty, Styles, Swatch } from "@adaptive-web/adaptive-ui";
+import { fillColor, InteractiveTokenGroup, StyleProperty, Styles, Swatch, TypedCSSDesignToken } from "@adaptive-web/adaptive-ui";
 import { css, customElement, FASTElement, html, observable, repeat, volatile } from "@microsoft/fast-element";
-import { CSSDesignToken } from "@microsoft/fast-foundation";
 import { SwatchType } from "./swatch.js";
 import "./adaptive-component.js";
 import "./swatch.js";
@@ -43,9 +42,9 @@ const styles = css`
 interface StyleValue {
     type: SwatchType;
     tokenName: string;
-    foregroundRecipe?: CSSDesignToken<Swatch>;
-    fillRecipe?: CSSDesignToken<Swatch>;
-    outlineRecipe?: CSSDesignToken<Swatch>;
+    foregroundRecipe?: TypedCSSDesignToken<Swatch>;
+    fillRecipe?: TypedCSSDesignToken<Swatch>;
+    outlineRecipe?: TypedCSSDesignToken<Swatch>;
 }
 
 @customElement({
@@ -70,15 +69,15 @@ export class StyleExample extends FASTElement {
         if (backgroundValue) {
             if (typeof backgroundValue === "string") {
                 // ignore for now
-            } else if (backgroundValue instanceof CSSDesignToken) {
+            } else if (backgroundValue instanceof TypedCSSDesignToken) {
                 backgroundRest = backgroundValue;
                 values.push({
                     type: SwatchType.fill,
-                    tokenName: (backgroundValue as CSSDesignToken<any>).name,
+                    tokenName: (backgroundValue as TypedCSSDesignToken<any>).name,
                     fillRecipe: backgroundValue,
                 });
             } else {
-                const set = backgroundValue as InteractiveTokenSet<any>;
+                const set = backgroundValue as InteractiveTokenGroup<any>;
                 backgroundRest = set.rest;
                 backgroundHover = set.hover;
                 backgroundActive = set.active;
@@ -110,15 +109,15 @@ export class StyleExample extends FASTElement {
         if (colorValue) {
             if (typeof colorValue === "string") {
                 // ignore for now
-            } else if (colorValue instanceof CSSDesignToken) {
+            } else if (colorValue instanceof TypedCSSDesignToken) {
                 values.push({
                     type: SwatchType.foreground,
-                    tokenName: (colorValue as CSSDesignToken<any>).name,
+                    tokenName: (colorValue as TypedCSSDesignToken<any>).name,
                     foregroundRecipe: colorValue,
                     fillRecipe: backgroundRest,
                 });
             } else {
-                const set = colorValue as InteractiveTokenSet<any>;
+                const set = colorValue as InteractiveTokenGroup<any>;
                 values.push({
                     type: SwatchType.foreground,
                     tokenName: set.rest.name,
@@ -150,15 +149,15 @@ export class StyleExample extends FASTElement {
         if (borderValue) {
             if (typeof borderValue === "string") {
                 // ignore for now
-            } else if (borderValue instanceof CSSDesignToken) {
+            } else if (borderValue instanceof TypedCSSDesignToken) {
                 values.push({
                     type: SwatchType.outline,
-                    tokenName: (borderValue as CSSDesignToken<any>).name,
+                    tokenName: (borderValue as TypedCSSDesignToken<any>).name,
                     outlineRecipe: borderValue,
                     fillRecipe: backgroundRest,
                 });
             } else {
-                const set = borderValue as InteractiveTokenSet<any>;
+                const set = borderValue as InteractiveTokenGroup<any>;
                 values.push({
                     type: SwatchType.outline,
                     tokenName: set.rest.name,

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -10,7 +10,8 @@ import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
 import { DesignTokenResolver } from '@microsoft/fast-foundation';
 import type { ElementStyles } from '@microsoft/fast-element';
-import type { ValuesOf } from '@microsoft/fast-foundation';
+import { TypedCSSDesignToken as TypedCSSDesignToken_2 } from '../adaptive-design-tokens.js';
+import { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public (undocumented)
 export const accentBaseColor: CSSDesignToken<string>;
@@ -19,46 +20,49 @@ export const accentBaseColor: CSSDesignToken<string>;
 export const accentBaseSwatch: DesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const accentFillActive: CSSDesignToken<Swatch>;
+export const accentFillActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillDiscernibleActive: CSSDesignToken<Swatch>;
+export const accentFillDiscernible: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const accentFillDiscernibleActive: TypedCSSDesignToken<Swatch>;
 
 // @public
 export const accentFillDiscernibleControlStyles: Styles;
 
 // @public (undocumented)
-export const accentFillDiscernibleFocus: CSSDesignToken<Swatch>;
+export const accentFillDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillDiscernibleHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const accentFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentFillDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentFillDiscernibleRest: CSSDesignToken<Swatch>;
+export const accentFillDiscernibleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const accentFillFocus: CSSDesignToken<Swatch>;
+export const accentFillFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const accentFillHover: CSSDesignToken<Swatch>;
+export const accentFillHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillReadableActive: CSSDesignToken<Swatch>;
+export const accentFillReadable: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const accentFillReadableActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillReadableActiveDelta: DesignToken<number>;
@@ -67,25 +71,22 @@ export const accentFillReadableActiveDelta: DesignToken<number>;
 export const accentFillReadableControlStyles: Styles;
 
 // @public (undocumented)
-export const accentFillReadableFocus: CSSDesignToken<Swatch>;
+export const accentFillReadableFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillReadableHover: CSSDesignToken<Swatch>;
+export const accentFillReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const accentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentFillReadableRest: CSSDesignToken<Swatch>;
+export const accentFillReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillReadableRestDelta: DesignToken<number>;
@@ -94,67 +95,67 @@ export const accentFillReadableRestDelta: DesignToken<number>;
 export const accentFillRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const accentFillRest: CSSDesignToken<Swatch>;
+export const accentFillRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentFillRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillStealthActive: CSSDesignToken<Swatch>;
+export const accentFillStealth: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const accentFillStealthActive: TypedCSSDesignToken<Swatch>;
 
 // @public
 export const accentFillStealthControlStyles: Styles;
 
 // @public (undocumented)
-export const accentFillStealthFocus: CSSDesignToken<Swatch>;
+export const accentFillStealthFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillStealthHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const accentFillStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentFillStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentFillStealthRest: CSSDesignToken<Swatch>;
+export const accentFillStealthRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillSubtleActive: CSSDesignToken<Swatch>;
+export const accentFillSubtle: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const accentFillSubtleActive: TypedCSSDesignToken<Swatch>;
 
 // @public
 export const accentFillSubtleControlStyles: Styles;
 
 // @public (undocumented)
-export const accentFillSubtleFocus: CSSDesignToken<Swatch>;
+export const accentFillSubtleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillSubtleHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const accentFillSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentFillSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentFillSubtleRest: CSSDesignToken<Swatch>;
+export const accentFillSubtleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const accentForegroundActive: CSSDesignToken<Swatch>;
+export const accentForegroundActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const accentForegroundFocus: CSSDesignToken<Swatch>;
+export const accentForegroundFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const accentForegroundHover: CSSDesignToken<Swatch>;
+export const accentForegroundHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundHoverDelta: DesignToken<number>;
@@ -166,7 +167,7 @@ export const accentForegroundReadableControlStyles: Styles;
 export const accentForegroundRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const accentForegroundRest: CSSDesignToken<Swatch>;
+export const accentForegroundRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundRestDelta: DesignToken<number>;
@@ -178,124 +179,124 @@ export const accentOutlineDiscernibleControlStyles: Styles;
 export const accentPalette: DesignToken<Palette<Swatch>>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleActive: CSSDesignToken<Swatch>;
+export const accentStrokeDiscernible: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleFocus: CSSDesignToken<Swatch>;
+export const accentStrokeDiscernibleActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleHover: CSSDesignToken<Swatch>;
+export const accentStrokeDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentStrokeDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleRest: CSSDesignToken<Swatch>;
+export const accentStrokeDiscernibleRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeReadableActive: CSSDesignToken<Swatch>;
+export const accentStrokeReadable: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const accentStrokeReadableActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentStrokeReadableActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentStrokeReadableFocus: CSSDesignToken<Swatch>;
+export const accentStrokeReadableFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentStrokeReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentStrokeReadableHover: CSSDesignToken<Swatch>;
+export const accentStrokeReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const accentStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeReadableRest: CSSDesignToken<Swatch>;
+export const accentStrokeReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const accentStrokeReadableRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentStrokeSafetyActive: CSSDesignToken<Swatch>;
+export const accentStrokeSafety: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSafetyFocus: CSSDesignToken<Swatch>;
+export const accentStrokeSafetyActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSafetyHover: CSSDesignToken<Swatch>;
+export const accentStrokeSafetyFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentStrokeSafetyHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeSafetyRest: CSSDesignToken<Swatch>;
+export const accentStrokeSafetyRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStealthActive: CSSDesignToken<Swatch>;
+export const accentStrokeStealth: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStealthFocus: CSSDesignToken<Swatch>;
+export const accentStrokeStealthActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStealthHover: CSSDesignToken<Swatch>;
+export const accentStrokeStealthFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentStrokeStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeStealthRest: CSSDesignToken<Swatch>;
+export const accentStrokeStealthRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStrongActive: CSSDesignToken<Swatch>;
+export const accentStrokeStrong: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStrongFocus: CSSDesignToken<Swatch>;
+export const accentStrokeStrongActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStrongHover: CSSDesignToken<Swatch>;
+export const accentStrokeStrongFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentStrokeStrongHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeStrongRest: CSSDesignToken<Swatch>;
+export const accentStrokeStrongRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSubtleActive: CSSDesignToken<Swatch>;
+export const accentStrokeSubtle: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSubtleFocus: CSSDesignToken<Swatch>;
+export const accentStrokeSubtleActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSubtleHover: CSSDesignToken<Swatch>;
+export const accentStrokeSubtleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
+export const accentStrokeSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const accentStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const accentStrokeSubtleRest: CSSDesignToken<Swatch>;
+export const accentStrokeSubtleRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const actionStyles: Styles;
@@ -334,8 +335,11 @@ export const blackOrWhiteDiscernibleRecipe: DesignToken<InteractiveColorRecipeBy
 // @public
 export const blackOrWhiteReadableRecipe: DesignToken<InteractiveColorRecipeBySet>;
 
+// @public @deprecated (undocumented)
+export const bodyFont: TypedCSSDesignToken_2<string>;
+
 // @public (undocumented)
-export const bodyFont: CSSDesignToken<string>;
+export const bodyFontFamily: TypedCSSDesignToken_2<string>;
 
 // @public
 export interface ColorRecipe<T = Swatch> {
@@ -381,17 +385,82 @@ export const ContrastTarget: Readonly<{
     readonly LargeText: 3;
 }>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const controlCornerRadius: CSSDesignToken<number>;
 
 // @public
-export const createForegroundSet: (foregroundRecipe: DesignToken<InteractiveColorRecipe>, foregroundState: keyof InteractiveSet<any>, background: InteractiveTokenSet<Swatch>) => InteractiveTokenSet<Swatch>;
+export const controlShapeStyles: Styles;
+
+// @public (undocumented)
+export const cornerRadiusControl: TypedCSSDesignToken_2<string>;
+
+// @public (undocumented)
+export const cornerRadiusLayer: TypedCSSDesignToken_2<string>;
+
+// Warning: (ae-internal-missing-underscore) The name "create" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal @deprecated (undocumented)
+export const create: typeof DesignToken.create;
+
+// @public
+export const createForegroundSet: (foregroundRecipe: DesignToken<InteractiveColorRecipe>, foregroundState: keyof InteractiveSet<any>, background: InteractiveTokenGroup<Swatch>) => InteractiveTokenGroup<Swatch>;
+
+// Warning: (ae-internal-missing-underscore) The name "createNonCss" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal @deprecated (undocumented)
+export function createNonCss<T>(name: string): DesignToken<T>;
+
+// @public
+export function createTokenDimension(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<string>;
+
+// @public
+export function createTokenFontFamily(name: string): TypedCSSDesignToken<string>;
+
+// @public
+export function createTokenFontSize(name: string): TypedCSSDesignToken<string>;
+
+// @public
+export function createTokenFontVariations(name: string): TypedCSSDesignToken<string>;
+
+// @public
+export function createTokenFontWeight(name: string): TypedCSSDesignToken<number>;
+
+// @public
+export function createTokenLineHeight(name: string): TypedCSSDesignToken<string>;
+
+// @public
+export function createTokenNonCss<T>(name: string): DesignToken<T>;
+
+// @public
+export function createTokenSwatch(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch>;
 
 // @public
 export function deltaSwatch(palette: Palette, reference: Swatch, delta: number, direction?: PaletteDirection): Swatch;
 
 // @public
 export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
+
+// @public
+export const DesignTokenType: {
+    readonly color: "color";
+    readonly dimension: "dimension";
+    readonly fontFamily: "fontFamily";
+    readonly fontWeight: "fontWeight";
+    readonly duration: "duration";
+    readonly cubicBezier: "cubicBezier";
+    readonly number: "number";
+    readonly strokeStyle: "strokeStyle";
+    readonly border: "border";
+    readonly transition: "transition";
+    readonly shadow: "shadow";
+    readonly gradient: "gradient";
+    readonly typography: "typography";
+    readonly fontStyle: "fontStyle";
+    readonly fontVariations: "fontVariations";
+};
+
+// @public
+export type DesignTokenType = ValuesOf<typeof DesignTokenType> | string;
 
 // @public (undocumented)
 export const designUnit: CSSDesignToken<number>;
@@ -450,7 +519,7 @@ export const elevationTooltip: CSSDesignToken<string>;
 export const elevationTooltipSize: DesignToken<number>;
 
 // @public (undocumented)
-export const fillColor: CSSDesignToken<Swatch>;
+export const fillColor: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const fillDiscernibleActiveDelta: DesignToken<number>;
@@ -504,13 +573,13 @@ export const fillSubtleRestDelta: DesignToken<number>;
 export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 
 // @public (undocumented)
-export const focusStrokeInner: CSSDesignToken<Swatch>;
+export const focusStrokeInner: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const focusStrokeInnerRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public (undocumented)
-export const focusStrokeOuter: CSSDesignToken<Swatch>;
+export const focusStrokeOuter: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const focusStrokeOuterRecipe: DesignToken<ColorRecipe<Swatch>>;
@@ -519,40 +588,43 @@ export const focusStrokeOuterRecipe: DesignToken<ColorRecipe<Swatch>>;
 export const focusStrokeWidth: CSSDesignToken<number>;
 
 // @public (undocumented)
-export const fontWeight: CSSDesignToken<number>;
+export const fontFamily: TypedCSSDesignToken_2<string>;
+
+// @public (undocumented)
+export const fontWeight: TypedCSSDesignToken_2<number>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentActive: CSSDesignToken<Swatch>;
+export const foregroundOnAccentActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableActive: CSSDesignToken<Swatch>;
+export const foregroundOnAccentFillReadable: InteractiveTokenGroup<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableFocus: CSSDesignToken<Swatch>;
+export const foregroundOnAccentFillReadableActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableHover: CSSDesignToken<Swatch>;
+export const foregroundOnAccentFillReadableFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
+export const foregroundOnAccentFillReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableRest: CSSDesignToken<Swatch>;
+export const foregroundOnAccentFillReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFocus: CSSDesignToken<Swatch>;
+export const foregroundOnAccentFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentHover: CSSDesignToken<Swatch>;
+export const foregroundOnAccentHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const foregroundOnAccentRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentRest: CSSDesignToken<Swatch>;
+export const foregroundOnAccentRest: TypedCSSDesignToken<Swatch>;
 
 // @public
 export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection): InteractiveSwatchSet;
@@ -584,7 +656,7 @@ export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {
 export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
 
 // @public
-export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>> {
+export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveSet<TypedCSSDesignToken<T>> {
 }
 
 // @public
@@ -608,6 +680,9 @@ export function isDark(color: RelativeLuminance): boolean;
 export const itemStyles: Styles;
 
 // @public (undocumented)
+export const labelFontFamily: TypedCSSDesignToken_2<string>;
+
+// @public (undocumented)
 export const labelTextStyles: Styles;
 
 // @public
@@ -616,7 +691,7 @@ export const LayerBaseLuminance: Readonly<{
     readonly DarkMode: 0.15;
 }>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const layerCornerRadius: CSSDesignToken<number>;
 
 // @public
@@ -688,6 +763,9 @@ export interface LayerRecipe {
 }
 
 // @public
+export const layerShapeStyles: Styles;
+
+// @public
 export function luminanceSwatch(luminance: number): Swatch;
 
 // @public
@@ -721,13 +799,16 @@ export const neutralDividerDiscernibleElementStyles: Styles;
 export const neutralDividerSubtleElementStyles: Styles;
 
 // @public @deprecated (undocumented)
-export const neutralFillActive: CSSDesignToken<Swatch>;
+export const neutralFillActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillDiscernibleActive: CSSDesignToken<Swatch>;
+export const neutralFillDiscernible: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralFillDiscernibleActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillDiscernibleActiveDelta: DesignToken<number>;
@@ -736,55 +817,52 @@ export const neutralFillDiscernibleActiveDelta: DesignToken<number>;
 export const neutralFillDiscernibleControlStyles: Styles;
 
 // @public (undocumented)
-export const neutralFillDiscernibleFocus: CSSDesignToken<Swatch>;
+export const neutralFillDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillDiscernibleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillDiscernibleHover: CSSDesignToken<Swatch>;
+export const neutralFillDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralFillDiscernibleRest: CSSDesignToken<Swatch>;
+export const neutralFillDiscernibleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillDiscernibleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillFocus: CSSDesignToken<Swatch>;
+export const neutralFillFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillHover: CSSDesignToken<Swatch>;
+export const neutralFillHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillInputActive: CSSDesignToken<Swatch>;
+export const neutralFillInputActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillInputFocus: CSSDesignToken<Swatch>;
+export const neutralFillInputFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillInputHover: CSSDesignToken<Swatch>;
+export const neutralFillInputHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputHoverDelta: DesignToken<number>;
@@ -793,55 +871,55 @@ export const neutralFillInputHoverDelta: DesignToken<number>;
 export const neutralFillInputRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralFillInputRest: CSSDesignToken<Swatch>;
+export const neutralFillInputRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillReadableActive: CSSDesignToken<Swatch>;
+export const neutralFillReadable: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralFillReadableActive: TypedCSSDesignToken<Swatch>;
 
 // @public
 export const neutralFillReadableControlStyles: Styles;
 
 // @public (undocumented)
-export const neutralFillReadableFocus: CSSDesignToken<Swatch>;
+export const neutralFillReadableFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralFillReadableHover: CSSDesignToken<Swatch>;
-
-// @public (undocumented)
-export const neutralFillReadableInteractiveSet: InteractiveTokenSet<Swatch>;
+export const neutralFillReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const neutralFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralFillReadableRest: CSSDesignToken<Swatch>;
+export const neutralFillReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralFillRest: CSSDesignToken<Swatch>;
+export const neutralFillRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillSecondaryActive: CSSDesignToken<Swatch>;
+export const neutralFillSecondaryActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSecondaryActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillSecondaryFocus: CSSDesignToken<Swatch>;
+export const neutralFillSecondaryFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSecondaryFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillSecondaryHover: CSSDesignToken<Swatch>;
+export const neutralFillSecondaryHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSecondaryHoverDelta: DesignToken<number>;
@@ -850,13 +928,16 @@ export const neutralFillSecondaryHoverDelta: DesignToken<number>;
 export const neutralFillSecondaryRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralFillSecondaryRest: CSSDesignToken<Swatch>;
+export const neutralFillSecondaryRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSecondaryRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillStealthActive: CSSDesignToken<Swatch>;
+export const neutralFillStealth: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralFillStealthActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStealthActiveDelta: DesignToken<number>;
@@ -865,43 +946,40 @@ export const neutralFillStealthActiveDelta: DesignToken<number>;
 export const neutralFillStealthControlStyles: Styles;
 
 // @public (undocumented)
-export const neutralFillStealthFocus: CSSDesignToken<Swatch>;
+export const neutralFillStealthFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStealthFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillStealthHover: CSSDesignToken<Swatch>;
+export const neutralFillStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStealthHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillStealthInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralFillStealthRest: CSSDesignToken<Swatch>;
+export const neutralFillStealthRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStealthRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongActive: CSSDesignToken<Swatch>;
+export const neutralFillStrongActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStrongActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongFocus: CSSDesignToken<Swatch>;
+export const neutralFillStrongFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStrongFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongHover: CSSDesignToken<Swatch>;
+export const neutralFillStrongHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStrongHoverDelta: DesignToken<number>;
@@ -910,13 +988,16 @@ export const neutralFillStrongHoverDelta: DesignToken<number>;
 export const neutralFillStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongRest: CSSDesignToken<Swatch>;
+export const neutralFillStrongRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStrongRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillSubtleActive: CSSDesignToken<Swatch>;
+export const neutralFillSubtle: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralFillSubtleActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSubtleActiveDelta: DesignToken<number>;
@@ -925,49 +1006,46 @@ export const neutralFillSubtleActiveDelta: DesignToken<number>;
 export const neutralFillSubtleControlStyles: Styles;
 
 // @public (undocumented)
-export const neutralFillSubtleFocus: CSSDesignToken<Swatch>;
+export const neutralFillSubtleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillSubtleHover: CSSDesignToken<Swatch>;
+export const neutralFillSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralFillSubtleRest: CSSDesignToken<Swatch>;
+export const neutralFillSubtleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSubtleRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundActive: CSSDesignToken<Swatch>;
+export const neutralForegroundActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundFocus: CSSDesignToken<Swatch>;
+export const neutralForegroundFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundHint: CSSDesignToken<Swatch>;
+export const neutralForegroundHint: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundHintRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundHover: CSSDesignToken<Swatch>;
+export const neutralForegroundHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundHoverDelta: DesignToken<number>;
@@ -982,7 +1060,7 @@ export const neutralForegroundReadableElementStyles: Styles;
 export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundRest: CSSDesignToken<Swatch>;
+export const neutralForegroundRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundRestDelta: DesignToken<number>;
@@ -997,37 +1075,37 @@ export const neutralOutlineDiscernibleControlStyles: Styles;
 export const neutralPalette: DesignToken<Palette<Swatch>>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeActive: CSSDesignToken<Swatch>;
+export const neutralStrokeActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleActive: CSSDesignToken<Swatch>;
+export const neutralStrokeDiscernible: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeDiscernibleActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleHover: CSSDesignToken<Swatch>;
+export const neutralStrokeDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleRest: CSSDesignToken<Swatch>;
+export const neutralStrokeDiscernibleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDiscernibleRestDelta: DesignToken<number>;
@@ -1036,37 +1114,37 @@ export const neutralStrokeDiscernibleRestDelta: DesignToken<number>;
 export const neutralStrokeDividerRecipe: DesignToken<ColorRecipe<Swatch>>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeDividerRest: CSSDesignToken<Swatch>;
+export const neutralStrokeDividerRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeDividerRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeHover: CSSDesignToken<Swatch>;
+export const neutralStrokeHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeInputActive: CSSDesignToken<Swatch>;
+export const neutralStrokeInputActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputActiveDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeInputFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeInputFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputFocusDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeInputHover: CSSDesignToken<Swatch>;
+export const neutralStrokeInputHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputHoverDelta: DesignToken<number>;
@@ -1075,37 +1153,37 @@ export const neutralStrokeInputHoverDelta: DesignToken<number>;
 export const neutralStrokeInputRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeInputRest: CSSDesignToken<Swatch>;
+export const neutralStrokeInputRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableActive: CSSDesignToken<Swatch>;
+export const neutralStrokeReadable: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeReadableActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeReadableActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeReadableFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableHover: CSSDesignToken<Swatch>;
+export const neutralStrokeReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeReadableRest: CSSDesignToken<Swatch>;
+export const neutralStrokeReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeReadableRestDelta: DesignToken<number>;
@@ -1114,67 +1192,67 @@ export const neutralStrokeReadableRestDelta: DesignToken<number>;
 export const neutralStrokeRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeRest: CSSDesignToken<Swatch>;
+export const neutralStrokeRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyActive: CSSDesignToken<Swatch>;
+export const neutralStrokeSafety: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeSafetyActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyHover: CSSDesignToken<Swatch>;
+export const neutralStrokeSafetyFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch>;
+export const neutralStrokeSafetyHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const neutralStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyRest: CSSDesignToken<Swatch>;
+export const neutralStrokeSafetyRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStealthActive: CSSDesignToken<Swatch>;
+export const neutralStrokeStealth: InteractiveTokenGroup<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStealthFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeStealthActive: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStealthHover: CSSDesignToken<Swatch>;
+export const neutralStrokeStealthFocus: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch>;
+export const neutralStrokeStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
 export const neutralStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeStealthRest: CSSDesignToken<Swatch>;
+export const neutralStrokeStealthRest: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStrongActive: CSSDesignToken<Swatch>;
+export const neutralStrokeStrong: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeStrongActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeStrongActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeStrongFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeStrongFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeStrongFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeStrongHover: CSSDesignToken<Swatch>;
+export const neutralStrokeStrongHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeStrongHoverDelta: DesignToken<number>;
-
-// @public (undocumented)
-export const neutralStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeStrongMinContrast: DesignToken<number>;
@@ -1183,37 +1261,37 @@ export const neutralStrokeStrongMinContrast: DesignToken<number>;
 export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeStrongRest: CSSDesignToken<Swatch>;
+export const neutralStrokeStrongRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeStrongRestDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleActive: CSSDesignToken<Swatch>;
+export const neutralStrokeSubtle: InteractiveTokenGroup<Swatch>;
+
+// @public (undocumented)
+export const neutralStrokeSubtleActive: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeSubtleActiveDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleFocus: CSSDesignToken<Swatch>;
+export const neutralStrokeSubtleFocus: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleHover: CSSDesignToken<Swatch>;
+export const neutralStrokeSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch>;
-
-// @public (undocumented)
 export const neutralStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleRest: CSSDesignToken<Swatch>;
+export const neutralStrokeSubtleRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeSubtleRestDelta: DesignToken<number>;
@@ -1364,6 +1442,9 @@ export const strokeSubtleHoverDelta: DesignToken<number>;
 export const strokeSubtleRestDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const strokeThickness: TypedCSSDesignToken_2<string>;
+
+// @public @deprecated (undocumented)
 export const strokeWidth: CSSDesignToken<number>;
 
 // @public
@@ -1380,7 +1461,7 @@ export interface StyleModuleTarget {
 }
 
 // @public
-export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenSet<any> | CSSDirective | string>>;
+export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>>;
 
 // @public
 export const StyleProperty: {
@@ -1450,17 +1531,33 @@ export class SwatchRGB implements Swatch {
     toColorString(): string;
 }
 
+// @public
+export interface TokenGroup {
+    // (undocumented)
+    name: string;
+}
+
+// @public
+export class TypedCSSDesignToken<T> extends CSSDesignToken<T> {
+    constructor(name: string, allowedTypes: DesignTokenType | DesignTokenType[], intendedFor?: StyleProperty | StyleProperty[]);
+    // (undocumented)
+    readonly allowedTypes: DesignTokenType[];
+    static createTyped<T>(name: string, allowedTypes: DesignTokenType | DesignTokenType[], intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<T>;
+    // (undocumented)
+    readonly intendedFor?: StyleProperty[];
+}
+
 // @public @deprecated (undocumented)
 export const typeRampBase: CSSDirective;
 
 // @public (undocumented)
-export const typeRampBaseFontSize: CSSDesignToken<string>;
+export const typeRampBaseFontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampBaseFontVariations: CSSDesignToken<string>;
+export const typeRampBaseFontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampBaseLineHeight: CSSDesignToken<string>;
+export const typeRampBaseLineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampBaseStyles: Styles;
@@ -1469,13 +1566,13 @@ export const typeRampBaseStyles: Styles;
 export const typeRampMinus1: CSSDirective;
 
 // @public (undocumented)
-export const typeRampMinus1FontSize: CSSDesignToken<string>;
+export const typeRampMinus1FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampMinus1FontVariations: CSSDesignToken<string>;
+export const typeRampMinus1FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampMinus1LineHeight: CSSDesignToken<string>;
+export const typeRampMinus1LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampMinus1Styles: Styles;
@@ -1484,13 +1581,13 @@ export const typeRampMinus1Styles: Styles;
 export const typeRampMinus2: CSSDirective;
 
 // @public (undocumented)
-export const typeRampMinus2FontSize: CSSDesignToken<string>;
+export const typeRampMinus2FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampMinus2FontVariations: CSSDesignToken<string>;
+export const typeRampMinus2FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampMinus2LineHeight: CSSDesignToken<string>;
+export const typeRampMinus2LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampMinus2Styles: Styles;
@@ -1499,13 +1596,13 @@ export const typeRampMinus2Styles: Styles;
 export const typeRampPlus1: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus1FontSize: CSSDesignToken<string>;
+export const typeRampPlus1FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus1FontVariations: CSSDesignToken<string>;
+export const typeRampPlus1FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus1LineHeight: CSSDesignToken<string>;
+export const typeRampPlus1LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus1Styles: Styles;
@@ -1514,13 +1611,13 @@ export const typeRampPlus1Styles: Styles;
 export const typeRampPlus2: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus2FontSize: CSSDesignToken<string>;
+export const typeRampPlus2FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus2FontVariations: CSSDesignToken<string>;
+export const typeRampPlus2FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus2LineHeight: CSSDesignToken<string>;
+export const typeRampPlus2LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus2Styles: Styles;
@@ -1529,13 +1626,13 @@ export const typeRampPlus2Styles: Styles;
 export const typeRampPlus3: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus3FontSize: CSSDesignToken<string>;
+export const typeRampPlus3FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus3FontVariations: CSSDesignToken<string>;
+export const typeRampPlus3FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus3LineHeight: CSSDesignToken<string>;
+export const typeRampPlus3LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus3Styles: Styles;
@@ -1544,13 +1641,13 @@ export const typeRampPlus3Styles: Styles;
 export const typeRampPlus4: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus4FontSize: CSSDesignToken<string>;
+export const typeRampPlus4FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus4FontVariations: CSSDesignToken<string>;
+export const typeRampPlus4FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus4LineHeight: CSSDesignToken<string>;
+export const typeRampPlus4LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus4Styles: Styles;
@@ -1559,13 +1656,13 @@ export const typeRampPlus4Styles: Styles;
 export const typeRampPlus5: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus5FontSize: CSSDesignToken<string>;
+export const typeRampPlus5FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus5FontVariations: CSSDesignToken<string>;
+export const typeRampPlus5FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus5LineHeight: CSSDesignToken<string>;
+export const typeRampPlus5LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus5Styles: Styles;
@@ -1574,13 +1671,13 @@ export const typeRampPlus5Styles: Styles;
 export const typeRampPlus6: CSSDirective;
 
 // @public (undocumented)
-export const typeRampPlus6FontSize: CSSDesignToken<string>;
+export const typeRampPlus6FontSize: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus6FontVariations: CSSDesignToken<string>;
+export const typeRampPlus6FontVariations: TypedCSSDesignToken_2<string>;
 
 // @public (undocumented)
-export const typeRampPlus6LineHeight: CSSDesignToken<string>;
+export const typeRampPlus6LineHeight: TypedCSSDesignToken_2<string>;
 
 // @public
 export const typeRampPlus6Styles: Styles;

--- a/packages/adaptive-ui/src/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/adaptive-design-tokens.ts
@@ -1,0 +1,66 @@
+import { cssDirective, htmlDirective } from "@microsoft/fast-element";
+import { CSSDesignToken, ValuesOf } from "@microsoft/fast-foundation";
+import { StyleProperty } from "./index.js";
+
+/**
+ * Standard design token types from the community group and new types defined in Adaptive UI.
+ *
+ * @public
+ */
+export const DesignTokenType = {
+    // From the DTCG recommended format
+    color: "color",
+    dimension: "dimension",
+    fontFamily: "fontFamily",
+    fontWeight: "fontWeight",
+    duration: "duration",
+    cubicBezier: "cubicBezier",
+    number: "number",
+    strokeStyle: "strokeStyle",
+    border: "border",
+    transition: "transition",
+    shadow: "shadow",
+    gradient: "gradient",
+    typography: "typography",
+    // Added in Adaptive UI
+    fontStyle: "fontStyle",
+    fontVariations: "fontVariations",
+} as const;
+
+/**
+ * A design token data type, either from the community group, Adaptive UI, or custom.
+ *
+ * @public
+ */
+export type DesignTokenType = ValuesOf<typeof DesignTokenType> | string;
+
+/**
+ * A DesignToken with allowed types and intended styling uses.
+ *
+ * @public
+ */
+@cssDirective()
+@htmlDirective()
+export class TypedCSSDesignToken<T> extends CSSDesignToken<T> {
+    public readonly allowedTypes: DesignTokenType[];
+    public readonly intendedFor?: StyleProperty[]
+
+    constructor(name: string, allowedTypes: DesignTokenType | DesignTokenType[], intendedFor?: StyleProperty | StyleProperty[]) {
+        super({ name, cssCustomPropertyName: name });
+        this.allowedTypes = [...allowedTypes];
+        if (intendedFor) {
+            this.intendedFor = [...intendedFor] as StyleProperty[];
+        }
+    }
+
+    /**
+     * Factory to create a DesignToken with allowed types and intended styling uses.
+     */
+    public static createTyped<T>(
+        name: string,
+        allowedTypes: DesignTokenType | DesignTokenType[],
+        intendedFor?: StyleProperty | StyleProperty[],
+    ): TypedCSSDesignToken<T> {
+        return new TypedCSSDesignToken<T>(name, allowedTypes, intendedFor);
+    }
+}

--- a/packages/adaptive-ui/src/design-tokens/appearance.ts
+++ b/packages/adaptive-ui/src/design-tokens/appearance.ts
@@ -1,16 +1,26 @@
-import { create } from "./create.js";
+import { StyleProperty } from "../modules/types.js";
+import { create, createTokenDimension } from "./create.js";
 
 /** @public */
 export const designUnit = create<number>("design-unit").withDefault(4);
 
-/** @public */
+/** @public @deprecated Use `cornerRadiusControl` instead */
 export const controlCornerRadius = create<number>("control-corner-radius").withDefault(4);
 
 /** @public */
+export const cornerRadiusControl = createTokenDimension("corner-radius-control", StyleProperty.cornerRadius).withDefault("4px");
+
+/** @public @deprecated Use `cornerRadiusLayer` instead */
 export const layerCornerRadius = create<number>("layer-corner-radius").withDefault(8);
 
 /** @public */
+export const cornerRadiusLayer = createTokenDimension("corner-radius-layer", StyleProperty.cornerRadius).withDefault("8px");
+
+/** @public @deprecated Use `strokeThickness` instead */
 export const strokeWidth = create<number>("stroke-width").withDefault(1);
+
+/** @public */
+export const strokeThickness = createTokenDimension("stroke-thickness", StyleProperty.borderThickness).withDefault("1px");
 
 /** @public */
 export const focusStrokeWidth = create<number>("focus-stroke-width").withDefault(2);

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -1,5 +1,5 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
-import type { CSSDesignToken, DesignToken, ValuesOf } from "@microsoft/fast-foundation";
+import type { DesignToken, ValuesOf } from "@microsoft/fast-foundation";
 import { ColorRecipe, InteractiveColorRecipe, InteractiveColorRecipeBySet, InteractiveSwatchSet } from "../color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../color/recipes/black-or-white-by-contrast-set.js";
 import { blackOrWhiteByContrast } from "../color/recipes/black-or-white-by-contrast.js";
@@ -10,15 +10,16 @@ import { Swatch } from "../color/swatch.js";
 import { _white } from "../color/utilities/color-constants.js";
 import { conditionalSwatchSet } from "../color/utilities/conditional.js";
 import { interactiveSwatchSetAsOverlay, swatchAsOverlay } from "../color/utilities/opacity.js";
-import type { InteractiveTokenSet } from "../types.js";
-import { create, createNonCss } from "./create.js";
+import type { InteractiveTokenGroup } from "../types.js";
+import { TypedCSSDesignToken } from "../adaptive-design-tokens.js";
+import { createNonCss, createTokenSwatch } from "./create.js";
 import { accentPalette, neutralPalette } from "./palette.js";
 
 function createDelta(name: string, state: keyof InteractiveSwatchSet, value: number | DesignToken<number>): DesignToken<number> {
     return createNonCss<number>(`${name}-${state}-delta`).withDefault(value);
 }
 
-function createMinContrast(name: string, value: number | DesignToken<number>) {
+function createMinContrast(name: string, value: number | DesignToken<number>): DesignToken<number> {
     return createNonCss<number>(`${name}-min-contrast`).withDefault(value);
 }
 
@@ -43,15 +44,15 @@ function createSet(recipeToken: DesignToken<InteractiveColorRecipe>): DesignToke
     );
 }
 
-function createStateToken(valueToken: DesignToken<InteractiveSwatchSet>, state: keyof InteractiveSwatchSet): CSSDesignToken<Swatch> {
-    return create<Swatch>(`${valueToken.name.replace("-recipe-value", "")}-${state}`).withDefault(
+function createStateToken(valueToken: DesignToken<InteractiveSwatchSet>, state: keyof InteractiveSwatchSet): TypedCSSDesignToken<Swatch> {
+    return createTokenSwatch(`${valueToken.name.replace("-recipe-value", "")}-${state}`).withDefault(
         (resolve: DesignTokenResolver) =>
             resolve(valueToken)[state]
     );
 }
 
-function createRecipeToken(recipeToken: DesignToken<ColorRecipe>): CSSDesignToken<Swatch> {
-    return create<Swatch>(`${recipeToken.name.replace("-recipe-value", "")}`).withDefault(
+function createRecipeToken(recipeToken: DesignToken<ColorRecipe>): TypedCSSDesignToken<Swatch> {
+    return createTokenSwatch(`${recipeToken.name.replace("-recipe-value", "")}`).withDefault(
         (resolve: DesignTokenResolver) =>
             resolve(recipeToken).evaluate(resolve)
     );
@@ -116,7 +117,7 @@ export const minContrastReadable = createNonCss<number>("min-contrast-readable")
 );
 
 /** @public */
-export const fillColor = create<Swatch>("fill-color").withDefault(_white);
+export const fillColor = createTokenSwatch("fill-color").withDefault(_white);
 
 /** @public */
 export const neutralAsOverlay = createNonCss<boolean>("neutral-as-overlay").withDefault(false);
@@ -344,7 +345,8 @@ export const accentFillStealthActive = createStateToken(accentFillStealthSet, "a
 export const accentFillStealthFocus = createStateToken(accentFillStealthSet, "focus");
 
 /** @public */
-export const accentFillStealthInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentFillStealth: InteractiveTokenGroup<Swatch> = {
+    name: accentFillStealthName,
     rest: accentFillStealthRest,
     hover: accentFillStealthHover,
     active: accentFillStealthActive,
@@ -383,7 +385,8 @@ export const accentFillSubtleActive = createStateToken(accentFillSubtleSet, "act
 export const accentFillSubtleFocus = createStateToken(accentFillSubtleSet, "focus");
 
 /** @public */
-export const accentFillSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentFillSubtle: InteractiveTokenGroup<Swatch> = {
+    name: accentFillSubtleName,
     rest: accentFillSubtleRest,
     hover: accentFillSubtleHover,
     active: accentFillSubtleActive,
@@ -423,7 +426,8 @@ export const accentFillDiscernibleActive = createStateToken(accentFillDiscernibl
 export const accentFillDiscernibleFocus = createStateToken(accentFillDiscernibleSet, "focus");
 
 /** @public */
-export const accentFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentFillDiscernible: InteractiveTokenGroup<Swatch> = {
+    name: accentFillDiscernibleName,
     rest: accentFillDiscernibleRest,
     hover: accentFillDiscernibleHover,
     active: accentFillDiscernibleActive,
@@ -475,7 +479,8 @@ export const accentFillReadableActive = createStateToken(accentFillReadableSet, 
 export const accentFillReadableFocus = createStateToken(accentFillReadableSet, "focus");
 
 /** @public */
-export const accentFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentFillReadable: InteractiveTokenGroup<Swatch> = {
+    name: accentFillReadableName,
     rest: accentFillReadableRest,
     hover: accentFillReadableHover,
     active: accentFillReadableActive,
@@ -514,7 +519,8 @@ export const foregroundOnAccentFillReadableActive = createStateToken(foregroundO
 export const foregroundOnAccentFillReadableFocus = createStateToken(foregroundOnAccentFillReadableSet, "focus");
 
 /** @public @deprecated This functionality has been migrated to style modules */
-export const foregroundOnAccentFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const foregroundOnAccentFillReadable: InteractiveTokenGroup<Swatch> = {
+    name: foregroundOnAccentFillReadableName,
     rest: foregroundOnAccentFillReadableRest,
     hover: foregroundOnAccentFillReadableHover,
     active: foregroundOnAccentFillReadableActive,
@@ -557,7 +563,8 @@ export const accentStrokeSafetyActive = createStateToken(accentStrokeSafetySet, 
 export const accentStrokeSafetyFocus = createStateToken(accentStrokeSafetySet, "focus");
 
 /** @public */
-export const accentStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeSafety: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeSafetyName,
     rest: accentStrokeSafetyRest,
     hover: accentStrokeSafetyHover,
     active: accentStrokeSafetyActive,
@@ -597,7 +604,8 @@ export const accentStrokeStealthActive = createStateToken(accentStrokeStealthSet
 export const accentStrokeStealthFocus = createStateToken(accentStrokeStealthSet, "focus");
 
 /** @public */
-export const accentStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeStealth: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeStealthName,
     rest: accentStrokeStealthRest,
     hover: accentStrokeStealthHover,
     active: accentStrokeStealthActive,
@@ -637,7 +645,8 @@ export const accentStrokeSubtleActive = createStateToken(accentStrokeSubtleSet, 
 export const accentStrokeSubtleFocus = createStateToken(accentStrokeSubtleSet, "focus");
 
 /** @public */
-export const accentStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeSubtle: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeSubtleName,
     rest: accentStrokeSubtleRest,
     hover: accentStrokeSubtleHover,
     active: accentStrokeSubtleActive,
@@ -677,7 +686,8 @@ export const accentStrokeDiscernibleActive = createStateToken(accentStrokeDiscer
 export const accentStrokeDiscernibleFocus = createStateToken(accentStrokeDiscernibleSet, "focus");
 
 /** @public */
-export const accentStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeDiscernible: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeDiscernibleName,
     rest: accentStrokeDiscernibleRest,
     hover: accentStrokeDiscernibleHover,
     active: accentStrokeDiscernibleActive,
@@ -729,7 +739,8 @@ export const accentStrokeReadableActive = createStateToken(accentStrokeReadableS
 export const accentStrokeReadableFocus = createStateToken(accentStrokeReadableSet, "focus");
 
 /** @public */
-export const accentStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeReadable: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeReadableName,
     rest: accentStrokeReadableRest,
     hover: accentStrokeReadableHover,
     active: accentStrokeReadableActive,
@@ -769,7 +780,8 @@ export const accentStrokeStrongActive = createStateToken(accentStrokeStrongSet, 
 export const accentStrokeStrongFocus = createStateToken(accentStrokeStrongSet, "focus");
 
 /** @public */
-export const accentStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const accentStrokeStrong: InteractiveTokenGroup<Swatch> = {
+    name: accentStrokeStrongName,
     rest: accentStrokeStrongRest,
     hover: accentStrokeStrongHover,
     active: accentStrokeStrongActive,
@@ -824,7 +836,8 @@ export const neutralFillStealthActive = createStateToken(neutralFillStealthSet, 
 export const neutralFillStealthFocus = createStateToken(neutralFillStealthSet, "focus");
 
 /** @public */
-export const neutralFillStealthInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralFillStealth: InteractiveTokenGroup<Swatch> = {
+    name: neutralFillStealthName,
     rest: neutralFillStealthRest,
     hover: neutralFillStealthHover,
     active: neutralFillStealthActive,
@@ -879,7 +892,8 @@ export const neutralFillSubtleActive = createStateToken(neutralFillSubtleSet, "a
 export const neutralFillSubtleFocus = createStateToken(neutralFillSubtleSet, "focus");
 
 /** @public */
-export const neutralFillSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralFillSubtle: InteractiveTokenGroup<Swatch> = {
+    name: neutralFillSubtleName,
     rest: neutralFillSubtleRest,
     hover: neutralFillSubtleHover,
     active: neutralFillSubtleActive,
@@ -935,7 +949,8 @@ export const neutralFillDiscernibleActive = createStateToken(neutralFillDiscerni
 export const neutralFillDiscernibleFocus = createStateToken(neutralFillDiscernibleSet, "focus");
 
 /** @public */
-export const neutralFillDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralFillDiscernible: InteractiveTokenGroup<Swatch> = {
+    name: neutralFillDiscernibleName,
     rest: neutralFillDiscernibleRest,
     hover: neutralFillDiscernibleHover,
     active: neutralFillDiscernibleActive,
@@ -975,7 +990,8 @@ export const neutralFillReadableActive = createStateToken(neutralFillReadableSet
 export const neutralFillReadableFocus = createStateToken(neutralFillReadableSet, "focus");
 
 /** @public */
-export const neutralFillReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralFillReadable: InteractiveTokenGroup<Swatch> = {
+    name: neutralFillReadableName,
     rest: neutralFillReadableRest,
     hover: neutralFillReadableHover,
     active: neutralFillReadableActive,
@@ -1022,7 +1038,8 @@ export const neutralStrokeSafetyActive = createStateToken(neutralStrokeSafetySet
 export const neutralStrokeSafetyFocus = createStateToken(neutralStrokeSafetySet, "focus");
 
 /** @public */
-export const neutralStrokeSafetyInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeSafety: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeSafetyName,
     rest: neutralStrokeSafetyRest,
     hover: neutralStrokeSafetyHover,
     active: neutralStrokeSafetyActive,
@@ -1066,7 +1083,8 @@ export const neutralStrokeStealthActive = createStateToken(neutralStrokeStealthS
 export const neutralStrokeStealthFocus = createStateToken(neutralStrokeStealthSet, "focus");
 
 /** @public */
-export const neutralStrokeStealthInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeStealth: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeStealthName,
     rest: neutralStrokeStealthRest,
     hover: neutralStrokeStealthHover,
     active: neutralStrokeStealthActive,
@@ -1122,7 +1140,8 @@ export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet
 export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus");
 
 /** @public */
-export const neutralStrokeSubtleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeSubtle: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeSubtleName,
     rest: neutralStrokeSubtleRest,
     hover: neutralStrokeSubtleHover,
     active: neutralStrokeSubtleActive,
@@ -1178,7 +1197,8 @@ export const neutralStrokeDiscernibleActive = createStateToken(neutralStrokeDisc
 export const neutralStrokeDiscernibleFocus = createStateToken(neutralStrokeDiscernibleSet, "focus");
 
 /** @public */
-export const neutralStrokeDiscernibleInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeDiscernible: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeDiscernibleName,
     rest: neutralStrokeDiscernibleRest,
     hover: neutralStrokeDiscernibleHover,
     active: neutralStrokeDiscernibleActive,
@@ -1234,7 +1254,8 @@ export const neutralStrokeReadableActive = createStateToken(neutralStrokeReadabl
 export const neutralStrokeReadableFocus = createStateToken(neutralStrokeReadableSet, "rest")
 
 /** @public */
-export const neutralStrokeReadableInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeReadable: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeReadableName,
     rest: neutralStrokeReadableRest,
     hover: neutralStrokeReadableHover,
     active: neutralStrokeReadableActive,
@@ -1293,7 +1314,8 @@ export const neutralStrokeStrongActive = createStateToken(neutralStrokeStrongSet
 export const neutralStrokeStrongFocus = createStateToken(neutralStrokeStrongSet, "focus");
 
 /** @public */
-export const neutralStrokeStrongInteractiveSet: InteractiveTokenSet<Swatch> = {
+export const neutralStrokeStrong: InteractiveTokenGroup<Swatch> = {
+    name: neutralStrokeStrongName,
     rest: neutralStrokeStrongRest,
     hover: neutralStrokeStrongHover,
     active: neutralStrokeStrongActive,

--- a/packages/adaptive-ui/src/design-tokens/create.ts
+++ b/packages/adaptive-ui/src/design-tokens/create.ts
@@ -1,9 +1,109 @@
 import { DesignToken } from "@microsoft/fast-foundation";
+import { DesignTokenType, TypedCSSDesignToken } from "../adaptive-design-tokens.js";
+import { Swatch } from "../color/swatch.js";
+import { StyleProperty } from "../modules/types.js";
 
-/** @internal */
+/** @internal @deprecated Use one of the typed `createTokenX` functions instead */
 export const { create } = DesignToken;
 
-/** @internal */
+/** @internal @deprecated Use `createTokenNonCss` instead */
 export function createNonCss<T>(name: string): DesignToken<T> {
     return DesignToken.create<T>({ name });
+}
+
+/**
+ * Creates a DesignToken that can be used by other DesignTokens, but not directly in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenNonCss<T>(name: string): DesignToken<T> {
+    return DesignToken.create<T>({ name });
+}
+
+/**
+ * Creates a DesignToken that can be used for thickness, sizes, and other dimension values in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ * @param intendedFor - The style properties where this token is intended to be used.
+ *
+ * @public
+ */
+export function createTokenDimension(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<string> {
+    return TypedCSSDesignToken.createTyped<string>(name, DesignTokenType.dimension, intendedFor);
+}
+
+/**
+ * Creates a DesignToken that can be used for typography font family in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenFontFamily(name: string): TypedCSSDesignToken<string> {
+    return TypedCSSDesignToken.createTyped<string>(name, DesignTokenType.fontFamily, StyleProperty.fontFamily);
+}
+
+/**
+ * Creates a DesignToken that can be used for typography font size in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenFontSize(name: string): TypedCSSDesignToken<string> {
+    return createTokenDimension(name, StyleProperty.fontSize);
+}
+
+/**
+ * Creates a DesignToken that can be used for typography font variations in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenFontVariations(name: string): TypedCSSDesignToken<string> {
+    return TypedCSSDesignToken.createTyped<string>(name, DesignTokenType.fontVariations, StyleProperty.fontVariationSettings);
+}
+
+/**
+ * Creates a DesignToken that can be used for typography font weight in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenFontWeight(name: string): TypedCSSDesignToken<number> {
+    return TypedCSSDesignToken.createTyped<number>(name, DesignTokenType.fontWeight, StyleProperty.fontWeight);
+}
+
+/**
+ * Creates a DesignToken that can be used for typography line height in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ *
+ * @public
+ */
+export function createTokenLineHeight(name: string): TypedCSSDesignToken<string> {
+    return createTokenDimension(name, StyleProperty.lineHeight);
+}
+
+/**
+ * Creates a DesignToken that can be used as a fill in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ * @param intendedFor - The style properties where this token is intended to be used.
+ *
+ * @remarks
+ * This is a token type allowing either `color` or `gradient` values.
+ *
+ * @public
+ */
+export function createTokenSwatch(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch> {
+    return TypedCSSDesignToken.createTyped<Swatch>(
+        name,
+        [DesignTokenType.color, DesignTokenType.gradient],
+        intendedFor
+    );
 }

--- a/packages/adaptive-ui/src/design-tokens/index.ts
+++ b/packages/adaptive-ui/src/design-tokens/index.ts
@@ -1,5 +1,6 @@
 export * from "./appearance.js";
 export * from "./color.js";
+export * from "./create.js";
 export * from "./elevation.js";
 export * from "./layer.js";
 export * from "./modules.js";

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,37 +1,40 @@
-import { CSSDesignToken, DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
+import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet, InteractiveSwatchSet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
-import type { InteractiveSet, InteractiveTokenSet } from "../types.js";
+import type { InteractiveSet, InteractiveTokenGroup } from "../types.js";
 import { StyleProperties, Styles } from "../modules/styles.js";
+import { TypedCSSDesignToken } from "../adaptive-design-tokens.js";
+import { cornerRadiusControl, cornerRadiusLayer, strokeThickness } from "./appearance.js";
 import {
-    accentFillDiscernibleInteractiveSet,
-    accentFillReadableInteractiveSet,
-    accentFillStealthInteractiveSet,
-    accentFillSubtleInteractiveSet,
-    accentStrokeDiscernibleInteractiveSet,
-    accentStrokeReadableInteractiveSet,
+    accentFillDiscernible,
+    accentFillReadable,
+    accentFillStealth,
+    accentFillSubtle,
+    accentStrokeDiscernible,
+    accentStrokeReadable,
     accentStrokeReadableRecipe,
-    accentStrokeSafetyInteractiveSet,
-    accentStrokeSubtleInteractiveSet,
+    accentStrokeSafety,
+    accentStrokeSubtle,
     blackOrWhiteDiscernibleRecipe,
     blackOrWhiteReadableRecipe,
-    neutralFillDiscernibleInteractiveSet,
-    neutralFillReadableInteractiveSet,
-    neutralFillStealthInteractiveSet,
-    neutralFillSubtleInteractiveSet,
-    neutralStrokeDiscernibleInteractiveSet,
+    neutralFillDiscernible,
+    neutralFillReadable,
+    neutralFillStealth,
+    neutralFillSubtle,
+    neutralStrokeDiscernible,
     neutralStrokeDiscernibleRest,
     neutralStrokeReadableRest,
-    neutralStrokeSafetyInteractiveSet,
-    neutralStrokeStrongInteractiveSet,
+    neutralStrokeSafety,
+    neutralStrokeStrong,
     neutralStrokeStrongRecipe,
     neutralStrokeStrongRest,
-    neutralStrokeSubtleInteractiveSet,
+    neutralStrokeSubtle,
     neutralStrokeSubtleRest,
 } from "./color.js";
-import { createNonCss } from "./create.js";
+import { createNonCss, createTokenSwatch } from "./create.js";
 import {
-    bodyFont,
+    fontFamily,
+    fontWeight,
     typeRampBaseFontSize,
     typeRampBaseFontVariations,
     typeRampBaseLineHeight,
@@ -74,22 +77,23 @@ import {
 export const createForegroundSet = (
     foregroundRecipe: DesignToken<InteractiveColorRecipe>,
     foregroundState: keyof InteractiveSet<any>,
-    background: InteractiveTokenSet<Swatch>,
-): InteractiveTokenSet<Swatch> => {
+    background: InteractiveTokenGroup<Swatch>,
+): InteractiveTokenGroup<Swatch> => {
     const foregroundBaseName = `${foregroundRecipe.name.replace("-recipe", "")}-${foregroundState}`;
     const backgroundBaseName = background.rest.name.replace("-rest", "");
     const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
 
     function createState(
         state: keyof InteractiveSet<any>,
-    ): CSSDesignToken<Swatch> {
-        return DesignToken.create<Swatch>(`${setName}-${state}`).withDefault(
+    ): TypedCSSDesignToken<Swatch> {
+        return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
                 resolve(foregroundRecipe).evaluate(resolve, resolve(background[state]))[foregroundState]
         );
     }
 
     return {
+        name: setName,
         rest: createState("rest"),
         hover: createState("hover"),
         active: createState("active"),
@@ -99,8 +103,8 @@ export const createForegroundSet = (
 
 function createForegroundSetBySet(
     foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>,
-    background: InteractiveTokenSet<Swatch>,
-): InteractiveTokenSet<Swatch> {
+    background: InteractiveTokenGroup<Swatch>,
+): InteractiveTokenGroup<Swatch> {
     const foregroundBaseName = foregroundRecipe.name.replace("-recipe", "");
     const backgroundBaseName = background.rest.name.replace("-rest", "");
     const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
@@ -120,14 +124,15 @@ function createForegroundSetBySet(
 
     function createState(
         state: keyof InteractiveSet<any>,
-    ): CSSDesignToken<Swatch> {
-        return DesignToken.create<Swatch>(`${setName}-${state}`).withDefault(
+    ): TypedCSSDesignToken<Swatch> {
+        return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
                 resolve(set)[state]
         );
     }
 
     return {
+        name: setName,
         rest: createState("rest"),
         hover: createState("hover"),
         active: createState("active"),
@@ -136,7 +141,7 @@ function createForegroundSetBySet(
 }
 
 function backgroundAndForeground(
-    background: InteractiveTokenSet<Swatch>,
+    background: InteractiveTokenGroup<Swatch>,
     foregroundRecipe: DesignToken<InteractiveColorRecipe>
 ): StyleProperties {
     return {
@@ -146,7 +151,7 @@ function backgroundAndForeground(
 }
 
 function backgroundAndForegroundBySet(
-    background: InteractiveTokenSet<Swatch>,
+    background: InteractiveTokenGroup<Swatch>,
     foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>
 ): StyleProperties {
     return {
@@ -154,6 +159,34 @@ function backgroundAndForegroundBySet(
         foregroundFill: createForegroundSetBySet(foregroundRecipe,  background),
     };
 }
+
+/**
+ * Style module for the shape of a control.
+ *
+ * By default, sets the border radius, thickness, and style, useful for buttons, inputs, list items, etc.
+ *
+ * @public
+ */
+export const controlShapeStyles: Styles = Styles.fromProperties({
+    borderThickness: strokeThickness,
+    borderStyle: "solid",
+    borderFill: "transparent",
+    cornerRadius: cornerRadiusControl,
+});
+
+/**
+ * Style module for the shape of a layer.
+ *
+ * By default, sets the border radius, thickness, and style, useful for card, panes, etc.
+ *
+ * @public
+ */
+export const layerShapeStyles: Styles = Styles.fromProperties({
+    borderThickness: strokeThickness,
+    borderStyle: "solid",
+    borderFill: "transparent",
+    cornerRadius: cornerRadiusLayer,
+});
 
 /**
  * Convenience style module for an accent-filled stealth control (interactive).
@@ -166,8 +199,8 @@ function backgroundAndForegroundBySet(
  * @public
  */
 export const accentFillStealthControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(accentFillStealthInteractiveSet, accentStrokeReadableRecipe),
-    borderFill: accentStrokeSafetyInteractiveSet,
+    ...backgroundAndForeground(accentFillStealth, accentStrokeReadableRecipe),
+    borderFill: accentStrokeSafety,
 });
 
 /**
@@ -181,8 +214,8 @@ export const accentFillStealthControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const accentFillSubtleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(accentFillSubtleInteractiveSet, accentStrokeReadableRecipe),
-    borderFill: accentStrokeSubtleInteractiveSet,
+    ...backgroundAndForeground(accentFillSubtle, accentStrokeReadableRecipe),
+    borderFill: accentStrokeSubtle,
 });
 
 /**
@@ -196,7 +229,7 @@ export const accentFillSubtleControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(accentFillDiscernibleInteractiveSet, blackOrWhiteDiscernibleRecipe),
+    ...backgroundAndForegroundBySet(accentFillDiscernible, blackOrWhiteDiscernibleRecipe),
     borderFill: "transparent", // TODO Remove "transparent" borders, this is a hack for the Explorer app.
 });
 
@@ -211,7 +244,7 @@ export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties(
  * @public
  */
 export const accentFillReadableControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(accentFillReadableInteractiveSet, blackOrWhiteReadableRecipe),
+    ...backgroundAndForegroundBySet(accentFillReadable, blackOrWhiteReadableRecipe),
     borderFill: "transparent",
 });
 
@@ -226,8 +259,8 @@ export const accentFillReadableControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperties({
-    borderFill: accentStrokeDiscernibleInteractiveSet,
-    foregroundFill: accentStrokeReadableInteractiveSet,
+    borderFill: accentStrokeDiscernible,
+    foregroundFill: accentStrokeReadable,
 });
 
 /**
@@ -242,7 +275,7 @@ export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperti
  */
 export const accentForegroundReadableControlStyles: Styles = Styles.fromProperties({
     borderFill: "transparent",
-    foregroundFill: accentStrokeReadableInteractiveSet,
+    foregroundFill: accentStrokeReadable,
 });
 
 /**
@@ -256,8 +289,8 @@ export const accentForegroundReadableControlStyles: Styles = Styles.fromProperti
  * @public
  */
 export const neutralFillStealthControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillStealthInteractiveSet, neutralStrokeStrongRecipe),
-    borderFill: neutralStrokeSafetyInteractiveSet,
+    ...backgroundAndForeground(neutralFillStealth, neutralStrokeStrongRecipe),
+    borderFill: neutralStrokeSafety,
 });
 
 /**
@@ -271,8 +304,8 @@ export const neutralFillStealthControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillSubtleInteractiveSet, neutralStrokeStrongRecipe),
-    borderFill: neutralStrokeSubtleInteractiveSet,
+    ...backgroundAndForeground(neutralFillSubtle, neutralStrokeStrongRecipe),
+    borderFill: neutralStrokeSubtle,
 });
 
 /**
@@ -286,7 +319,7 @@ export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(neutralFillDiscernibleInteractiveSet, blackOrWhiteDiscernibleRecipe),
+    ...backgroundAndForegroundBySet(neutralFillDiscernible, blackOrWhiteDiscernibleRecipe),
     borderFill: "transparent",
 });
 
@@ -301,7 +334,7 @@ export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties
  * @public
  */
 export const neutralFillReadableControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillReadableInteractiveSet, neutralStrokeStrongRecipe),
+    ...backgroundAndForeground(neutralFillReadable, neutralStrokeStrongRecipe),
     borderFill: "transparent",
 });
 
@@ -316,8 +349,8 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties({
-    borderFill: neutralStrokeDiscernibleInteractiveSet,
-    foregroundFill: neutralStrokeStrongInteractiveSet,
+    borderFill: neutralStrokeDiscernible,
+    foregroundFill: neutralStrokeStrong,
 });
 
 /**
@@ -384,10 +417,10 @@ export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromPropert
  * @public
  */
 export const typeRampBaseStyles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampBaseFontSize,
     lineHeight: typeRampBaseLineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampBaseFontVariations,
 });
 
@@ -397,10 +430,10 @@ export const typeRampBaseStyles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampMinus1Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampMinus1FontSize,
     lineHeight: typeRampMinus1LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampMinus1FontVariations,
 });
 
@@ -410,10 +443,10 @@ export const typeRampMinus1Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampMinus2Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampMinus2FontSize,
     lineHeight: typeRampMinus2LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampMinus2FontVariations,
 });
 
@@ -423,10 +456,10 @@ export const typeRampMinus2Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus1Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus1FontSize,
     lineHeight: typeRampPlus1LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus1FontVariations,
 });
 
@@ -436,10 +469,10 @@ export const typeRampPlus1Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus2Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus2FontSize,
     lineHeight: typeRampPlus2LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus2FontVariations,
 });
 
@@ -449,10 +482,10 @@ export const typeRampPlus2Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus3Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus3FontSize,
     lineHeight: typeRampPlus3LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus3FontVariations,
 });
 
@@ -462,10 +495,10 @@ export const typeRampPlus3Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus4Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus4FontSize,
     lineHeight: typeRampPlus4LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus4FontVariations,
 });
 
@@ -475,10 +508,10 @@ export const typeRampPlus4Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus5Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus5FontSize,
     lineHeight: typeRampPlus5LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus5FontVariations,
 });
 
@@ -488,10 +521,10 @@ export const typeRampPlus5Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const typeRampPlus6Styles: Styles = Styles.fromProperties({
-    fontFamily: bodyFont,
+    fontFamily: fontFamily,
     fontSize: typeRampPlus6FontSize,
     lineHeight: typeRampPlus6LineHeight,
-    fontWeight: "initial",
+    fontWeight: fontWeight,
     fontVariationSettings: typeRampPlus6FontVariations,
 });
 
@@ -499,6 +532,7 @@ export const typeRampPlus6Styles: Styles = Styles.fromProperties({
  * @public
  */
 export const actionStyles: Styles = Styles.compose(
+    controlShapeStyles,
     typeRampBaseStyles,
     neutralFillSubtleControlStyles
 );
@@ -507,6 +541,7 @@ export const actionStyles: Styles = Styles.compose(
  * @public
  */
 export const inputStyles: Styles = Styles.compose(
+    controlShapeStyles,
     typeRampBaseStyles,
     neutralOutlineDiscernibleControlStyles
 );
@@ -515,6 +550,7 @@ export const inputStyles: Styles = Styles.compose(
  * @public
  */
 export const selectableSelectedStyles: Styles = Styles.compose(
+    controlShapeStyles,
     typeRampBaseStyles,
     accentFillReadableControlStyles
 );
@@ -523,6 +559,7 @@ export const selectableSelectedStyles: Styles = Styles.compose(
  * @public
  */
 export const selectableUnselectedStyles: Styles = Styles.compose(
+    controlShapeStyles,
     typeRampBaseStyles,
     neutralOutlineDiscernibleControlStyles
 );
@@ -531,6 +568,7 @@ export const selectableUnselectedStyles: Styles = Styles.compose(
  * @public
  */
 export const itemStyles: Styles = Styles.compose(
+    controlShapeStyles,
     typeRampBaseStyles,
     neutralFillStealthControlStyles
 );

--- a/packages/adaptive-ui/src/design-tokens/type.ts
+++ b/packages/adaptive-ui/src/design-tokens/type.ts
@@ -1,5 +1,11 @@
 import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
-import { create } from "./create.js";
+import {
+    createTokenFontFamily,
+    createTokenFontSize,
+    createTokenFontVariations,
+    createTokenFontWeight,
+    createTokenLineHeight
+} from "./create.js";
 
 /**
  * Standard font wights.
@@ -19,10 +25,19 @@ export const StandardFontWeight = {
 } as const;
 
 /** @public */
-export const bodyFont = create<string>("body-font").withDefault('Arial, Helvetica, sans-serif');
+export const fontFamily = createTokenFontFamily("font-family").withDefault('Arial, Helvetica, sans-serif');
 
 /** @public */
-export const fontWeight = create<number>("font-weight").withDefault(StandardFontWeight.Normal);
+export const bodyFontFamily = createTokenFontFamily("body-font-family").withDefault(fontFamily);
+
+/** @public @deprecated Renamed to `bodyFontFamily` */
+export const bodyFont = bodyFontFamily;
+
+/** @public */
+export const labelFontFamily = createTokenFontFamily("label-font-family").withDefault(fontFamily);
+
+/** @public */
+export const fontWeight = createTokenFontWeight("font-weight").withDefault(StandardFontWeight.Normal);
 
 function fontVariations(sizeToken: DesignToken<string>): (resolve: DesignTokenResolver) => string {
     return (resolve: DesignTokenResolver): string => {
@@ -31,100 +46,100 @@ function fontVariations(sizeToken: DesignToken<string>): (resolve: DesignTokenRe
 }
 
 /** @public */
-export const typeRampBaseFontSize = create<string>("type-ramp-base-font-size").withDefault("14px");
+export const typeRampBaseFontSize = createTokenFontSize("type-ramp-base-font-size").withDefault("14px");
 
 /** @public */
-export const typeRampBaseLineHeight = create<string>("type-ramp-base-line-height").withDefault("20px");
+export const typeRampBaseLineHeight = createTokenLineHeight("type-ramp-base-line-height").withDefault("20px");
 
 /** @public */
-export const typeRampBaseFontVariations = create<string>("type-ramp-base-font-variations").withDefault(
+export const typeRampBaseFontVariations = createTokenFontVariations("type-ramp-base-font-variations").withDefault(
     fontVariations(typeRampBaseFontSize)
 );
 
 /** @public */
-export const typeRampMinus1FontSize = create<string>("type-ramp-minus-1-font-size").withDefault("12px");
+export const typeRampMinus1FontSize = createTokenFontSize("type-ramp-minus-1-font-size").withDefault("12px");
 
 /** @public */
-export const typeRampMinus1LineHeight = create<string>("type-ramp-minus-1-line-height").withDefault("16px");
+export const typeRampMinus1LineHeight = createTokenLineHeight("type-ramp-minus-1-line-height").withDefault("16px");
 
 /** @public */
-export const typeRampMinus1FontVariations = create<string>("type-ramp-minus-1-font-variations").withDefault(
+export const typeRampMinus1FontVariations = createTokenFontVariations("type-ramp-minus-1-font-variations").withDefault(
     fontVariations(typeRampMinus1FontSize)
 );
 
 /** @public */
-export const typeRampMinus2FontSize = create<string>("type-ramp-minus-2-font-size").withDefault("10px");
+export const typeRampMinus2FontSize = createTokenFontSize("type-ramp-minus-2-font-size").withDefault("10px");
 
 /** @public */
-export const typeRampMinus2LineHeight = create<string>("type-ramp-minus-2-line-height").withDefault("14px");
+export const typeRampMinus2LineHeight = createTokenLineHeight("type-ramp-minus-2-line-height").withDefault("14px");
 
 /** @public */
-export const typeRampMinus2FontVariations = create<string>("type-ramp-minus-2-font-variations").withDefault(
+export const typeRampMinus2FontVariations = createTokenFontVariations("type-ramp-minus-2-font-variations").withDefault(
     fontVariations(typeRampMinus2FontSize)
 );
 
 /** @public */
-export const typeRampPlus1FontSize = create<string>("type-ramp-plus-1-font-size").withDefault("16px");
+export const typeRampPlus1FontSize = createTokenFontSize("type-ramp-plus-1-font-size").withDefault("16px");
 
 /** @public */
-export const typeRampPlus1LineHeight = create<string>("type-ramp-plus-1-line-height").withDefault("22px");
+export const typeRampPlus1LineHeight = createTokenLineHeight("type-ramp-plus-1-line-height").withDefault("22px");
 
 /** @public */
-export const typeRampPlus1FontVariations = create<string>("type-ramp-plus-1-font-variations").withDefault(
+export const typeRampPlus1FontVariations = createTokenFontVariations("type-ramp-plus-1-font-variations").withDefault(
     fontVariations(typeRampPlus1FontSize)
 );
 
 /** @public */
-export const typeRampPlus2FontSize = create<string>("type-ramp-plus-2-font-size").withDefault("20px");
+export const typeRampPlus2FontSize = createTokenFontSize("type-ramp-plus-2-font-size").withDefault("20px");
 
 /** @public */
-export const typeRampPlus2LineHeight = create<string>("type-ramp-plus-2-line-height").withDefault("26px");
+export const typeRampPlus2LineHeight = createTokenLineHeight("type-ramp-plus-2-line-height").withDefault("26px");
 
 /** @public */
-export const typeRampPlus2FontVariations = create<string>("type-ramp-plus-2-font-variations").withDefault(
+export const typeRampPlus2FontVariations = createTokenFontVariations("type-ramp-plus-2-font-variations").withDefault(
     fontVariations(typeRampPlus2FontSize)
 );
 
 /** @public */
-export const typeRampPlus3FontSize = create<string>("type-ramp-plus-3-font-size").withDefault("24px");
+export const typeRampPlus3FontSize = createTokenFontSize("type-ramp-plus-3-font-size").withDefault("24px");
 
 /** @public */
-export const typeRampPlus3LineHeight = create<string>("type-ramp-plus-3-line-height").withDefault("32px");
+export const typeRampPlus3LineHeight = createTokenLineHeight("type-ramp-plus-3-line-height").withDefault("32px");
 
 /** @public */
-export const typeRampPlus3FontVariations = create<string>("type-ramp-plus-3-font-variations").withDefault(
+export const typeRampPlus3FontVariations = createTokenFontVariations("type-ramp-plus-3-font-variations").withDefault(
     fontVariations(typeRampPlus3FontSize)
 );
 
 /** @public */
-export const typeRampPlus4FontSize = create<string>("type-ramp-plus-4-font-size").withDefault("28px");
+export const typeRampPlus4FontSize = createTokenFontSize("type-ramp-plus-4-font-size").withDefault("28px");
 
 /** @public */
-export const typeRampPlus4LineHeight = create<string>("type-ramp-plus-4-line-height").withDefault("36px");
+export const typeRampPlus4LineHeight = createTokenLineHeight("type-ramp-plus-4-line-height").withDefault("36px");
 
 /** @public */
-export const typeRampPlus4FontVariations = create<string>("type-ramp-plus-4-font-variations").withDefault(
+export const typeRampPlus4FontVariations = createTokenFontVariations("type-ramp-plus-4-font-variations").withDefault(
     fontVariations(typeRampPlus4FontSize)
 );
 
 /** @public */
-export const typeRampPlus5FontSize = create<string>("type-ramp-plus-5-font-size").withDefault("32px");
+export const typeRampPlus5FontSize = createTokenFontSize("type-ramp-plus-5-font-size").withDefault("32px");
 
 /** @public */
-export const typeRampPlus5LineHeight = create<string>("type-ramp-plus-5-line-height").withDefault("40px");
+export const typeRampPlus5LineHeight = createTokenLineHeight("type-ramp-plus-5-line-height").withDefault("40px");
 
 /** @public */
-export const typeRampPlus5FontVariations = create<string>("type-ramp-plus-5-font-variations").withDefault(
+export const typeRampPlus5FontVariations = createTokenFontVariations("type-ramp-plus-5-font-variations").withDefault(
     fontVariations(typeRampPlus5FontSize)
 );
 
 /** @public */
-export const typeRampPlus6FontSize = create<string>("type-ramp-plus-6-font-size").withDefault("40px");
+export const typeRampPlus6FontSize = createTokenFontSize("type-ramp-plus-6-font-size").withDefault("40px");
 
 /** @public */
-export const typeRampPlus6LineHeight = create<string>("type-ramp-plus-6-line-height").withDefault("52px");
+export const typeRampPlus6LineHeight = createTokenLineHeight("type-ramp-plus-6-line-height").withDefault("52px");
 
 /** @public */
-export const typeRampPlus6FontVariations = create<string>("type-ramp-plus-6-font-variations").withDefault(
+export const typeRampPlus6FontVariations = createTokenFontVariations("type-ramp-plus-6-font-variations").withDefault(
     fontVariations(typeRampPlus6FontSize)
 );

--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -3,5 +3,6 @@ export * from "./design-tokens/index.js";
 export * from "./elevation/index.js";
 export * from "./modules/index.js";
 export * from "./type/index.js";
+export * from "./adaptive-design-tokens.js";
 export * from "./styles.js";
 export * from "./types.js";

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -2,7 +2,7 @@ import { css } from "@microsoft/fast-element";
 import type { CSSDirective, ElementStyles } from "@microsoft/fast-element";
 import { CSSDesignToken } from "@microsoft/fast-foundation";
 import type { StyleProperty } from "../modules/types.js";
-import type { InteractiveTokenSet } from "../types.js";
+import type { InteractiveTokenGroup } from "../types.js";
 import { makeSelector } from "./selector.js";
 import type { FocusSelector, StyleModuleEvaluateParameters } from "./types.js";
 import { stylePropertyToCssProperty } from "./css.js";
@@ -20,7 +20,7 @@ function propertySingle<T = string>(
 
 function propertyInteractive<T = string>(
     property: string,
-    values: InteractiveTokenSet<T>,
+    values: InteractiveTokenGroup<T>,
     focusSelector: FocusSelector = "focus-visible",
 ): StyleModuleEvaluate {
     return (params: StyleModuleEvaluateParameters): ElementStyles => css`
@@ -51,7 +51,7 @@ function createElementStyleModules(styles: Styles): StyleModuleEvaluate[] {
         } else if (value && typeof (value as any).createCSS === "function") {
             return propertySingle(property, value as CSSDirective);
         } else {
-            return propertyInteractive(property, value as InteractiveTokenSet<any>);
+            return propertyInteractive(property, value as InteractiveTokenGroup<any>);
         }
     });
     return modules;

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -1,6 +1,6 @@
 import type { CSSDirective } from "@microsoft/fast-element";
 import type { CSSDesignToken } from "@microsoft/fast-foundation";
-import { InteractiveTokenSet } from "../types.js";
+import { InteractiveTokenGroup } from "../types.js";
 import { StyleProperty } from "./types.js";
 
 /**
@@ -8,7 +8,7 @@ import { StyleProperty } from "./types.js";
  *
  * @public
  */
-export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenSet<any> | CSSDirective | string>>;
+export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>>;
 
 /**
  * A modular definition of style properties, either an alias to another style module or a collection of style properties.
@@ -53,15 +53,12 @@ export class Styles {
     }
 
     /**
-     * Gets the local properties or composition overrides. See {@link }.
+     * The local properties or composition overrides.
      */
     public get properties(): StyleProperties | undefined {
         return this._properties;
     }
 
-    /**
-     * Sets the local properties or composition overrides.
-     */
     public set properties(properties: StyleProperties | undefined) {
         this._properties = properties;
         this.createEffectiveProperties();

--- a/packages/adaptive-ui/src/type/type-ramp.ts
+++ b/packages/adaptive-ui/src/type/type-ramp.ts
@@ -1,6 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import {
-    bodyFont,
+    fontFamily,
     typeRampBaseFontSize,
     typeRampBaseFontVariations,
     typeRampBaseLineHeight,
@@ -35,7 +35,7 @@ import {
  * @deprecated Use style modules instead.
  */
 export const typeRampBase = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampBaseFontSize};
     line-height: ${typeRampBaseLineHeight};
     font-weight: initial;
@@ -47,7 +47,7 @@ export const typeRampBase = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampMinus1 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampMinus1FontSize};
     line-height: ${typeRampMinus1LineHeight};
     font-weight: initial;
@@ -59,7 +59,7 @@ export const typeRampMinus1 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampMinus2 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampMinus2FontSize};
     line-height: ${typeRampMinus2LineHeight};
     font-weight: initial;
@@ -71,7 +71,7 @@ export const typeRampMinus2 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus1 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus1FontSize};
     line-height: ${typeRampPlus1LineHeight};
     font-weight: initial;
@@ -83,7 +83,7 @@ export const typeRampPlus1 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus2 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus2FontSize};
     line-height: ${typeRampPlus2LineHeight};
     font-weight: initial;
@@ -95,7 +95,7 @@ export const typeRampPlus2 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus3 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus3FontSize};
     line-height: ${typeRampPlus3LineHeight};
     font-weight: initial;
@@ -107,7 +107,7 @@ export const typeRampPlus3 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus4 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus4FontSize};
     line-height: ${typeRampPlus4LineHeight};
     font-weight: initial;
@@ -119,7 +119,7 @@ export const typeRampPlus4 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus5 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus5FontSize};
     line-height: ${typeRampPlus5LineHeight};
     font-weight: initial;
@@ -131,7 +131,7 @@ export const typeRampPlus5 = css.partial`
  * @deprecated Use style modules instead.
  */
 export const typeRampPlus6 = css.partial`
-    font-family: ${bodyFont};
+    font-family: ${fontFamily};
     font-size: ${typeRampPlus6FontSize};
     line-height: ${typeRampPlus6LineHeight};
     font-weight: initial;

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -1,7 +1,16 @@
-import type { CSSDesignToken } from "@microsoft/fast-foundation";
+import type { TypedCSSDesignToken } from "./adaptive-design-tokens.js";
 
 /**
- * A set of values to use for an interactive element's states.
+ * A group of tokens.
+ *
+ * @public
+ */
+export interface TokenGroup {
+    name: string;
+}
+
+/**
+ * A set for an interactive element's states.
  *
  * @public
  */
@@ -28,8 +37,8 @@ export interface InteractiveSet<T> {
 }
 
 /**
- * A set of tokens to use for an interactive element's states.
+ * A group of tokens to use for an interactive element's states.
  *
  * @public
  */
-export interface InteractiveTokenSet<T> extends InteractiveSet<CSSDesignToken<T>> {}
+export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveSet<TypedCSSDesignToken<T>> {}

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css } from "@microsoft/fast-element";
 import type { ElementStyles } from "@microsoft/fast-element";
@@ -49,10 +47,8 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .control {
-        border: calc(${strokeWidth} * 1px) solid transparent;
         gap: 10px;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    controlShapeStyles,
     neutralFillReadableControlStyles,
     StyleModules,
+    Styles,
     typeRampMinus1Styles,
 } from "@adaptive-web/adaptive-ui";
 import { BadgeAnatomy } from "./badge.template.js";
@@ -20,6 +22,9 @@ export const styleModules: StyleModules = [
         {
             part: BadgeAnatomy.parts.control,
         },
-        neutralFillReadableControlStyles
+        Styles.compose(
+            controlShapeStyles,
+            neutralFillReadableControlStyles,
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -1,6 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
-    controlCornerRadius,
     designUnit,
     strokeWidth,
 } from "@adaptive-web/adaptive-ui";
@@ -19,8 +18,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .control {
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding:
             calc(((${designUnit} * 0.5) - ${strokeWidth}) * 1px)
             calc((${designUnit} - ${strokeWidth}) * 1px);

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -1,10 +1,8 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { density, heightNumber } from "../../styles/index.js";
 
@@ -52,13 +50,10 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
     }
 
     .control {
-        border: calc(${strokeWidth} * 1px) solid transparent;
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
-        border-radius: inherit;
         white-space: nowrap;
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
@@ -1,7 +1,9 @@
 import {
+    controlShapeStyles,
     plainTextStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { CalendarAnatomy } from "./calendar.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -13,5 +15,11 @@ export const styleModules: StyleModules = [
         {
         },
         plainTextStyles
+    ],
+    [
+        {
+            part: CalendarAnatomy.parts.day
+        },
+        controlShapeStyles
     ],
 ];

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -69,11 +69,6 @@ export const aestheticStyles: ElementStyles = css`
         font-weight: 600;
     }
 
-    .day {
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
-    }
-
     .date {
         height: 100%;
     }

--- a/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    layerShapeStyles,
     plainTextStyles,
     StyleModules,
+    Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -12,6 +14,9 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        plainTextStyles
+        Styles.compose(
+            layerShapeStyles,
+            plainTextStyles,
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -2,11 +2,9 @@ import {
     elevationCardFocus,
     elevationCardHover,
     elevationCardRest,
-    layerCornerRadius,
     layerFillInteractiveActive,
     layerFillInteractiveHover,
     layerFillInteractiveRest,
-    neutralForegroundRest,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -28,8 +26,6 @@ export const aestheticStyles: ElementStyles = css`
         height: 100%;
         width: 100%;
         background: ${layerFillInteractiveRest};
-        color: ${neutralForegroundRest};
-        border-radius: calc(${layerCornerRadius} * 1px);
         box-shadow: ${elevationCardRest}
     }
 

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -69,8 +67,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
@@ -1,7 +1,9 @@
 import {
+    controlShapeStyles,
     inputStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { ComboboxAnatomy } from "./combobox.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -13,5 +15,11 @@ export const styleModules: StyleModules = [
         {
         },
         inputStyles
+    ],
+    [
+        {
+            part: ComboboxAnatomy.parts.listbox
+        },
+        controlShapeStyles
     ],
 ];

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -1,11 +1,9 @@
 import {
-    controlCornerRadius,
     designUnit,
     elevationFlyout,
     focusStrokeOuter,
     focusStrokeWidth,
     layerFillFixedPlus1,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -81,8 +79,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: 250px;
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 
@@ -108,7 +104,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .listbox {
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) 0;
         background: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    controlShapeStyles,
     plainTextStyles,
     StyleModules,
+    Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -12,6 +14,9 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        plainTextStyles
+        Styles.compose(
+            controlShapeStyles,
+            plainTextStyles,
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -1,10 +1,8 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -21,8 +19,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border: transparent calc(${strokeWidth} * 1px) solid;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) calc(${designUnit} * 3px);
         fill: currentcolor;
         white-space: nowrap;

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    layerShapeStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { DialogAnatomy } from "./dialog.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +10,10 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            part: DialogAnatomy.parts.control
+        },
+        layerShapeStyles
+    ]
 ];

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
@@ -1,5 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { elevationDialog, fillColor, layerCornerRadius, strokeWidth } from "@adaptive-web/adaptive-ui";
+import { elevationDialog, fillColor } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -48,8 +48,6 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         margin-top: auto;
         margin-bottom: auto;
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${layerCornerRadius} * 1px);
         width: var(--dialog-width);
         height: var(--dialog-height);
         background: ${fillColor};

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
     accentFillReadableControlStyles,
+    controlShapeStyles,
     StyleModules,
+    Styles,
     typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { DisclosureAnatomy } from "./disclosure.template.js";
@@ -20,6 +22,9 @@ export const styleModules: StyleModules = [
         {
             part: DisclosureAnatomy.parts.invoker
         },
-        accentFillReadableControlStyles
+        Styles.compose(
+            controlShapeStyles,
+            accentFillReadableControlStyles,
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -2,7 +2,6 @@ import {
     accentFillReadableActive,
     accentFillReadableHover,
     accentFillReadableRest,
-    controlCornerRadius,
     foregroundOnAccentActive,
     foregroundOnAccentHover,
     foregroundOnAccentRest,
@@ -48,7 +47,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .invoker {
-        border-radius: calc(${controlCornerRadius} * 1px);
         background: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};
         fill: currentcolor;

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -1,7 +1,6 @@
 import {
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -38,7 +37,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         width: calc(${heightNumber} * 1px);
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: 50%;
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -41,8 +39,6 @@ export const aestheticStyles: ElementStyles = css`
         gap: 8px;
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 2.25px);
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -1,5 +1,8 @@
 import {
+    controlShapeStyles,
+    neutralStrokeSubtleRest,
     StyleModules,
+    Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -8,4 +11,14 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        Styles.compose(
+            controlShapeStyles,
+            Styles.fromProperties({
+                borderFill: neutralStrokeSubtleRest
+            }),
+        )
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -1,11 +1,8 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     layerFillFixedPlus1,
-    neutralStrokeSubtleRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -24,8 +21,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-        border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         padding: calc(${designUnit} * 1px) 0;
         background: ${layerFillFixedPlus1};

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -1,11 +1,9 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     neutralFillStealthActive,
     neutralStrokeReadableRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -130,9 +128,7 @@ export const aestheticStyles: ElementStyles = css`
         margin: 0 calc(${designUnit} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
         overflow: visible;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 12px;
         grid-column-gap: 8px;
         fill: currentcolor;

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    layerShapeStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        layerShapeStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.ts
@@ -1,9 +1,7 @@
 import {
     designUnit,
     elevationFlyout,
-    layerCornerRadius,
     layerFillFixedPlus1,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -27,8 +25,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         max-width: 368px;
         min-width: 64px;
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${layerCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) 0;
         background: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -84,8 +82,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         gap: 8px;
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -30,8 +28,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 1px);
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -38,8 +36,6 @@ export const aestheticStyles: ElementStyles = css`
         min-height: calc(${heightNumber} * 1px);
         column-gap: calc(${designUnit} * 1px);
         row-gap: calc(${designUnit} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
         padding: calc(${designUnit} * 1px) calc(${designUnit} * 2px);
     }

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -1,11 +1,9 @@
 import {
     accentFillReadableRest,
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
     foregroundOnAccentRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -32,8 +30,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 1px);
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    layerShapeStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
 
@@ -8,4 +9,9 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        layerShapeStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
@@ -1,4 +1,4 @@
-import { designUnit, elevationFlyout, layerCornerRadius, layerFillFixedPlus1, strokeWidth } from "@adaptive-web/adaptive-ui";
+import { designUnit, elevationFlyout, layerFillFixedPlus1 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -28,8 +28,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${layerCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) 0;
         background: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -2,7 +2,6 @@ import {
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -69,7 +68,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: 50%;
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -1,8 +1,10 @@
 import {
+    controlShapeStyles,
     inputStyles,
     labelTextStyles,
     neutralFillStealthControlStyles,
     StyleModules,
+    Styles,
     typeRampBaseStyles,
 } from "@adaptive-web/adaptive-ui";
 import { SearchAnatomy } from "./search.template.js";
@@ -34,6 +36,9 @@ export const styleModules: StyleModules = [
         {
             part: SearchAnatomy.parts.clearButton
         },
-        neutralFillStealthControlStyles
+        Styles.compose(
+            controlShapeStyles,
+            neutralFillStealthControlStyles,
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
@@ -92,8 +90,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         fill: currentcolor;
@@ -122,7 +118,6 @@ export const aestheticStyles: ElementStyles = css`
         margin: 1px;
         height: calc(100% - 2px);
         min-width: calc(${heightNumber} * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
@@ -1,7 +1,9 @@
 import {
+    controlShapeStyles,
     inputStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { SelectAnatomy } from "./select.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -13,5 +15,11 @@ export const styleModules: StyleModules = [
         {
         },
         inputStyles
+    ],
+    [
+        {
+            part: SelectAnatomy.parts.listbox
+        },
+        controlShapeStyles
     ],
 ];

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -1,5 +1,4 @@
 import {
-    controlCornerRadius,
     designUnit,
     elevationFlyout,
     focusStrokeOuter,
@@ -81,8 +80,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         min-width: 250px;
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 
@@ -104,7 +101,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .listbox {
         max-height: calc((var(--size, 0) * ${heightNumber} + (${designUnit} * ${strokeWidth} * 2)) * 1px);
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: calc(${designUnit} * 1px) 0;
         background: ${layerFillFixedPlus1};
     }

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    controlShapeStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { SkeletonAnatomy } from "./skeleton.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +10,10 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            hostCondition: SkeletonAnatomy.conditions.rectangle
+        },
+        controlShapeStyles
+    ]
 ];

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
@@ -1,4 +1,4 @@
-import { controlCornerRadius, neutralFillSubtleHover, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui";
+import { neutralFillSubtleHover, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -50,10 +50,6 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  */
 export const aestheticStyles: ElementStyles = css`
-    :host([shape="rect"]) {
-        border-radius: calc(${controlCornerRadius} * 1px);
-    }
-
     :host {
         background-color: ${neutralFillSubtleRest};
     }

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
+    controlShapeStyles,
     StyleModules,
 } from "@adaptive-web/adaptive-ui";
+import { SliderAnatomy } from "./slider.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +10,15 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        controlShapeStyles
+    ],
+    [
+        {
+            part: SliderAnatomy.parts.trackStart
+        },
+        controlShapeStyles
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -1,6 +1,5 @@
 import {
     accentForegroundRest,
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
@@ -118,7 +117,6 @@ export const aestheticStyles: ElementStyles = css`
         --track-overhang: calc((${designUnit} / 2) * -1);
         --track-width: ${designUnit};
         margin: calc(${designUnit} * 1px) 0;
-        border-radius: calc(${controlCornerRadius} * 1px);
     }
 
     :host([orientation="horizontal"]) .positioning-region {
@@ -151,7 +149,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .track-start {
-        border-radius: calc(${controlCornerRadius} * 1px);
         background: ${accentForegroundRest};
     }
 

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -3,7 +3,6 @@ import {
     fillColor,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -55,7 +54,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         width: calc(((${heightNumber} / 2) + ${designUnit}) * 2px);
         height: calc(((${heightNumber} / 2) + ${designUnit}) * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
         border-radius: calc(${heightNumber} * 1px);
         padding: 4px;
     }

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
@@ -33,8 +31,6 @@ export const aestheticStyles: ElementStyles = css`
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -63,8 +61,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .control {
         /* position: relative; */
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 2px);
         width: 100%;

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -1,9 +1,7 @@
 import {
-    controlCornerRadius,
     designUnit,
     focusStrokeOuter,
     focusStrokeWidth,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -63,8 +61,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         fill: currentcolor;

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -1,6 +1,9 @@
 import {
+    controlShapeStyles,
+    neutralStrokeSubtleRest,
     plainTextStyles,
     StyleModules,
+    Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -12,6 +15,12 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        plainTextStyles
+        Styles.compose(
+            controlShapeStyles,
+            plainTextStyles,
+            Styles.fromProperties({
+                borderFill: neutralStrokeSubtleRest
+            }),
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -1,9 +1,6 @@
 import {
-    controlCornerRadius,
     elevationTooltip,
     neutralFillSubtleRest,
-    neutralStrokeSubtleRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -34,8 +31,6 @@ export const aestheticStyles: ElementStyles = css`
         height: fit-content;
         width: fit-content;
         padding: 4px 12px;
-        border: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-        border-radius: calc(${controlCornerRadius} * 1px);
         background: ${neutralFillSubtleRest};
         white-space: nowrap;
         box-shadow: ${elevationTooltip};

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -7,7 +7,6 @@ import {
     neutralFillStealthRecipe,
     neutralFillSubtleRecipe,
     neutralFillSubtleRest,
-    strokeWidth,
     Swatch,
 } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
@@ -109,8 +108,6 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         box-sizing: border-box;
         height: calc((${heightNumber} + 1) * 1px);
-        border: calc(${strokeWidth} * 1px) solid transparent;
-        border-radius: calc(${controlCornerRadius} * 1px);
         padding: 0 calc(${designUnit} * 2px + 8px);
         fill: currentcolor;
     }


### PR DESCRIPTION
# Pull Request

## Description

Our token model was already close to the DTCG recommendation. This makes it more official so we can benefit from some existing tooling and support that format as much as possible. It also helps with some organizational needs in tooling like our Figma plugin.

- Add token bridge and helpers between CG standard types and Adaptive UI
- Updated border radius and thickness tokens and migrated to style modules
- Updated font tokens

## Reviewer Notes

All changes under `adaptive-web-components` are migrating the border styling to style modules. Same changes in each file.

## Test Plan

Tested in AUI Explorer and Storybook

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

This will enable some cleanup of the token organization in the Figma plugin, which will allow me to finally open that PR.
Some other minor cleanup and migration of current tokens.