### PR TITLE
Fix API docs

### DIFF
--- a/change/@adaptive-web-adaptive-ui-a60b3971-8218-4788-b9b9-d48427a1d714.json
+++ b/change/@adaptive-web-adaptive-ui-a60b3971-8218-4788-b9b9-d48427a1d714.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix API docs",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-0de227a5-8642-4ff7-8be1-3a4c931395b5.json
+++ b/change/@adaptive-web-adaptive-web-components-0de227a5-8642-4ff7-8be1-3a4c931395b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix API docs",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -97,15 +97,13 @@ export const AccordionItemParts: {
     region: string;
 };
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-//
 // @beta
 export const AccordionItemStatics: {
     readonly collapsed: "accordion-item-collapsed-icon";
     readonly expanded: "accordion-item-expanded-icon";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type AccordionItemStatics = ValuesOf<typeof AccordionItemStatics>;
 
 // @public
@@ -143,12 +141,10 @@ export class AdaptiveButton extends FASTButton {
     protected defaultSlottedContentChanged(): void;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "DefaultDesignSystem" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
-//
-// @public
+// @beta
 export const AdaptiveDesignSystem: DesignSystem;
 
-// @public (undocumented)
+// @public
 export class AdaptiveHorizontalScroll extends FASTHorizontalScroll {
     // (undocumented)
     connectedCallback(): void;
@@ -156,13 +152,13 @@ export class AdaptiveHorizontalScroll extends FASTHorizontalScroll {
     protected viewChanged(prev?: HorizontalScrollView, next?: HorizontalScrollView): void;
 }
 
-// @public (undocumented)
+// @public
 export class AdaptiveMenu extends FASTMenu {
     // (undocumented)
     protected setItems(): void;
 }
 
-// @public (undocumented)
+// @public
 export class AdaptiveMenuItem extends FASTMenuItem {
     // Warning: (ae-forgotten-export) The symbol "AdaptiveMenuItemColumnCount" needs to be exported by the entry point index.d.ts
     startColumnCount: AdaptiveMenuItemColumnCount;
@@ -297,12 +293,12 @@ export const BreadcrumbItemParts: {
     separator: string;
 };
 
-// @public
+// @beta
 export const BreadcrumbItemStatics: {
     readonly separator: "breadcrumb-item-separator";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type BreadcrumbItemStatics = ValuesOf<typeof BreadcrumbItemStatics>;
 
 // @public
@@ -435,13 +431,13 @@ export const CheckboxParts: {
     label: string;
 };
 
-// @public
+// @beta
 export const CheckboxStatics: {
     readonly checked: "checkbox-checked-indicator";
     readonly indeterminate: "checkbox-indeterminate-indicator";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type CheckboxStatics = ValuesOf<typeof CheckboxStatics>;
 
 // @public
@@ -472,12 +468,12 @@ export const ComboboxParts: {
     listbox: string;
 };
 
-// @public
+// @beta
 export const ComboboxStatics: {
     readonly indicator: "combobox-indicator";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type ComboboxStatics = ValuesOf<typeof ComboboxStatics>;
 
 // @public
@@ -498,6 +494,7 @@ export const comboboxTemplateStyles: ElementStyles;
 export function composeAccordion(ds: DesignSystem, options?: ComposeOptions<FASTAccordion>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeAccordionItem" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeAccordionItem" is marked as @public, but its signature references "AccordionItemStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeAccordionItem(ds: DesignSystem, options?: ComposeOptions<FASTAccordionItem, AccordionItemStatics>): FASTElementDefinition;
@@ -528,6 +525,7 @@ export function composeBadge(ds: DesignSystem, options?: ComposeOptions<FASTBadg
 export function composeBreadcrumb(ds: DesignSystem, options?: ComposeOptions<FASTBreadcrumb>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeBreadcrumbItem" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeBreadcrumbItem" is marked as @public, but its signature references "BreadcrumbItemStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeBreadcrumbItem(ds: DesignSystem, options?: ComposeOptions<FASTBreadcrumbItem, BreadcrumbItemStatics>): FASTElementDefinition;
@@ -548,11 +546,13 @@ export function composeCalendar(ds: DesignSystem, options?: ComposeOptions<FASTC
 export function composeCard(ds: DesignSystem, options?: ComposeOptions<FASTCard>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeCheckbox" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeCheckbox" is marked as @public, but its signature references "CheckboxStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeCheckbox(ds: DesignSystem, options?: ComposeOptions<FASTCheckbox, CheckboxStatics>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeCombobox" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeCombobox" is marked as @public, but its signature references "ComboboxStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeCombobox(ds: DesignSystem, options?: ComposeOptions<FASTCombobox, ComboboxStatics>): FASTElementDefinition;
@@ -588,6 +588,7 @@ export function composeDisclosure(ds: DesignSystem, options?: ComposeOptions<FAS
 export function composeDivider(ds: DesignSystem, options?: ComposeOptions<FASTDivider>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeFlipper" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeFlipper" is marked as @public, but its signature references "FlipperStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeFlipper(ds: DesignSystem, options?: ComposeOptions<FASTFlipper, FlipperStatics>): FASTElementDefinition;
@@ -613,11 +614,13 @@ export function composeListboxOption(ds: DesignSystem, options?: ComposeOptions<
 export function composeMenu(ds: DesignSystem, options?: ComposeOptions<AdaptiveMenu>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeMenuItem" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeMenuItem" is marked as @public, but its signature references "MenuItemStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeMenuItem(ds: DesignSystem, options?: ComposeOptions<AdaptiveMenuItem, MenuItemStatics>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeNumberField" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeNumberField" is marked as @public, but its signature references "NumberFieldStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeNumberField(ds: DesignSystem, options?: ComposeOptions<FASTNumberField, NumberFieldStatics>): FASTElementDefinition;
@@ -658,6 +661,7 @@ export function composeProgress(ds: DesignSystem, options?: ComposeOptions<FASTP
 export function composeProgressRing(ds: DesignSystem, options?: ComposeOptions<FASTProgressRing>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeRadio" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeRadio" is marked as @public, but its signature references "RadioStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeRadio(ds: DesignSystem, options?: ComposeOptions<FASTRadio, RadioStatics>): FASTElementDefinition;
@@ -674,6 +678,7 @@ export function composeSearch(ds: DesignSystem, options?: ComposeOptions<FASTSea
 
 // Warning: (ae-forgotten-export) The symbol "AdaptiveSelect" needs to be exported by the entry point index.d.ts
 // Warning: (ae-incompatible-release-tags) The symbol "composeSelect" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeSelect" is marked as @public, but its signature references "SelectStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeSelect(ds: DesignSystem, options?: ComposeOptions<AdaptiveSelect, SelectStatics>): FASTElementDefinition;
@@ -734,6 +739,7 @@ export function composeToolbar(ds: DesignSystem, options?: ComposeOptions<FASTTo
 export function composeTooltip(ds: DesignSystem, options?: ComposeOptions<FASTTooltip>): FASTElementDefinition;
 
 // Warning: (ae-incompatible-release-tags) The symbol "composeTreeItem" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
+// Warning: (ae-incompatible-release-tags) The symbol "composeTreeItem" is marked as @public, but its signature references "TreeItemStatics" which is marked as @beta
 //
 // @public (undocumented)
 export function composeTreeItem(ds: DesignSystem, options?: ComposeOptions<FASTTreeItem, TreeItemStatics>): FASTElementDefinition;
@@ -936,13 +942,13 @@ export const FlipperParts: {
     previous: string;
 };
 
-// @public
+// @beta
 export const FlipperStatics: {
     readonly next: "flipper-next";
     readonly previous: "flipper-previous";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type FlipperStatics = ValuesOf<typeof FlipperStatics>;
 
 // @public
@@ -1066,14 +1072,14 @@ export const MenuItemParts: {
     submenuIcon: string;
 };
 
-// @public
+// @beta
 export const MenuItemStatics: {
     readonly checkbox: "menu-item-checkbox-indicator";
     readonly radio: "menu-item-radio-indicator";
     readonly submenu: "menu-item-submenu-item";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type MenuItemStatics = ValuesOf<typeof MenuItemStatics>;
 
 // @public
@@ -1120,13 +1126,13 @@ export const NumberFieldParts: {
     stepDown: string;
 };
 
-// @public
+// @beta
 export const NumberFieldStatics: {
     readonly stepDown: "number-field-step-down-icon";
     readonly stepUp: "number-field-step-up-icon";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type NumberFieldStatics = ValuesOf<typeof NumberFieldStatics>;
 
 // @public
@@ -1364,12 +1370,12 @@ export const RadioParts: {
     label: string;
 };
 
-// @public
+// @beta
 export const RadioStatics: {
     readonly checked: "radio-checked-indicator";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type RadioStatics = ValuesOf<typeof RadioStatics>;
 
 // @public
@@ -1428,12 +1434,12 @@ export const SelectParts: {
     listbox: string;
 };
 
-// @public
+// @beta
 export const SelectStatics: {
     readonly indicator: "select-indicator";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type SelectStatics = ValuesOf<typeof SelectStatics>;
 
 // @public
@@ -1765,12 +1771,12 @@ export const TreeItemParts: {
     items: string;
 };
 
-// @public
+// @beta
 export const TreeItemStatics: {
     readonly expandCollapse: "tree-item-expand-collapse-icon";
 };
 
-// @public (undocumented)
+// @beta (undocumented)
 export type TreeItemStatics = ValuesOf<typeof TreeItemStatics>;
 
 // @public

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
@@ -7,6 +7,9 @@ import { AccordionItemAnatomy, AccordionItemStatics, template } from "./accordio
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeAccordionItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAccordionItem, AccordionItemStatics>

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -10,6 +10,7 @@ import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -101,6 +102,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.template.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.template.ts
@@ -14,12 +14,21 @@ export const AccordionItemStatics = {
     expanded: "accordion-item-expanded-icon"
 } as const;
 
+/**
+ * @beta
+ */
 export type AccordionItemStatics = ValuesOf<typeof AccordionItemStatics>;
 
+/**
+ * @public
+ */
 export const AccordionItemConditions = {
     expanded: "[expanded]",
 };
 
+/**
+ * @public
+ */
 export const AccordionItemParts = {
     heading: "heading",
     button: "button",
@@ -28,6 +37,9 @@ export const AccordionItemParts = {
     region: "region",
 };
 
+/**
+ * @public
+ */
 export const AccordionItemAnatomy: ComponentAnatomy<typeof AccordionItemConditions, typeof AccordionItemParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: AccordionItemConditions,
@@ -36,6 +48,7 @@ export const AccordionItemAnatomy: ComponentAnatomy<typeof AccordionItemConditio
 
 /**
  * Default Accordion Item template, {@link @microsoft/fast-foundation#accordionItemTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTAccordionItem> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
@@ -7,6 +7,9 @@ import { AccordionAnatomy, template } from "./accordion.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeAccordion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAccordion>

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
@@ -3,6 +3,7 @@ import { neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui"
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -13,6 +14,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/accordion/accordion.template.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.template.ts
@@ -3,12 +3,21 @@ import { accordionTemplate, FASTAccordion } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const AccordionConditions = {
 };
 
+/**
+ * @public
+ */
 export const AccordionParts = {
 };
 
+/**
+ * @public
+ */
 export const AccordionAnatomy: ComponentAnatomy<typeof AccordionConditions, typeof AccordionParts> = {
     interactivity: Interactivity.never,
     conditions: AccordionConditions,
@@ -17,6 +26,7 @@ export const AccordionAnatomy: ComponentAnatomy<typeof AccordionConditions, type
 
 /**
  * Default Accordion template, {@link @microsoft/fast-foundation#accordionTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTAccordion> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -7,6 +7,9 @@ import { AnchorAnatomy, template } from "./anchor.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeAnchor(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveAnchor>

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -9,6 +9,7 @@ import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -38,6 +39,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
@@ -3,15 +3,24 @@ import { anchorTemplate, FASTAnchor } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const AnchorConditions = {
     iconOnly: ".icon-only",
 };
 
+/**
+ * @public
+ */
 export const AnchorParts = {
     control: "control",
     content: "content",
 };
 
+/**
+ * @public
+ */
 export const AnchorAnatomy: ComponentAnatomy<typeof AnchorConditions, typeof AnchorParts> = {
     interactivity: Interactivity.hrefAttribute,
     conditions: AnchorConditions,
@@ -20,6 +29,7 @@ export const AnchorAnatomy: ComponentAnatomy<typeof AnchorConditions, typeof Anc
 
 /**
  * Default Anchor template, {@link @microsoft/fast-foundation#anchorTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTAnchor> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/anchor/anchor.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.ts
@@ -2,6 +2,8 @@ import { FASTAnchor } from "@microsoft/fast-foundation";
 
 /**
  * The Adaptive version of Anchor. Extends {@link @microsoft/fast-foundation#FASTAnchor}.
+ *
+ * @public
  */
 export class AdaptiveAnchor extends FASTAnchor {
     /**

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -7,6 +7,9 @@ import { AnchoredRegionAnatomy, template } from "./anchored-region.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeAnchoredRegion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAnchoredRegion>

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -12,5 +13,6 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css``;

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.template.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.template.ts
@@ -3,13 +3,22 @@ import { anchoredRegionTemplate, FASTAnchoredRegion } from "@microsoft/fast-foun
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const AnchoredRegionConditions = {
     loaded: "[data-loaded='loaded']",
 };
 
+/**
+ * @public
+ */
 export const AnchoredRegionParts = {
 };
 
+/**
+ * @public
+ */
 export const AnchoredRegionAnatomy: ComponentAnatomy<typeof AnchoredRegionConditions, typeof AnchoredRegionParts> = {
     interactivity: Interactivity.never,
     conditions: AnchoredRegionConditions,
@@ -18,6 +27,7 @@ export const AnchoredRegionAnatomy: ComponentAnatomy<typeof AnchoredRegionCondit
 
 /**
  * Default Anchored Region template, {@link @microsoft/fast-foundation#anchoredRegionTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTAnchoredRegion> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
@@ -7,6 +7,9 @@ import { AvatarAnatomy, template } from "./avatar.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeAvatar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAvatar>

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -3,6 +3,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -36,6 +37,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/avatar/avatar.template.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.template.ts
@@ -3,12 +3,21 @@ import { avatarTemplate, FASTAvatar } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const AvatarConditions = {};
 
+/**
+ * @public
+ */
 export const AvatarParts = {
     backplate: "backplate",
 };
 
+/**
+ * @public
+ */
 export const AvatarAnatomy: ComponentAnatomy<typeof AvatarConditions, typeof AvatarParts> = {
     interactivity: Interactivity.never,
     conditions: AvatarConditions,
@@ -17,6 +26,7 @@ export const AvatarAnatomy: ComponentAnatomy<typeof AvatarConditions, typeof Ava
 
 /**
  * Default Avatar template, {@link @microsoft/fast-foundation#avatarTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTAvatar> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/badge/badge.compose.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.compose.ts
@@ -7,6 +7,9 @@ import { BadgeAnatomy, template } from "./badge.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeBadge(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBadge>

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -6,6 +6,7 @@ import {
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -15,6 +16,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .control {

--- a/packages/adaptive-web-components/src/components/badge/badge.template.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.template.ts
@@ -3,12 +3,21 @@ import { badgeTemplate, FASTBadge } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const BadgeConditions = {};
 
+/**
+ * @public
+ */
 export const BadgeParts = {
     control: "control",
 };
 
+/**
+ * @public
+ */
 export const BadgeAnatomy: ComponentAnatomy<typeof BadgeConditions, typeof BadgeParts> = {
     interactivity: Interactivity.never,
     conditions: BadgeConditions,
@@ -17,6 +26,7 @@ export const BadgeAnatomy: ComponentAnatomy<typeof BadgeConditions, typeof Badge
 
 /**
  * Default Badge template, {@link @microsoft/fast-foundation#badgeTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTBadge> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -7,6 +7,9 @@ import { BreadcrumbItemAnatomy, BreadcrumbItemStatics, template } from "./breadc
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeBreadcrumbItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBreadcrumbItem, BreadcrumbItemStatics>

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -41,6 +42,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
@@ -6,15 +6,26 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the breadcrumb item.
+ *
+ * @beta
  */
 export const BreadcrumbItemStatics = {
     separator: "breadcrumb-item-separator"
 } as const;
 
+/**
+ * @beta
+ */
 export type BreadcrumbItemStatics = ValuesOf<typeof BreadcrumbItemStatics>;
 
+/**
+ * @public
+ */
 export const BreadcrumbItemConditions = {};
 
+/**
+ * @public
+ */
 export const BreadcrumbItemParts = {
     control: "control",
     content: "content",
@@ -22,6 +33,9 @@ export const BreadcrumbItemParts = {
     separator: "separator",
 };
 
+/**
+ * @public
+ */
 export const BreadcrumbItemAnatomy: ComponentAnatomy<typeof BreadcrumbItemConditions, typeof BreadcrumbItemParts> = {
     interactivity: Interactivity.hrefAttribute,
     conditions: BreadcrumbItemConditions,
@@ -30,6 +44,7 @@ export const BreadcrumbItemAnatomy: ComponentAnatomy<typeof BreadcrumbItemCondit
 
 /**
  * Default Breadcrumb Item template, {@link @microsoft/fast-foundation#breadcrumbItemTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTBreadcrumbItem> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -7,6 +7,9 @@ import { BreadcrumbAnatomy, template } from "./breadcrumb.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeBreadcrumb(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBreadcrumb>

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -16,6 +17,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .list {

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.template.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.template.ts
@@ -3,13 +3,22 @@ import { breadcrumbTemplate, FASTBreadcrumb } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const BreadcrumbConditions = {
 };
 
+/**
+ * @public
+ */
 export const BreadcrumbParts = {
     list: "list",
 };
 
+/**
+ * @public
+ */
 export const BreadcrumbAnatomy: ComponentAnatomy<typeof BreadcrumbConditions, typeof BreadcrumbParts> = {
     interactivity: Interactivity.never,
     conditions: BreadcrumbConditions,
@@ -18,6 +27,7 @@ export const BreadcrumbAnatomy: ComponentAnatomy<typeof BreadcrumbConditions, ty
 
 /**
  * Default Breadcrumb template, {@link @microsoft/fast-foundation#breadcrumbTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTBreadcrumb> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/button/button.compose.ts
+++ b/packages/adaptive-web-components/src/components/button/button.compose.ts
@@ -7,6 +7,9 @@ import { ButtonAnatomy, template } from "./button.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeButton(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveButton>

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -8,6 +8,7 @@ import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -44,6 +45,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/button/button.template.ts
+++ b/packages/adaptive-web-components/src/components/button/button.template.ts
@@ -3,15 +3,24 @@ import { buttonTemplate, FASTButton } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ButtonConditions = {
     iconOnly: ".icon-only",
 };
 
+/**
+ * @public
+ */
 export const ButtonParts = {
     control: "control",
     content: "content",
 };
 
+/**
+ * @public
+ */
 export const ButtonAnatomy: ComponentAnatomy<typeof ButtonConditions, typeof ButtonParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: ButtonConditions,
@@ -20,6 +29,7 @@ export const ButtonAnatomy: ComponentAnatomy<typeof ButtonConditions, typeof But
 
 /**
  * Default Button template, {@link @microsoft/fast-foundation#buttonTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTButton> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/button/button.ts
+++ b/packages/adaptive-web-components/src/components/button/button.ts
@@ -2,6 +2,8 @@ import { FASTButton } from "@microsoft/fast-foundation";
 
 /**
  * The Adaptive version of Button. Extends {@link @microsoft/fast-foundation#FASTButton}.
+ *
+ * @public
  */
 export class AdaptiveButton extends FASTButton {
     /**

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -7,6 +7,9 @@ import { CalendarAnatomy, template } from "./calendar.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeCalendar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCalendar>

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -12,6 +12,7 @@ import { baseHeightMultiplier, density } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -35,6 +36,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/calendar/calendar.template.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.template.ts
@@ -6,9 +6,15 @@ import { composeDataGridCell } from "../data-grid-cell/index.js";
 import { composeDataGridRow } from "../data-grid-row/index.js";
 import { composeDataGrid } from "../data-grid/index.js";
 
+/**
+ * @public
+ */
 export const CalendarConditions = {
 };
 
+/**
+ * @public
+ */
 export const CalendarParts = {
     title: "title",
     month: "month",
@@ -22,6 +28,9 @@ export const CalendarParts = {
     today: "today",
 };
 
+/**
+ * @public
+ */
 export const CalendarAnatomy: ComponentAnatomy<typeof CalendarConditions, typeof CalendarParts> = {
     interactivity: Interactivity.never,
     conditions: CalendarConditions,
@@ -30,6 +39,7 @@ export const CalendarAnatomy: ComponentAnatomy<typeof CalendarConditions, typeof
 
 /**
  * Default Calendar template, {@link @microsoft/fast-foundation#calendarTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTCalendar> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -7,6 +7,9 @@ import { CardAnatomy, template } from "./card.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeCard(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCard>

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -10,6 +10,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -19,6 +20,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/card/card.template.ts
+++ b/packages/adaptive-web-components/src/components/card/card.template.ts
@@ -3,12 +3,21 @@ import { cardTemplate, FASTCard } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const CardConditions = {
 };
 
+/**
+ * @public
+ */
 export const CardParts = {
 };
 
+/**
+ * @public
+ */
 export const CardAnatomy: ComponentAnatomy<typeof CardConditions, typeof CardParts> = {
     interactivity: Interactivity.never,
     conditions: CardConditions,
@@ -17,6 +26,7 @@ export const CardAnatomy: ComponentAnatomy<typeof CardConditions, typeof CardPar
 
 /**
  * Default Card template, {@link @microsoft/fast-foundation#cardTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTCard> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -7,6 +7,9 @@ import { CheckboxAnatomy, CheckboxStatics, template } from "./checkbox.template.
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeCheckbox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCheckbox, CheckboxStatics>

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -57,6 +58,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
@@ -6,24 +6,38 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the checkbox.
+ *
+ * @beta
  */
 export const CheckboxStatics = {
     checked: "checkbox-checked-indicator",
     indeterminate: "checkbox-indeterminate-indicator"
 } as const;
 
+/**
+ * @beta
+ */
 export type CheckboxStatics = ValuesOf<typeof CheckboxStatics>;
 
+/**
+ * @public
+ */
 export const CheckboxConditions = {
     checked: "[aria-checked='true']",
     indeterminate: "[aria-checked='mixed']"
 };
 
+/**
+ * @public
+ */
 export const CheckboxParts = {
     control: "control",
     label: "label"
 };
 
+/**
+ * @public
+ */
 export const CheckboxAnatomy: ComponentAnatomy<typeof CheckboxConditions, typeof CheckboxParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: CheckboxConditions,
@@ -32,6 +46,7 @@ export const CheckboxAnatomy: ComponentAnatomy<typeof CheckboxConditions, typeof
 
 /**
  * Default Checkbox template, {@link @microsoft/fast-foundation#checkboxTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTCheckbox> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -7,6 +7,9 @@ import { ComboboxAnatomy, ComboboxStatics, template } from "./combobox.template.
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeCombobox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCombobox, ComboboxStatics>

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -10,6 +10,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -73,6 +74,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/combobox/combobox.template.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.template.ts
@@ -6,16 +6,27 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the combobox.
+ *
+ * @beta
  */
 export const ComboboxStatics = {
     indicator: "combobox-indicator"
 } as const;
 
+/**
+ * @beta
+ */
 export type ComboboxStatics = ValuesOf<typeof ComboboxStatics>;
 
+/**
+ * @public
+ */
 export const ComboboxConditions = {
 };
 
+/**
+ * @public
+ */
 export const ComboboxParts = {
     control: "control",
     selectedValue: "selected-value",
@@ -23,6 +34,9 @@ export const ComboboxParts = {
     listbox: "listbox",
 };
 
+/**
+ * @public
+ */
 export const ComboboxAnatomy: ComponentAnatomy<typeof ComboboxConditions, typeof ComboboxParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: ComboboxConditions,
@@ -31,6 +45,7 @@ export const ComboboxAnatomy: ComponentAnatomy<typeof ComboboxConditions, typeof
 
 /**
  * Default Combobox template, {@link @microsoft/fast-foundation#comboboxTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTCombobox> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -7,6 +7,9 @@ import { DataGridCellAnatomy, template } from "./data-grid-cell.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDataGridCell(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridCell>

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -7,6 +7,7 @@ import {
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -16,6 +17,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
@@ -3,15 +3,24 @@ import { dataGridCellTemplate, FASTDataGridCell } from "@microsoft/fast-foundati
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const DataGridCellConditions = {
     cellTypeDefault: "[cell-type='default']",
     cellTypeColumnHeader: "[cell-type='columnheader']",
     cellTypeRowHeader: "[cell-type='rowheader']",
 };
 
+/**
+ * @public
+ */
 export const DataGridCellParts = {
 };
 
+/**
+ * @public
+ */
 export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions, typeof DataGridCellParts> = {
     interactivity: Interactivity.never,
     conditions: DataGridCellConditions,
@@ -20,6 +29,7 @@ export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions
 
 /**
  * Default Data Grid Cell template, {@link @microsoft/fast-foundation#dataGridCellTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDataGridCell> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -7,6 +7,9 @@ import { DataGridRowAnatomy, template } from "./data-grid-row.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDataGridRow(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridRow>

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -11,6 +11,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -27,6 +28,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.template.ts
@@ -4,6 +4,9 @@ import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeDataGridCell } from "../data-grid-cell/index.js";
 
+/**
+ * @public
+ */
 export const DataGridRowConditions = {
     rowTypeDefault: "[row-type='default']",
     rowTypeHeader: "[row-type='header']",
@@ -11,9 +14,15 @@ export const DataGridRowConditions = {
     selected: "[aria-selected='true']",
 };
 
+/**
+ * @public
+ */
 export const DataGridRowParts = {
 };
 
+/**
+ * @public
+ */
 export const DataGridRowAnatomy: ComponentAnatomy<typeof DataGridRowConditions, typeof DataGridRowParts> = {
     interactivity: Interactivity.never,
     conditions: DataGridRowConditions,
@@ -22,6 +31,7 @@ export const DataGridRowAnatomy: ComponentAnatomy<typeof DataGridRowConditions, 
 
 /**
  * Default Data Grid Row template, {@link @microsoft/fast-foundation#dataGridRowTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDataGridRow> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -7,6 +7,9 @@ import { DataGridAnatomy, template } from "./data-grid.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDataGrid(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGrid>

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -17,5 +18,6 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css``;

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.template.ts
@@ -4,12 +4,21 @@ import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeDataGridRow } from '../data-grid-row/index.js';
 
+/**
+ * @public
+ */
 export const DataGridConditions = {
 };
 
+/**
+ * @public
+ */
 export const DataGridParts = {
 };
 
+/**
+ * @public
+ */
 export const DataGridAnatomy: ComponentAnatomy<typeof DataGridConditions, typeof DataGridParts> = {
     interactivity: Interactivity.never,
     conditions: DataGridConditions,
@@ -18,6 +27,7 @@ export const DataGridAnatomy: ComponentAnatomy<typeof DataGridConditions, typeof
 
 /**
  * Default Data Grid template, {@link @microsoft/fast-foundation#dataGridTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDataGrid> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -7,6 +7,9 @@ import { DialogAnatomy, template } from "./dialog.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDialog(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDialog>

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
@@ -3,6 +3,7 @@ import { elevationDialog, fillColor } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -33,6 +34,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/dialog/dialog.template.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.template.ts
@@ -3,15 +3,24 @@ import { dialogTemplate, FASTDialog } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const DialogConditions = {
 };
 
+/**
+ * @public
+ */
 export const DialogParts = {
     positioningRegion: "positioning-region",
     overlay: "overlay",
     control: "control",
 };
 
+/**
+ * @public
+ */
 export const DialogAnatomy: ComponentAnatomy<typeof DialogConditions, typeof DialogParts> = {
     interactivity: Interactivity.never,
     conditions: DialogConditions,
@@ -20,6 +29,7 @@ export const DialogAnatomy: ComponentAnatomy<typeof DialogConditions, typeof Dia
 
 /**
  * Default Dialog template, {@link @microsoft/fast-foundation#dialogTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDialog> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -7,6 +7,9 @@ import { DisclosureAnatomy, template } from "./disclosure.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDisclosure(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDisclosure>

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -10,6 +10,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -44,6 +45,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .invoker {

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
@@ -3,14 +3,23 @@ import { disclosureTemplate, FASTDisclosure } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const DisclosureConditions = {
     expanded: "[expanded]",
 };
 
+/**
+ * @public
+ */
 export const DisclosureParts = {
     invoker: "invoker",
 };
 
+/**
+ * @public
+ */
 export const DisclosureAnatomy: ComponentAnatomy<typeof DisclosureConditions, typeof DisclosureParts> = {
     interactivity: Interactivity.never,
     conditions: DisclosureConditions,
@@ -19,6 +28,7 @@ export const DisclosureAnatomy: ComponentAnatomy<typeof DisclosureConditions, ty
 
 /**
  * Default Disclosure template, {@link @microsoft/fast-foundation#disclosureTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDisclosure> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -7,6 +7,9 @@ import { DividerAnatomy, template } from "./divider.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeDivider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDivider>

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.ts
@@ -3,6 +3,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -12,6 +13,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/divider/divider.template.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.template.ts
@@ -3,14 +3,23 @@ import { dividerTemplate, FASTDivider } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui"; 
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const DividerConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const DividerParts = {
 };
 
+/**
+ * @public
+ */
 export const DividerAnatomy: ComponentAnatomy<typeof DividerConditions, typeof DividerParts> = {
     interactivity: Interactivity.never,
     conditions: DividerConditions,
@@ -19,6 +28,7 @@ export const DividerAnatomy: ComponentAnatomy<typeof DividerConditions, typeof D
 
 /**
  * Default Divider template, {@link @microsoft/fast-foundation#dividerTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTDivider> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
@@ -7,6 +7,9 @@ import { FlipperAnatomy, FlipperStatics, template } from "./flipper.template.js"
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeFlipper(
     ds: DesignSystem,
     options?: ComposeOptions<FASTFlipper, FlipperStatics>

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -7,6 +7,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -32,6 +33,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
@@ -6,24 +6,38 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the flipper.
+ *
+ * @beta
  */
 export const FlipperStatics = {
     next: "flipper-next",
     previous: "flipper-previous",
 } as const;
 
+/**
+ * @beta
+ */
 export type FlipperStatics = ValuesOf<typeof FlipperStatics>;
 
+/**
+ * @public
+ */
 export const FlipperConditions = {
     next: "[direction='next']",
     previous: "[direction='previous']",
 };
 
+/**
+ * @public
+ */
 export const FlipperParts = {
     next: "next",
     previous: "previous",
 };
 
+/**
+ * @public
+ */
 export const FlipperAnatomy: ComponentAnatomy<typeof FlipperConditions, typeof FlipperParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: FlipperConditions,
@@ -32,6 +46,7 @@ export const FlipperAnatomy: ComponentAnatomy<typeof FlipperConditions, typeof F
 
 /**
  * Default Flipper template, {@link @microsoft/fast-foundation#flipperTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTFlipper> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -7,6 +7,9 @@ import { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeHorizontalScroll(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveHorizontalScroll>

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -29,6 +30,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .scroll-view {

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.template.ts
@@ -13,9 +13,15 @@ import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 import { composeFlipper } from "../flipper/index.js";
 
+/**
+ * @public
+ */
 export const HorizontalScrollConditions = {
 };
 
+/**
+ * @public
+ */
 export const HorizontalScrollParts = {
     scrollArea: "scroll-area",
     scrollView: "scroll-view",
@@ -26,6 +32,9 @@ export const HorizontalScrollParts = {
     nextFlipper: "next-flipper",
 };
 
+/**
+ * @public
+ */
 export const HorizontalScrollAnatomy: ComponentAnatomy<typeof HorizontalScrollConditions, typeof HorizontalScrollParts> = {
     interactivity: Interactivity.never,
     conditions: HorizontalScrollConditions,
@@ -42,6 +51,7 @@ export type HorizontalScrollOptions = StartEndOptions<FASTHorizontalScroll> & {
 
 /**
  * Default Horizontal Scroll template, {@link @microsoft/fast-foundation#horizontalScrollTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTHorizontalScroll> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.ts
@@ -1,6 +1,11 @@
 import { FASTHorizontalScroll, HorizontalScrollView } from "@microsoft/fast-foundation";
 import { actionsStyles } from "./horizontal-scroll.styles.js";
 
+/**
+ * The Adaptive version of HorizontalScroll. Extends {@link @microsoft/fast-foundation#FASTHorizontalScroll}.
+ *
+ * @public
+ */
 export class AdaptiveHorizontalScroll extends FASTHorizontalScroll {
     public connectedCallback(): void {
         super.connectedCallback();

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
@@ -7,6 +7,9 @@ import { ListboxOptionAnatomy, template } from "./listbox-option.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeListboxOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxOption>

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -32,6 +33,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.template.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.template.ts
@@ -3,15 +3,24 @@ import { FASTListboxOption, listboxOptionTemplate } from "@microsoft/fast-founda
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ListboxOptionConditions = {
     checked: "[aria-checked='true']",
     selected: "[aria-selected='true']",
 };
 
+/**
+ * @public
+ */
 export const ListboxOptionParts = {
     content: "content",
 };
 
+/**
+ * @public
+ */
 export const ListboxOptionAnatomy: ComponentAnatomy<typeof ListboxOptionConditions, typeof ListboxOptionParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: ListboxOptionConditions,
@@ -20,6 +29,7 @@ export const ListboxOptionAnatomy: ComponentAnatomy<typeof ListboxOptionConditio
 
 /**
  * Default Listbox Option template, {@link @microsoft/fast-foundation#listboxOptionTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTListboxOption> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -7,6 +7,9 @@ import { ListboxAnatomy, template } from "./listbox.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeListbox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxElement>

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -8,6 +8,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -18,6 +19,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
@@ -3,12 +3,21 @@ import { FASTListboxElement, listboxTemplate } from "@microsoft/fast-foundation"
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ListboxConditions = {
 };
 
+/**
+ * @public
+ */
 export const ListboxParts = {
 };
 
+/**
+ * @public
+ */
 export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof ListboxParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: ListboxConditions,
@@ -17,6 +26,7 @@ export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof L
 
 /**
  * Default Listbox template, {@link @microsoft/fast-foundation#listboxTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTListboxElement> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
@@ -7,6 +7,9 @@ import { MenuItemAnatomy, MenuItemStatics, template } from "./menu-item.template
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeMenuItem(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveMenuItem, MenuItemStatics>

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -10,6 +10,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -121,6 +122,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
@@ -13,6 +13,8 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the menu item.
+ *
+ * @beta
  */
 export const MenuItemStatics = {
     checkbox: "menu-item-checkbox-indicator",
@@ -20,17 +22,29 @@ export const MenuItemStatics = {
     submenu: "menu-item-submenu-item"
 } as const;
 
+/**
+ * @beta
+ */
 export type MenuItemStatics = ValuesOf<typeof MenuItemStatics>;
 
+/**
+ * @public
+ */
 export const MenuItemConditions = {
     checked: "[aria-checked='true']",
 };
 
+/**
+ * @public
+ */
 export const MenuItemParts = {
     content: "content",
     submenuIcon: "submenu-icon",
 };
 
+/**
+ * @public
+ */
 export const MenuItemAnatomy: ComponentAnatomy<typeof MenuItemConditions, typeof MenuItemParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: MenuItemConditions,
@@ -41,6 +55,7 @@ export const MenuItemAnatomy: ComponentAnatomy<typeof MenuItemConditions, typeof
 
 /**
  * Default Menu Item template, {@link @microsoft/fast-foundation#menuItemTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTMenuItem> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.ts
@@ -7,6 +7,11 @@ import { FASTMenuItem } from "@microsoft/fast-foundation";
  */
 export type AdaptiveMenuItemColumnCount = 0 | 1 | 2;
 
+/**
+ * The Adaptive version of MenuItem. Extends {@link @microsoft/fast-foundation#FASTMenuItem}.
+ *
+ * @public
+ */
 export class AdaptiveMenuItem extends FASTMenuItem {
     /**
      * Managed by {@link AdaptiveMenu} to align checkbox or radio controls and `start` slot content properly.

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -7,6 +7,9 @@ import { MenuAnatomy, template } from "./menu.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeMenu(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveMenu>

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.ts
@@ -7,6 +7,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -20,6 +21,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/menu/menu.template.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.template.ts
@@ -3,13 +3,22 @@ import { FASTMenu, menuTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const MenuConditions = {
     submenu: "[slot='submenu']",
 };
 
+/**
+ * @public
+ */
 export const MenuParts = {
 };
 
+/**
+ * @public
+ */
 export const MenuAnatomy: ComponentAnatomy<typeof MenuConditions, typeof MenuParts> = {
     interactivity: Interactivity.never,
     conditions: MenuConditions,
@@ -18,6 +27,7 @@ export const MenuAnatomy: ComponentAnatomy<typeof MenuConditions, typeof MenuPar
 
 /**
  * Default Menu template, {@link @microsoft/fast-foundation#menuTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTMenu> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/menu/menu.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.ts
@@ -7,6 +7,11 @@ import { AdaptiveMenuItem, AdaptiveMenuItemColumnCount } from "../menu-item/menu
  */
 type AdaptiveMenuIndentInfo = { hasControl: boolean; hasStart: boolean };
 
+/**
+ * The Adaptive version of Menu. Extends {@link @microsoft/fast-foundation#FASTMenu}.
+ *
+ * @public
+ */
 export class AdaptiveMenu extends FASTMenu {
     private static elementIndent(el: HTMLElement): AdaptiveMenuIndentInfo {
         const role = el.getAttribute("role");

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -7,6 +7,9 @@ import { NumberFieldAnatomy, NumberFieldStatics, template } from "./number-field
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeNumberField(
     ds: DesignSystem,
     options?: ComposeOptions<FASTNumberField, NumberFieldStatics>

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -72,6 +73,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .label {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.template.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.template.ts
@@ -6,17 +6,28 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the number field.
+ *
+ * @beta
  */
 export const NumberFieldStatics = {
     stepDown: "number-field-step-down-icon",
     stepUp: "number-field-step-up-icon"
 } as const;
 
+/**
+ * @beta
+ */
 export type NumberFieldStatics = ValuesOf<typeof NumberFieldStatics>;
 
+/**
+ * @public
+ */
 export const NumberFieldConditions = {
 };
 
+/**
+ * @public
+ */
 export const NumberFieldParts = {
     label: "label",
     root: "root",
@@ -26,6 +37,9 @@ export const NumberFieldParts = {
     stepDown: "step-down",
 };
 
+/**
+ * @public
+ */
 export const NumberFieldAnatomy: ComponentAnatomy<typeof NumberFieldConditions, typeof NumberFieldParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: NumberFieldConditions,
@@ -34,6 +48,7 @@ export const NumberFieldAnatomy: ComponentAnatomy<typeof NumberFieldConditions, 
 
 /**
  * Default Number Field template, {@link @microsoft/fast-foundation#numberFieldTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTNumberField> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
@@ -7,6 +7,9 @@ import { PickerListItemAnatomy, template } from "./picker-list-item.template.js"
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composePickerListItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerListItem>

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -23,6 +24,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
@@ -3,12 +3,21 @@ import { FASTPickerListItem, pickerListItemTemplate } from "@microsoft/fast-foun
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const PickerListItemConditions = {
 };
 
+/**
+ * @public
+ */
 export const PickerListItemParts = {
 };
 
+/**
+ * @public
+ */
 export const PickerListItemAnatomy: ComponentAnatomy<typeof PickerListItemConditions, typeof PickerListItemParts> = {
     interactivity: Interactivity.always,
     conditions: PickerListItemConditions,
@@ -17,6 +26,7 @@ export const PickerListItemAnatomy: ComponentAnatomy<typeof PickerListItemCondit
 
 /**
  * Default Picker List Item template, {@link @microsoft/fast-foundation#pickerListItemTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTPickerListItem> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -7,6 +7,9 @@ import { PickerListAnatomy, template } from "./picker-list.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composePickerList(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerList>

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -29,6 +30,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.template.ts
@@ -3,12 +3,21 @@ import { FASTPickerList, pickerListTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const PickerListConditions = {
 };
 
+/**
+ * @public
+ */
 export const PickerListParts = {
 };
 
+/**
+ * @public
+ */
 export const PickerListAnatomy: ComponentAnatomy<typeof PickerListConditions, typeof PickerListParts> = {
     interactivity: Interactivity.always,
     conditions: PickerListConditions,
@@ -17,6 +26,7 @@ export const PickerListAnatomy: ComponentAnatomy<typeof PickerListConditions, ty
 
 /**
  * Default Picker List template, {@link @microsoft/fast-foundation#pickerListTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTPickerList> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
@@ -7,6 +7,9 @@ import { PickerMenuOptionAnatomy, template } from "./picker-menu-option.template
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composePickerMenuOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenuOption>

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -10,6 +10,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -25,6 +26,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.template.ts
@@ -3,12 +3,21 @@ import { FASTPickerMenuOption, pickerMenuOptionTemplate } from "@microsoft/fast-
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const PickerMenuOptionConditions = {
 };
 
+/**
+ * @public
+ */
 export const PickerMenuOptionParts = {
 };
 
+/**
+ * @public
+ */
 export const PickerMenuOptionAnatomy: ComponentAnatomy<typeof PickerMenuOptionConditions, typeof PickerMenuOptionParts> = {
     interactivity: Interactivity.always,
     conditions: PickerMenuOptionConditions,
@@ -17,6 +26,7 @@ export const PickerMenuOptionAnatomy: ComponentAnatomy<typeof PickerMenuOptionCo
 
 /**
  * Default Picker Menu Option template, {@link @microsoft/fast-foundation#pickerMenuOptionTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTPickerMenuOption> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -7,6 +7,9 @@ import { PickerMenuAnatomy, template } from "./picker-menu.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composePickerMenu(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenu>

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
@@ -3,6 +3,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -25,6 +26,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.template.ts
@@ -3,9 +3,15 @@ import { FASTPickerMenu, pickerMenuTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const PickerMenuConditions = {
 };
 
+/**
+ * @public
+ */
 export const PickerMenuParts = {
     optionsDisplay: "options-display",
     headerRegion: "header-region",
@@ -13,6 +19,9 @@ export const PickerMenuParts = {
     suggestionsAvailableAlert: "suggestions-available-alert",
 };
 
+/**
+ * @public
+ */
 export const PickerMenuAnatomy: ComponentAnatomy<typeof PickerMenuConditions, typeof PickerMenuParts> = {
     interactivity: Interactivity.never,
     conditions: PickerMenuConditions,
@@ -21,6 +30,7 @@ export const PickerMenuAnatomy: ComponentAnatomy<typeof PickerMenuConditions, ty
 
 /**
  * Default Picker Menu template, {@link @microsoft/fast-foundation#pickerMenuTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTPickerMenu> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -7,6 +7,9 @@ import { PickerAnatomy, template } from "./picker.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composePicker(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPicker>

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.ts
@@ -3,6 +3,7 @@ import { designUnit, elevationFlyout, layerCornerRadius, layerFillFixedPlus1, st
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -39,6 +40,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .loading-display,

--- a/packages/adaptive-web-components/src/components/picker/picker.template.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.template.ts
@@ -9,9 +9,15 @@ import { composePickerListItem } from '../picker-list-item/index.js';
 import { composePickerMenuOption } from '../picker-menu-option/index.js';
 import { composeProgressRing } from '../progress-ring/index.js';
 
+/**
+ * @public
+ */
 export const PickerConditions = {
 };
 
+/**
+ * @public
+ */
 export const PickerParts = {
     region: "region",
     noOptionsDisplay: "no-options-display",
@@ -19,6 +25,9 @@ export const PickerParts = {
     loadingProgress: "loading-progress",
 };
 
+/**
+ * @public
+ */
 export const PickerAnatomy: ComponentAnatomy<typeof PickerConditions, typeof PickerParts> = {
     interactivity: Interactivity.never,
     conditions: PickerConditions,
@@ -27,6 +36,7 @@ export const PickerAnatomy: ComponentAnatomy<typeof PickerConditions, typeof Pic
 
 /**
  * Default Picker template, {@link @microsoft/fast-foundation#pickerTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTPicker> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -7,6 +7,9 @@ import { ProgressRingAnatomy, template } from "./progress-ring.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeProgressRing(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgressRing>

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
@@ -3,6 +3,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -15,6 +16,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.template.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.template.ts
@@ -3,15 +3,24 @@ import { FASTProgressRing, StaticallyComposableHTML, staticallyCompose } from "@
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ProgressRingConditions = {
 };
 
+/**
+ * @public
+ */
 export const ProgressRingParts = {
     indicator: "indicator",
     determinate: "determinate",
     indeterminate: "indeterminate",
 };
 
+/**
+ * @public
+ */
 export const ProgressRingAnatomy: ComponentAnatomy<typeof ProgressRingConditions, typeof ProgressRingParts> = {
     interactivity: Interactivity.never,
     conditions: ProgressRingConditions,
@@ -34,6 +43,7 @@ const progressRingIndicatorTemplate = html`
 
 /**
  * Default Progress template, {@link @microsoft/fast-foundation#progressTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTProgressRing> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -7,6 +7,9 @@ import { ProgressAnatomy, template } from "./progress.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeProgress(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgress>

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.ts
@@ -3,6 +3,7 @@ import { designUnit } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -40,6 +41,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/progress/progress.template.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.template.ts
@@ -3,15 +3,24 @@ import { FASTProgress, StaticallyComposableHTML, staticallyCompose } from "@micr
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ProgressConditions = {
 };
 
+/**
+ * @public
+ */
 export const ProgressParts = {
     indicator: "indicator",
     determinate: "determinate",
     indeterminate: "indeterminate",
 };
 
+/**
+ * @public
+ */
 export const ProgressAnatomy: ComponentAnatomy<typeof ProgressConditions, typeof ProgressParts> = {
     interactivity: Interactivity.never,
     conditions: ProgressConditions,
@@ -31,6 +40,7 @@ const progressIndicatorTemplate = html`
 
 /**
  * Default Progress template, {@link @microsoft/fast-foundation#progressTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTProgress> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -7,6 +7,9 @@ import { RadioGroupAnatomy, template } from "./radio-group.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeRadioGroup(
     ds: DesignSystem,
     options?: ComposeOptions<FASTRadioGroup>

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -20,6 +21,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.template.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.template.ts
@@ -3,15 +3,24 @@ import { FASTRadioGroup, radioGroupTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const RadioGroupConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const RadioGroupParts = {
     positioningRegion: "positioning-region",
 };
 
+/**
+ * @public
+ */
 export const RadioGroupAnatomy: ComponentAnatomy<typeof RadioGroupConditions, typeof RadioGroupParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: RadioGroupConditions,
@@ -20,6 +29,7 @@ export const RadioGroupAnatomy: ComponentAnatomy<typeof RadioGroupConditions, ty
 
 /**
  * Default Radio Group template, {@link @microsoft/fast-foundation#radioGroupTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTRadioGroup> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/radio/radio.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.compose.ts
@@ -7,6 +7,9 @@ import { RadioAnatomy, RadioStatics, template } from "./radio.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeRadio(
     ds: DesignSystem,
     options?: ComposeOptions<FASTRadio, RadioStatics>

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -58,6 +59,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/radio/radio.template.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.template.ts
@@ -6,22 +6,36 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the radio.
+ *
+ * @beta
  */
 export const RadioStatics = {
     checked: "radio-checked-indicator"
 } as const;
 
+/**
+ * @beta
+ */
 export type RadioStatics = ValuesOf<typeof RadioStatics>;
 
+/**
+ * @public
+ */
 export const RadioConditions = {
     checked: "[aria-checked='true']",
 };
 
+/**
+ * @public
+ */
 export const RadioParts = {
     control: "control",
     label: "label",
 };
 
+/**
+ * @public
+ */
 export const RadioAnatomy: ComponentAnatomy<typeof RadioConditions, typeof RadioParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: RadioConditions,
@@ -30,6 +44,7 @@ export const RadioAnatomy: ComponentAnatomy<typeof RadioConditions, typeof Radio
 
 /**
  * Default Radio template, {@link @microsoft/fast-foundation#radioTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTRadio> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -7,6 +7,9 @@ import { SearchAnatomy, template } from "./search.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSearch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSearch>

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -8,6 +8,7 @@ import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -78,6 +79,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/search/search.template.ts
+++ b/packages/adaptive-web-components/src/components/search/search.template.ts
@@ -3,9 +3,15 @@ import { FASTSearch, searchTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const SearchConditions = {
 };
 
+/**
+ * @public
+ */
 export const SearchParts = {
     label: "label",
     root: "root",
@@ -13,6 +19,9 @@ export const SearchParts = {
     clearButton: "clear-button",
 };
 
+/**
+ * @public
+ */
 export const SearchAnatomy: ComponentAnatomy<typeof SearchConditions, typeof SearchParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: SearchConditions,
@@ -21,6 +30,7 @@ export const SearchAnatomy: ComponentAnatomy<typeof SearchConditions, typeof Sea
 
 /**
  * Default Search Field template, {@link @microsoft/fast-foundation#searchTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSearch> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -7,6 +7,9 @@ import { SelectAnatomy, SelectStatics, template } from "./select.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSelect(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveSelect, SelectStatics>

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -11,6 +11,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -74,6 +75,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/select/select.template.ts
+++ b/packages/adaptive-web-components/src/components/select/select.template.ts
@@ -6,16 +6,27 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the select.
+ *
+ * @beta
  */
 export const SelectStatics = {
     indicator: "select-indicator"
 } as const;
 
+/**
+ * @beta
+ */
 export type SelectStatics = ValuesOf<typeof SelectStatics>;
 
+/**
+ * @public
+ */
 export const SelectConditions = {
 };
 
+/**
+ * @public
+ */
 export const SelectParts = {
     control: "control",
     selectedValue: "selected-value",
@@ -23,6 +34,9 @@ export const SelectParts = {
     listbox: "listbox",
 };
 
+/**
+ * @public
+ */
 export const SelectAnatomy: ComponentAnatomy<typeof SelectConditions, typeof SelectParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: SelectConditions,
@@ -31,6 +45,7 @@ export const SelectAnatomy: ComponentAnatomy<typeof SelectConditions, typeof Sel
 
 /**
  * Default Select template, {@link @microsoft/fast-foundation#selectTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSelect> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -7,6 +7,9 @@ import { SkeletonAnatomy, template } from "./skeleton.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSkeleton(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSkeleton>

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
@@ -3,6 +3,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -48,6 +49,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.template.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.template.ts
@@ -3,14 +3,23 @@ import type { FASTSkeleton } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const SkeletonConditions = {
     rectangle: "[shape='rect']",
     circle: "[shape='circle']",
 };
 
+/**
+ * @public
+ */
 export const SkeletonParts = {
 };
 
+/**
+ * @public
+ */
 export const SkeletonAnatomy: ComponentAnatomy<typeof SkeletonConditions, typeof SkeletonParts> = {
     interactivity: Interactivity.never,
     conditions: SkeletonConditions,
@@ -19,6 +28,7 @@ export const SkeletonAnatomy: ComponentAnatomy<typeof SkeletonConditions, typeof
 
 /**
  * Default Skeleton template, {@link @microsoft/fast-foundation#skeletonTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSkeleton> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -7,6 +7,9 @@ import { SliderLabelAnatomy, template } from "./slider-label.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSliderLabel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSliderLabel>

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -4,6 +4,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host([orientation="horizontal"]) {
@@ -62,6 +63,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .mark {

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.template.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.template.ts
@@ -4,17 +4,26 @@ import type { FASTSliderLabel } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const SliderLabelConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const SliderLabelParts = {
     container: "container",
     mark: "mark",
     content: "content",
 };
 
+/**
+ * @public
+ */
 export const SliderLabelAnatomy: ComponentAnatomy<typeof SliderLabelConditions, typeof SliderLabelParts> = {
     interactivity: Interactivity.never,
     conditions: SliderLabelConditions,
@@ -25,6 +34,7 @@ export const SliderLabelAnatomy: ComponentAnatomy<typeof SliderLabelConditions, 
 
 /**
  * Default Slider Label template, {@link @microsoft/fast-foundation#sliderLabelTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSliderLabel> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -7,6 +7,9 @@ import { SliderAnatomy, template } from "./slider.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSlider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSlider>

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -13,6 +13,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -109,6 +110,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/slider/slider.template.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.template.ts
@@ -4,11 +4,17 @@ import { FASTSlider, staticallyCompose } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const SliderConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const SliderParts = {
     positioningRegion: "positioning-region",
     track: "track",
@@ -17,6 +23,9 @@ export const SliderParts = {
     thumb: "thumb",
 };
 
+/**
+ * @public
+ */
 export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof SliderParts> = {
     interactivity: Interactivity.never,
     conditions: SliderConditions,
@@ -27,6 +36,7 @@ export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof Sli
 
 /**
  * Default Slider template, {@link @microsoft/fast-foundation#sliderTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSlider> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/switch/switch.compose.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.compose.ts
@@ -7,6 +7,9 @@ import { SwitchAnatomy, template } from "./switch.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeSwitch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSwitch>

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -9,6 +9,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -43,6 +44,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/switch/switch.template.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.template.ts
@@ -3,16 +3,25 @@ import { FASTSwitch, switchTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const SwitchConditions = {
     checked: "[aria-checked='true']",
 };
 
+/**
+ * @public
+ */
 export const SwitchParts = {
     switch: "switch",
     label: "label",
     thumb: "thumb",
 };
 
+/**
+ * @public
+ */
 export const SwitchAnatomy: ComponentAnatomy<typeof SwitchConditions, typeof SwitchParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: SwitchConditions,
@@ -21,6 +30,7 @@ export const SwitchAnatomy: ComponentAnatomy<typeof SwitchConditions, typeof Swi
 
 /**
  * Default Switch template, {@link @microsoft/fast-foundation#switchTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTSwitch> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -7,6 +7,9 @@ import { TabPanelAnatomy, template } from "./tab-panel.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTabPanel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabPanel>

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.ts
@@ -4,6 +4,7 @@ import { density } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -13,6 +14,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.template.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.template.ts
@@ -3,12 +3,21 @@ import { FASTTabPanel, tabPanelTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TabPanelConditions = {
 };
 
+/**
+ * @public
+ */
 export const TabPanelParts = {
 };
 
+/**
+ * @public
+ */
 export const TabPanelAnatomy: ComponentAnatomy<typeof TabPanelConditions, typeof TabPanelParts> = {
     interactivity: Interactivity.never,
     conditions: TabPanelConditions,
@@ -17,6 +26,7 @@ export const TabPanelAnatomy: ComponentAnatomy<typeof TabPanelConditions, typeof
 
 /**
  * Default Tab Panel template, {@link @microsoft/fast-foundation#tabPanelTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTabPanel> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/tab/tab.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.compose.ts
@@ -7,6 +7,9 @@ import { TabAnatomy, template } from "./tab.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTab(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTab>

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -8,6 +8,7 @@ import { density, heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -25,6 +26,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/tab/tab.template.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.template.ts
@@ -3,12 +3,21 @@ import { FASTTab, tabTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TabConditions = {
 };
 
+/**
+ * @public
+ */
 export const TabParts = {
 };
 
+/**
+ * @public
+ */
 export const TabAnatomy: ComponentAnatomy<typeof TabConditions, typeof TabParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: TabConditions,
@@ -17,6 +26,7 @@ export const TabAnatomy: ComponentAnatomy<typeof TabConditions, typeof TabParts>
 
 /**
  * Default Tab template, {@link @microsoft/fast-foundation#tabTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTab> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -7,6 +7,9 @@ import { TabsAnatomy, template } from "./tabs.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTabs(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabs>

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
@@ -9,6 +9,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -68,6 +69,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/tabs/tabs.template.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.template.ts
@@ -3,16 +3,25 @@ import { FASTTabs, tabsTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TabsConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const TabsParts = {
     tablist: "tablist",
     tabpanel: "tabpanel",
 };
 
+/**
+ * @public
+ */
 export const TabsAnatomy: ComponentAnatomy<typeof TabsConditions, typeof TabsParts> = {
     interactivity: Interactivity.never,
     conditions: TabsConditions,
@@ -21,6 +30,7 @@ export const TabsAnatomy: ComponentAnatomy<typeof TabsConditions, typeof TabsPar
 
 /**
  * Default Tabs template, {@link @microsoft/fast-foundation#tabsTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTabs> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -7,6 +7,9 @@ import { template, TextAreaAnatomy } from "./text-area.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTextArea(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextArea>

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -53,6 +54,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     .label {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.template.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.template.ts
@@ -3,14 +3,23 @@ import { FASTTextArea, textAreaTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TextAreaConditions = {
 };
 
+/**
+ * @public
+ */
 export const TextAreaParts = {
     label: "label",
     control: "control",
 };
 
+/**
+ * @public
+ */
 export const TextAreaAnatomy: ComponentAnatomy<typeof TextAreaConditions, typeof TextAreaParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: TextAreaConditions,
@@ -19,6 +28,7 @@ export const TextAreaAnatomy: ComponentAnatomy<typeof TextAreaConditions, typeof
 
 /**
  * Default Text Area template, {@link @microsoft/fast-foundation#textAreaTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTextArea> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -7,6 +7,9 @@ import { template, TextFieldAnatomy } from "./text-field.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTextField(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextField>

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -8,6 +8,7 @@ import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -49,6 +50,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/text-field/text-field.template.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.template.ts
@@ -3,15 +3,24 @@ import { FASTTextField, textFieldTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TextFieldConditions = {
 };
 
+/**
+ * @public
+ */
 export const TextFieldParts = {
     label: "label",
     root: "root",
     control: "control",
 };
 
+/**
+ * @public
+ */
 export const TextFieldAnatomy: ComponentAnatomy<typeof TextFieldConditions, typeof TextFieldParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: TextFieldConditions,
@@ -20,6 +29,7 @@ export const TextFieldAnatomy: ComponentAnatomy<typeof TextFieldConditions, type
 
 /**
  * Default Text Field template, {@link @microsoft/fast-foundation#textFieldTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTextField> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -7,6 +7,9 @@ import { template, ToolbarAnatomy } from "./toolbar.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeToolbar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTToolbar>

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -3,6 +3,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -35,6 +36,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.template.ts
@@ -3,15 +3,24 @@ import { FASTToolbar, toolbarTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const ToolbarConditions = {
     horizontal: "[orientation='horizontal']",
     vertical: "[orientation='vertical']",
 };
 
+/**
+ * @public
+ */
 export const ToolbarParts = {
     positioningRegion: "positioning-region",
 };
 
+/**
+ * @public
+ */
 export const ToolbarAnatomy: ComponentAnatomy<typeof ToolbarConditions, typeof ToolbarParts> = {
     interactivity: Interactivity.never,
     conditions: ToolbarConditions,
@@ -20,6 +29,7 @@ export const ToolbarAnatomy: ComponentAnatomy<typeof ToolbarConditions, typeof T
 
 /**
  * Default Toolbar template, {@link @microsoft/fast-foundation#toolbarTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTToolbar> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -7,6 +7,9 @@ import { template, TooltipAnatomy } from "./tooltip.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTooltip(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTooltip>

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -6,6 +6,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -23,6 +24,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.template.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.template.ts
@@ -3,14 +3,23 @@ import { FASTTooltip, tooltipTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TooltipConditions = {
     show: "[show='true']",
     visible: "[visible]",
 };
 
+/**
+ * @public
+ */
 export const TooltipParts = {
 };
 
+/**
+ * @public
+ */
 export const TooltipAnatomy: ComponentAnatomy<typeof TooltipConditions, typeof TooltipParts> = {
     interactivity: Interactivity.never,
     conditions: TooltipConditions,
@@ -19,6 +28,7 @@ export const TooltipAnatomy: ComponentAnatomy<typeof TooltipConditions, typeof T
 
 /**
  * Default Tooltip template, {@link @microsoft/fast-foundation#tooltipTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTooltip> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -7,6 +7,9 @@ import { template, TreeItemAnatomy, TreeItemStatics } from "./tree-item.template
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTreeItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTreeItem, TreeItemStatics>

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -30,6 +30,7 @@ const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -99,6 +100,7 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css`
     :host {

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
@@ -6,17 +6,28 @@ import { DesignSystem } from "../../design-system.js";
 
 /**
  * Keys for {@link DesignSystem} `statics` registration for the tree item.
+ *
+ * @beta
  */
 export const TreeItemStatics = {
     expandCollapse: "tree-item-expand-collapse-icon"
 } as const;
 
+/**
+ * @beta
+ */
 export type TreeItemStatics = ValuesOf<typeof TreeItemStatics>;
 
+/**
+ * @public
+ */
 export const TreeItemConditions = {
     selected: "[aria-selected='true']",
 };
 
+/**
+ * @public
+ */
 export const TreeItemParts = {
     control: "control",
     expandCollapseButton: "expand-collapse-button",
@@ -24,6 +35,9 @@ export const TreeItemParts = {
     items: "items",
 };
 
+/**
+ * @public
+ */
 export const TreeItemAnatomy: ComponentAnatomy<typeof TreeItemConditions, typeof TreeItemParts> = {
     interactivity: Interactivity.disabledAttribute,
     conditions: TreeItemConditions,
@@ -34,6 +48,7 @@ export const TreeItemAnatomy: ComponentAnatomy<typeof TreeItemConditions, typeof
 
 /**
  * Default Tree Item template, {@link @microsoft/fast-foundation#treeItemTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTreeItem> =
     (ds: DesignSystem) => {

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -7,6 +7,9 @@ import { template, TreeViewAnatomy } from "./tree-view.template.js";
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
+/**
+ * @public
+ */
 export function composeTreeView(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTreeView>

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
@@ -2,6 +2,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
+ * @public
  */
 export const templateStyles: ElementStyles = css`
     :host {
@@ -14,5 +15,6 @@ export const templateStyles: ElementStyles = css`
 
 /**
  * Visual styles including Adaptive UI tokens.
+ * @public
  */
 export const aestheticStyles: ElementStyles = css``;

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.template.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.template.ts
@@ -3,12 +3,21 @@ import { FASTTreeView, treeViewTemplate } from "@microsoft/fast-foundation";
 import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
+/**
+ * @public
+ */
 export const TreeViewConditions = {
 };
 
+/**
+ * @public
+ */
 export const TreeViewParts = {
 };
 
+/**
+ * @public
+ */
 export const TreeViewAnatomy: ComponentAnatomy<typeof TreeViewConditions, typeof TreeViewParts> = {
     interactivity: Interactivity.never,
     conditions: TreeViewConditions,
@@ -17,6 +26,7 @@ export const TreeViewAnatomy: ComponentAnatomy<typeof TreeViewConditions, typeof
 
 /**
  * Default Tree View template, {@link @microsoft/fast-foundation#treeViewTemplate}.
+ * @public
  */
 export const template: (ds: DesignSystem) => ElementViewTemplate<FASTTreeView> =
     (ds: DesignSystem) =>

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -143,6 +143,8 @@ export class DesignSystem {
 
 /**
  * The default {@link DesignSystem} configuration.
+ *
+ * @beta
  */
 export const DefaultDesignSystem: DesignSystem = new DesignSystem("adaptive");
 


### PR DESCRIPTION
# Pull Request

## Description

Getting rid of many of the warnings when API Extractor runs.
- Added release tags to many exports.
- Cleaned up a couple of other minor issues

## Reviewer Notes

Lots of find and replace here.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

There are still warnings coming from fast-foundation, looks like we need to update the config to allow some doc extensions like @slot and @csspart.