### PR TITLE
Designer: Separate effective applied tokens

### DIFF
--- a/packages/adaptive-ui-figma-designer/src/core/controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/controller.ts
@@ -1,6 +1,9 @@
 import { pluginNodesToUINodes, PluginUINodeData } from "./model.js";
 import { PluginNode } from "./node.js";
 
+/**
+ * The state object that is passed back and forth between the plugin UI and Controller portions.
+ */
 export interface PluginUIState {
     selectedNodes: PluginUINodeData[];
 }
@@ -90,7 +93,7 @@ export abstract class Controller {
                 pluginNode.setAppliedDesignTokens(node.appliedDesignTokens);
 
                 // Paint all applied design tokens on the node
-                pluginNode.appliedDesignTokens.forEach((applied, target) => {
+                node.effectiveAppliedDesignTokens?.forEach((applied, target) => {
                     // console.log("applied design token eval", target, applied);
 
                     pluginNode.paint(target, applied);

--- a/packages/adaptive-ui-figma-designer/src/core/model.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/model.ts
@@ -150,6 +150,13 @@ export interface PluginUINodeData extends PluginNodeData {
     componentAppliedDesignTokens?: ReadonlyAppliedDesignTokens;
 
     /**
+     * The resultant set of effective applied design tokens and values that need to be updated
+     * to the node. This will include the sum of applied design tokens inherited from the main
+     * component, applied directly to this node, or applied via style modules.
+     */
+    effectiveAppliedDesignTokens: AppliedDesignTokens;
+
+    /**
      * Children of this node that have design tokens set or applied.
      */
     children: PluginUINodeData[];
@@ -175,6 +182,7 @@ export const pluginNodesToUINodes = (
                 inheritedDesignTokens,
                 componentDesignTokens: node.componentDesignTokens,
                 componentAppliedDesignTokens: node.componentAppliedDesignTokens,
+                effectiveAppliedDesignTokens: new AppliedDesignTokens(),
                 children,
                 designTokens: node.localDesignTokens as DesignTokenValues,
                 appliedDesignTokens: node.appliedDesignTokens as AppliedDesignTokens,

--- a/packages/adaptive-ui-figma-designer/src/core/serialization.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/serialization.ts
@@ -15,6 +15,7 @@ export interface SerializableNodeData {
     componentAppliedDesignTokens?: string;
     appliedDesignTokens: string;
     additionalData: string;
+    effectiveAppliedDesignTokens: string;
 }
 
 /**
@@ -45,6 +46,7 @@ export function serializeUINodes(
                 componentAppliedDesignTokens: (node.componentAppliedDesignTokens as AppliedDesignTokens)?.serialize(),
                 appliedDesignTokens: node.appliedDesignTokens.serialize(),
                 additionalData: node.additionalData.serialize(),
+                effectiveAppliedDesignTokens: node.effectiveAppliedDesignTokens.serialize(),
             };
         }
     );
@@ -74,6 +76,8 @@ export function deserializeUINodes(
             appliedDesignTokens.deserialize(node.appliedDesignTokens);
             const additionalData = new AdditionalData();
             additionalData.deserialize(node.additionalData);
+            const effectiveAppliedDesignTokens = new AppliedDesignTokens();
+            effectiveAppliedDesignTokens.deserialize(node.effectiveAppliedDesignTokens);
 
             return {
                 id: node.id,
@@ -86,6 +90,7 @@ export function deserializeUINodes(
                 componentAppliedDesignTokens,
                 appliedDesignTokens,
                 additionalData,
+                effectiveAppliedDesignTokens,
             };
         }
     );

--- a/packages/adaptive-ui-figma-designer/src/figma/controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/controller.ts
@@ -17,11 +17,11 @@ export class FigmaController extends Controller {
         super.receiveStateFromUI({
             selectedNodes: pluginNodes
         })
+
+        FigmaPluginNode.clearCache();
     }
 
     public sendStateToUI(state: PluginUIState): void {
-        FigmaPluginNode.clearCache();
-
         const message: SerializableUIState = {
             selectedNodes: serializeUINodes(state.selectedNodes),
         };


### PR DESCRIPTION
# Pull Request

## Description

The Designer plugin previously stored all applied design tokens (style attributes and values) is a single property. This included any styles that were inherited because they needed to be evaluated and pushed back to the design tool.

This accounted for a complexity in the Figma plugin data model, but as the style application model is becoming more complex, this complexity further hides what's going on.

Also includes some logging and doc updates.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

This will be followed by a PR that adds support for applying style modules in the Designer.