### PR TITLE
Designer: add style module support

### DIFF
--- a/change/@adaptive-web-adaptive-ui-5a8c14e6-76e1-4b14-b0a1-5be5bd4ab774.json
+++ b/change/@adaptive-web-adaptive-ui-5a8c14e6-76e1-4b14-b0a1-5be5bd4ab774.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Designer: add style module support",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-4f880444-6134-4422-8d95-fad857235e9d.json
+++ b/change/@adaptive-web-adaptive-web-components-4f880444-6134-4422-8d95-fad857235e9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Designer: add style module support",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -65,7 +65,7 @@ export class StyleExample extends FASTElement {
         let backgroundActive = fillColor;
         let backgroundFocus = fillColor;
 
-        const backgroundValue = (this.styles?.effectiveProperties || {})[StyleProperty.backgroundFill];
+        const backgroundValue = this.styles?.effectiveProperties?.get(StyleProperty.backgroundFill);
         if (backgroundValue) {
             if (typeof backgroundValue === "string") {
                 // ignore for now
@@ -105,7 +105,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const colorValue = (this.styles?.effectiveProperties || {})[StyleProperty.foregroundFill];
+        const colorValue = this.styles?.effectiveProperties?.get(StyleProperty.foregroundFill);
         if (colorValue) {
             if (typeof colorValue === "string") {
                 // ignore for now
@@ -145,7 +145,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const borderValue = (this.styles?.effectiveProperties || {})[StyleProperty.borderFill];
+        const borderValue = this.styles?.effectiveProperties?.get(StyleProperty.borderFill);
         if (borderValue) {
             if (typeof borderValue === "string") {
                 // ignore for now

--- a/packages/adaptive-ui-figma-designer/src/core/controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/controller.ts
@@ -90,6 +90,7 @@ export abstract class Controller {
             if (pluginNode) {
                 pluginNode.handleManualDarkMode();
                 pluginNode.setDesignTokens(node.designTokens);
+                pluginNode.setAppliedStyleModules(node.appliedStyleModules);
                 pluginNode.setAppliedDesignTokens(node.appliedDesignTokens);
 
                 // Paint all applied design tokens on the node

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -4,9 +4,11 @@ import {
     AdditionalData,
     AppliedDesignToken,
     AppliedDesignTokens,
+    AppliedStyleModules,
     DesignTokenValues,
     PluginNodeData,
     ReadonlyAppliedDesignTokens,
+    ReadonlyAppliedStyleModules,
     ReadonlyDesignTokenValues,
     TOOL_FILL_COLOR_TOKEN,
 } from "./model.js";
@@ -28,6 +30,13 @@ export abstract class PluginNode {
     protected _componentDesignTokens?: ReadonlyDesignTokenValues;
 
     /**
+     * Applied style modules inherited by an instance node from the main component.
+     *
+     * It is the responsibility of the subclass to load this field.
+     */
+    protected _componentAppliedStyleModules?: ReadonlyAppliedStyleModules;
+
+    /**
      * Applied design tokens inherited by an instance node from the main component.
      *
      * It is the responsibility of the subclass to load this field.
@@ -47,6 +56,13 @@ export abstract class PluginNode {
      * It is the responsibility of the subclass to load this field.
      */
     protected _appliedDesignTokens: AppliedDesignTokens = new AppliedDesignTokens();
+
+    /**
+     * Style modules applied to the style of this node.
+     *
+     * It is the responsibility of the subclass to load this field.
+     */
+    protected _appliedStyleModules: AppliedStyleModules = new AppliedStyleModules();
 
     /**
      * Additional data associated with this node.
@@ -81,6 +97,13 @@ export abstract class PluginNode {
         DesignTokenCache.set(this.id, designTokens);
 
         return designTokens;
+    }
+
+    /**
+     * Gets the applied style modules inherited by an instance node from the main component.
+     */
+    public get componentAppliedStyleModules(): ReadonlyAppliedStyleModules | undefined {
+        return this._componentAppliedStyleModules;
     }
 
     /**
@@ -173,6 +196,27 @@ export abstract class PluginNode {
             this.setPluginData("appliedDesignTokens", json);
         } else {
             this.deletePluginData("appliedDesignTokens");
+        }
+    }
+
+    /**
+     * Gets the styler modules applied to the style of this node.
+     */
+    public get appliedStyleModules(): ReadonlyAppliedStyleModules {
+        return this._appliedStyleModules;
+    }
+
+    /**
+     * Sets the style modules applied to the style of this node.
+     * @param appliedModules The complete style modules applied to the style.
+     */
+    public setAppliedStyleModules(appliedModules: AppliedStyleModules) {
+        this._appliedStyleModules = appliedModules;
+        if (appliedModules.length) {
+            const json = JSON.stringify(appliedModules);
+            this.setPluginData("appliedStyleModules", json);
+        } else {
+            this.deletePluginData("appliedStyleModules");
         }
     }
 

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -157,7 +157,7 @@ const textTokens: DesignTokenStore = [
     typeRampMinus2LineHeight,
 ];
 
-function nameToTitle(name: string): string {
+export function nameToTitle(name: string): string {
     const base = name.replace(/-/g, ' ');
     return base.charAt(0).toUpperCase() + base.substr(1);
 }

--- a/packages/adaptive-ui-figma-designer/src/core/serialization.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/serialization.ts
@@ -1,5 +1,5 @@
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
-import { AdditionalData, AppliedDesignTokens, DesignTokenValues, PluginUINodeData } from "../core/model.js";
+import { AdditionalData, AppliedDesignTokens, AppliedStyleModules, DesignTokenValues, PluginUINodeData } from "../core/model.js";
 
 /**
  * Serializable version of PluginUINodeData that works across Figma's iframe sandbox setup.
@@ -7,11 +7,14 @@ import { AdditionalData, AppliedDesignTokens, DesignTokenValues, PluginUINodeDat
 export interface SerializableNodeData {
     id: string;
     type: string;
+    name: string;
     supports: Array<StyleProperty>;
     children: SerializableNodeData[];
     inheritedDesignTokens: string;
     componentDesignTokens?: string;
     designTokens: string;
+    componentAppliedStyleModules?: string;
+    appliedStyleModules: string;
     componentAppliedDesignTokens?: string;
     appliedDesignTokens: string;
     additionalData: string;
@@ -38,11 +41,14 @@ export function serializeUINodes(
             return {
                 id: node.id,
                 type: node.type,
+                name: node.name,
                 supports: node.supports,
                 children: serializeUINodes(node.children),
                 inheritedDesignTokens: (node.inheritedDesignTokens as DesignTokenValues).serialize(),
                 componentDesignTokens: (node.componentDesignTokens as DesignTokenValues)?.serialize(),
                 designTokens: node.designTokens.serialize(),
+                componentAppliedStyleModules: (node.componentAppliedStyleModules as AppliedStyleModules)?.serialize(),
+                appliedStyleModules: node.appliedStyleModules.serialize(),
                 componentAppliedDesignTokens: (node.componentAppliedDesignTokens as AppliedDesignTokens)?.serialize(),
                 appliedDesignTokens: node.appliedDesignTokens.serialize(),
                 additionalData: node.additionalData.serialize(),
@@ -70,6 +76,10 @@ export function deserializeUINodes(
             componentDesignTokens.deserialize(node.componentDesignTokens);
             const designTokens = new DesignTokenValues();
             designTokens.deserialize(node.designTokens);
+            const componentAppliedStyleModules = new AppliedStyleModules();
+            componentAppliedStyleModules.deserialize(node.componentAppliedStyleModules);
+            const appliedStyleModules = new AppliedStyleModules();
+            appliedStyleModules.deserialize(node.appliedStyleModules);
             const componentAppliedDesignTokens = new AppliedDesignTokens();
             componentAppliedDesignTokens.deserialize(node.componentAppliedDesignTokens);
             const appliedDesignTokens = new AppliedDesignTokens();
@@ -82,11 +92,14 @@ export function deserializeUINodes(
             return {
                 id: node.id,
                 type: node.type,
+                name: node.name,
                 supports: node.supports,
                 children: deserializeUINodes(node.children),
                 inheritedDesignTokens,
                 componentDesignTokens,
                 designTokens,
+                componentAppliedStyleModules,
+                appliedStyleModules,
                 componentAppliedDesignTokens,
                 appliedDesignTokens,
                 additionalData,

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -1526,6 +1526,9 @@ export interface StyleModuleTarget {
 export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>>;
 
 // @public
+export type StylePropertiesMap = Map<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>;
+
+// @public
 export const StyleProperty: {
     readonly backgroundFill: "backgroundFill";
     readonly foregroundFill: "foregroundFill";
@@ -1558,11 +1561,11 @@ export class Styles {
     clearComposed(): void;
     static compose(styles: Styles[], properties?: StyleProperties, name?: string): Styles;
     get composed(): Styles[] | undefined;
-    get effectiveProperties(): StyleProperties;
+    get effectiveProperties(): StylePropertiesMap;
     static fromProperties(properties: StyleProperties, name?: string): Styles;
     readonly name: string | undefined;
-    get properties(): StyleProperties | undefined;
-    set properties(properties: StyleProperties | undefined);
+    get properties(): StylePropertiesMap | undefined;
+    set properties(properties: StylePropertiesMap | undefined);
     // (undocumented)
     static Shared: Map<string, Styles>;
 }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -1556,12 +1556,15 @@ export class Styles {
     // (undocumented)
     appendComposed(styles: Styles): void;
     clearComposed(): void;
-    static compose(...styles: Styles[]): Styles;
+    static compose(styles: Styles[], properties?: StyleProperties, name?: string): Styles;
     get composed(): Styles[] | undefined;
     get effectiveProperties(): StyleProperties;
-    static fromProperties(properties: StyleProperties): Styles;
+    static fromProperties(properties: StyleProperties, name?: string): Styles;
+    readonly name: string | undefined;
     get properties(): StyleProperties | undefined;
     set properties(properties: StyleProperties | undefined);
+    // (undocumented)
+    static Shared: Map<string, Styles>;
 }
 
 // @public

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -311,7 +311,6 @@ export const accentFillSubtleControlStyles: Styles = Styles.fromProperties(
 export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForegroundBySet(accentFillDiscernible, blackOrWhiteDiscernibleRecipe),
-        borderFill: "transparent", // TODO Remove "transparent" borders, this is a hack for the Explorer app.
     },
     "color.accent-fill-discernible-control",
 );
@@ -329,7 +328,6 @@ export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties(
 export const accentFillReadableControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForegroundBySet(accentFillReadable, blackOrWhiteReadableRecipe),
-        borderFill: "transparent",
     },
     "color.accent-fill-readable-control",
 );
@@ -364,7 +362,6 @@ export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperti
  */
 export const accentForegroundReadableControlStyles: Styles = Styles.fromProperties(
     {
-        borderFill: "transparent",
         foregroundFill: accentStrokeReadable,
     },
     "color.accent-foreground-readable-control",
@@ -419,7 +416,6 @@ export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties(
 export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForegroundBySet(neutralFillDiscernible, blackOrWhiteDiscernibleRecipe),
-        borderFill: "transparent",
     },
     "color.neutral-fill-discernible-control",
 );
@@ -437,7 +433,6 @@ export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties
 export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForeground(neutralFillReadable, neutralStrokeStrongRecipe),
-        borderFill: "transparent",
     },
     "color.neutral-fill-readable-control",
 );
@@ -472,7 +467,6 @@ export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties(
     {
-        borderFill: "transparent",
         foregroundFill: neutralStrokeReadableRest,
     },
     "color.neutral-foreground-readable-control",
@@ -490,7 +484,6 @@ export const neutralForegroundReadableElementStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties(
     {
-        borderFill: "transparent",
         foregroundFill: neutralStrokeStrongRest,
     },
     "color.neutral-foreground-strong-element",

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -168,12 +168,15 @@ function backgroundAndForegroundBySet(
  *
  * @public
  */
-export const controlShapeStyles: Styles = Styles.fromProperties({
-    borderThickness: strokeThickness,
-    borderStyle: "solid",
-    borderFill: "transparent",
-    cornerRadius: cornerRadiusControl,
-});
+export const controlShapeStyles: Styles = Styles.fromProperties(
+    {
+        borderThickness: strokeThickness,
+        borderStyle: "solid",
+        borderFill: "transparent",
+        cornerRadius: cornerRadiusControl,
+    },
+    "shape.control",
+);
 
 /**
  * Style module for the shape of a layer.
@@ -182,26 +185,32 @@ export const controlShapeStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const layerShapeStyles: Styles = Styles.fromProperties({
-    borderThickness: strokeThickness,
-    borderStyle: "solid",
-    borderFill: "transparent",
-    cornerRadius: cornerRadiusLayer,
-});
+export const layerShapeStyles: Styles = Styles.fromProperties(
+    {
+        borderThickness: strokeThickness,
+        borderStyle: "solid",
+        borderFill: "transparent",
+        cornerRadius: cornerRadiusLayer,
+    },
+    "shape.layer",
+);
 
 /**
  * Style module for the density and spacing of a control.
  *
  * By default, sets the padding and gap, useful for buttons, list items, etc.
  *
- * See {@link autofillDensityStyles} or {@link itemContainerDensityStyles}.
+ * See {@link autofillOuterDensityStyles} or {@link itemContainerDensityStyles}.
  *
  * @public
  */
-export const controlDensityStyles: Styles = Styles.fromProperties({
-    padding: css.partial`${densityControl.verticalPadding} ${densityControl.horizontalPadding}`,
-    gap: densityControl.horizontalGap,
-});
+export const controlDensityStyles: Styles = Styles.fromProperties(
+    {
+        padding: css.partial`${densityControl.verticalPadding} ${densityControl.horizontalPadding}`,
+        gap: densityControl.horizontalGap,
+    },
+    "density.control",
+);
 
 /**
  * Style module pair (outer portion) for input controls that support autofill to allow for better handling of platform styling.
@@ -212,10 +221,13 @@ export const controlDensityStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const autofillOuterDensityStyles: Styles = Styles.fromProperties({
-    padding: css.partial`0 ${densityControl.horizontalPadding}`,
-    gap: densityControl.horizontalGap,
-});
+export const autofillOuterDensityStyles: Styles = Styles.fromProperties(
+    {
+        padding: css.partial`0 ${densityControl.horizontalPadding}`,
+        gap: densityControl.horizontalGap,
+    },
+    "density.autofill-outer",
+);
 
 /**
  * Style module pair (inner portion) for input controls that support autofill to allow for better handling of platform styling.
@@ -226,23 +238,29 @@ export const autofillOuterDensityStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const autofillInnerDensityStyles: Styles = Styles.fromProperties({
-    padding: css.partial`${densityControl.verticalPadding} 0`,
-});
+export const autofillInnerDensityStyles: Styles = Styles.fromProperties(
+    {
+        padding: css.partial`${densityControl.verticalPadding} 0`,
+    },
+    "density.autofill-inner",
+);
 
 /**
  * Style module for the density and spacing of an item container.
  *
  * By default, sets the padding and gap, useful for buttons, list items, etc.
  *
- * See {@link controlDensityStyles} or {@link autofillDensityStyles}.
+ * See {@link controlDensityStyles} or {@link autofillOuterDensityStyles}.
  *
  * @public
  */
-export const itemContainerDensityStyles: Styles = Styles.fromProperties({
-    padding: css.partial`${densityItemContainer.verticalPadding} ${densityItemContainer.horizontalPadding}`,
-    gap: densityItemContainer.horizontalGap,
-});
+export const itemContainerDensityStyles: Styles = Styles.fromProperties(
+    {
+        padding: css.partial`${densityItemContainer.verticalPadding} ${densityItemContainer.horizontalPadding}`,
+        gap: densityItemContainer.horizontalGap,
+    },
+    "density.item-container",
+);
 
 /**
  * Convenience style module for an accent-filled stealth control (interactive).
@@ -254,10 +272,13 @@ export const itemContainerDensityStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const accentFillStealthControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(accentFillStealth, accentStrokeReadableRecipe),
-    borderFill: accentStrokeSafety,
-});
+export const accentFillStealthControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForeground(accentFillStealth, accentStrokeReadableRecipe),
+        borderFill: accentStrokeSafety,
+    },
+    "color.accent-fill-stealth-control",
+);
 
 /**
  * Convenience style module for an accent-filled subtle control (interactive).
@@ -269,10 +290,13 @@ export const accentFillStealthControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const accentFillSubtleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(accentFillSubtle, accentStrokeReadableRecipe),
-    borderFill: accentStrokeSubtle,
-});
+export const accentFillSubtleControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForeground(accentFillSubtle, accentStrokeReadableRecipe),
+        borderFill: accentStrokeSubtle,
+    },
+    "color.accent-fill-subtle-control",
+);
 
 /**
  * Convenience style module for an accent-filled discernible control (interactive).
@@ -284,10 +308,13 @@ export const accentFillSubtleControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(accentFillDiscernible, blackOrWhiteDiscernibleRecipe),
-    borderFill: "transparent", // TODO Remove "transparent" borders, this is a hack for the Explorer app.
-});
+export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForegroundBySet(accentFillDiscernible, blackOrWhiteDiscernibleRecipe),
+        borderFill: "transparent", // TODO Remove "transparent" borders, this is a hack for the Explorer app.
+    },
+    "color.accent-fill-discernible-control",
+);
 
 /**
  * Convenience style module for an accent-filled readable control (interactive).
@@ -299,10 +326,13 @@ export const accentFillDiscernibleControlStyles: Styles = Styles.fromProperties(
  *
  * @public
  */
-export const accentFillReadableControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(accentFillReadable, blackOrWhiteReadableRecipe),
-    borderFill: "transparent",
-});
+export const accentFillReadableControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForegroundBySet(accentFillReadable, blackOrWhiteReadableRecipe),
+        borderFill: "transparent",
+    },
+    "color.accent-fill-readable-control",
+);
 
 /**
  * Convenience style module for an accent-outlined discernible control (interactive).
@@ -314,10 +344,13 @@ export const accentFillReadableControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperties({
-    borderFill: accentStrokeDiscernible,
-    foregroundFill: accentStrokeReadable,
-});
+export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
+    {
+        borderFill: accentStrokeDiscernible,
+        foregroundFill: accentStrokeReadable,
+    },
+    "color.accent-outline-discernible-control",
+);
 
 /**
  * Convenience style module for an accent-colored text or icon control (interactive).
@@ -329,10 +362,13 @@ export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperti
  *
  * @public
  */
-export const accentForegroundReadableControlStyles: Styles = Styles.fromProperties({
-    borderFill: "transparent",
-    foregroundFill: accentStrokeReadable,
-});
+export const accentForegroundReadableControlStyles: Styles = Styles.fromProperties(
+    {
+        borderFill: "transparent",
+        foregroundFill: accentStrokeReadable,
+    },
+    "color.accent-foreground-readable-control",
+);
 
 /**
  * Convenience style module for a neutral-filled stealth control (interactive).
@@ -344,10 +380,13 @@ export const accentForegroundReadableControlStyles: Styles = Styles.fromProperti
  *
  * @public
  */
-export const neutralFillStealthControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillStealth, neutralStrokeStrongRecipe),
-    borderFill: neutralStrokeSafety,
-});
+export const neutralFillStealthControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForeground(neutralFillStealth, neutralStrokeStrongRecipe),
+        borderFill: neutralStrokeSafety,
+    },
+    "color.neutral-fill-stealth-control",
+);
 
 /**
  * Convenience style module for a neutral-filled subtle control (interactive).
@@ -359,10 +398,13 @@ export const neutralFillStealthControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillSubtle, neutralStrokeStrongRecipe),
-    borderFill: neutralStrokeSubtle,
-});
+export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForeground(neutralFillSubtle, neutralStrokeStrongRecipe),
+        borderFill: neutralStrokeSubtle,
+    },
+    "color.neutral-fill-subtle-control",
+);
 
 /**
  * Convenience style module for a neutral-filled discernible control (interactive).
@@ -374,10 +416,13 @@ export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForegroundBySet(neutralFillDiscernible, blackOrWhiteDiscernibleRecipe),
-    borderFill: "transparent",
-});
+export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForegroundBySet(neutralFillDiscernible, blackOrWhiteDiscernibleRecipe),
+        borderFill: "transparent",
+    },
+    "color.neutral-fill-discernible-control",
+);
 
 /**
  * Convenience style module for a neutral-filled readable control (interactive).
@@ -389,10 +434,13 @@ export const neutralFillDiscernibleControlStyles: Styles = Styles.fromProperties
  *
  * @public
  */
-export const neutralFillReadableControlStyles: Styles = Styles.fromProperties({
-    ...backgroundAndForeground(neutralFillReadable, neutralStrokeStrongRecipe),
-    borderFill: "transparent",
-});
+export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
+    {
+        ...backgroundAndForeground(neutralFillReadable, neutralStrokeStrongRecipe),
+        borderFill: "transparent",
+    },
+    "color.neutral-fill-readable-control",
+);
 
 /**
  * Convenience style module for a neutral-outlined discernible control (interactive).
@@ -404,10 +452,13 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties({
-    borderFill: neutralStrokeDiscernible,
-    foregroundFill: neutralStrokeStrongRest,
-});
+export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
+    {
+        borderFill: neutralStrokeDiscernible,
+        foregroundFill: neutralStrokeStrongRest,
+    },
+    "color.neutral-outline-discernible-control",
+);
 
 /**
  * Convenience style module for neutral-colored hint or placeholder text or icons (not interactive).
@@ -419,10 +470,13 @@ export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromPropert
  *
  * @public
  */
-export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties({
-    borderFill: "transparent",
-    foregroundFill: neutralStrokeReadableRest,
-});
+export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties(
+    {
+        borderFill: "transparent",
+        foregroundFill: neutralStrokeReadableRest,
+    },
+    "color.neutral-foreground-readable-control",
+);
 
 /**
  * Convenience style module for neutral-colored regular text or icons (not interactive).
@@ -434,10 +488,13 @@ export const neutralForegroundReadableElementStyles: Styles = Styles.fromPropert
  *
  * @public
  */
-export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties({
-    borderFill: "transparent",
-    foregroundFill: neutralStrokeStrongRest,
-});
+export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties(
+    {
+        borderFill: "transparent",
+        foregroundFill: neutralStrokeStrongRest,
+    },
+    "color.neutral-foreground-strong-element",
+);
 
 /**
  * Convenience style module for neutral-colored divider for presentation role.
@@ -449,9 +506,12 @@ export const neutralForegroundStrongElementStyles: Styles = Styles.fromPropertie
  *
  * @public
  */
-export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties({
-    foregroundFill: neutralStrokeSubtleRest,
-});
+export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
+    {
+        foregroundFill: neutralStrokeSubtleRest,
+    },
+    "color.neutral-divider-subtle-element",
+);
 
 /**
  * Convenience style module for neutral-colored divider for separator role.
@@ -463,197 +523,259 @@ export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties({
  *
  * @public
  */
-export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromProperties({
-    foregroundFill: neutralStrokeDiscernibleRest,
-});
+export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromProperties(
+    {
+        foregroundFill: neutralStrokeDiscernibleRest,
+    },
+    "color.neutral-divider-discernible-element",
+);
 
 /**
  * Convenience style module combining all font values for the `base` type ramp.
  *
  * @public
  */
-export const typeRampBaseStyles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampBaseFontSize,
-    lineHeight: typeRampBaseLineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampBaseFontVariations,
-});
+export const typeRampBaseStyles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampBaseFontSize,
+        lineHeight: typeRampBaseLineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampBaseFontVariations,
+    },
+    "font.type-ramp-base",
+);
 
 /**
  * Convenience style module combining all font values for the `minus 1` type ramp.
  *
  * @public
  */
-export const typeRampMinus1Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampMinus1FontSize,
-    lineHeight: typeRampMinus1LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampMinus1FontVariations,
-});
+export const typeRampMinus1Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampMinus1FontSize,
+        lineHeight: typeRampMinus1LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampMinus1FontVariations,
+    },
+    "font.type-ramp-minus-1",
+);
 
 /**
  * Convenience style module combining all font values for the `minus 2` type ramp.
  *
  * @public
  */
-export const typeRampMinus2Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampMinus2FontSize,
-    lineHeight: typeRampMinus2LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampMinus2FontVariations,
-});
+export const typeRampMinus2Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampMinus2FontSize,
+        lineHeight: typeRampMinus2LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampMinus2FontVariations,
+    },
+    "font.type-ramp-minus-2",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 1` type ramp.
  *
  * @public
  */
-export const typeRampPlus1Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus1FontSize,
-    lineHeight: typeRampPlus1LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus1FontVariations,
-});
+export const typeRampPlus1Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus1FontSize,
+        lineHeight: typeRampPlus1LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus1FontVariations,
+    },
+    "font.type-ramp-plus-1",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 2` type ramp.
  *
  * @public
  */
-export const typeRampPlus2Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus2FontSize,
-    lineHeight: typeRampPlus2LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus2FontVariations,
-});
+export const typeRampPlus2Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus2FontSize,
+        lineHeight: typeRampPlus2LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus2FontVariations,
+    },
+    "font.type-ramp-plus-2",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 3` type ramp.
  *
  * @public
  */
-export const typeRampPlus3Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus3FontSize,
-    lineHeight: typeRampPlus3LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus3FontVariations,
-});
+export const typeRampPlus3Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus3FontSize,
+        lineHeight: typeRampPlus3LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus3FontVariations,
+    },
+    "font.type-ramp-plus-3",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 4` type ramp.
  *
  * @public
  */
-export const typeRampPlus4Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus4FontSize,
-    lineHeight: typeRampPlus4LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus4FontVariations,
-});
+export const typeRampPlus4Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus4FontSize,
+        lineHeight: typeRampPlus4LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus4FontVariations,
+    },
+    "font.type-ramp-plus-4",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 5` type ramp.
  *
  * @public
  */
-export const typeRampPlus5Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus5FontSize,
-    lineHeight: typeRampPlus5LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus5FontVariations,
-});
+export const typeRampPlus5Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus5FontSize,
+        lineHeight: typeRampPlus5LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus5FontVariations,
+    },
+    "font.type-ramp-plus-5",
+);
 
 /**
  * Convenience style module combining all font values for the `plus 6` type ramp.
  *
  * @public
  */
-export const typeRampPlus6Styles: Styles = Styles.fromProperties({
-    fontFamily: fontFamily,
-    fontSize: typeRampPlus6FontSize,
-    lineHeight: typeRampPlus6LineHeight,
-    fontWeight: fontWeight,
-    fontVariationSettings: typeRampPlus6FontVariations,
-});
+export const typeRampPlus6Styles: Styles = Styles.fromProperties(
+    {
+        fontFamily: fontFamily,
+        fontSize: typeRampPlus6FontSize,
+        lineHeight: typeRampPlus6LineHeight,
+        fontWeight: fontWeight,
+        fontVariationSettings: typeRampPlus6FontVariations,
+    },
+    "font.type-ramp-plus-6",
+);
 
 /**
  * @public
  */
 export const actionStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    controlDensityStyles,
-    typeRampBaseStyles,
-    neutralFillSubtleControlStyles
+    [
+        controlShapeStyles,
+        controlDensityStyles,
+        typeRampBaseStyles,
+        neutralFillSubtleControlStyles
+    ],
+    undefined,
+    "styles.action-control",
 );
 
 /**
  * @public
  */
 export const inputStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    controlDensityStyles,
-    typeRampBaseStyles,
-    neutralOutlineDiscernibleControlStyles
+    [
+        controlShapeStyles,
+        controlDensityStyles,
+        typeRampBaseStyles,
+        neutralOutlineDiscernibleControlStyles
+    ],
+    undefined,
+    "styles.input-control",
 );
 
 /**
  * @public
  */
 export const inputAutofillStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    autofillOuterDensityStyles,
-    typeRampBaseStyles,
-    neutralOutlineDiscernibleControlStyles
+    [
+        controlShapeStyles,
+        autofillOuterDensityStyles,
+        typeRampBaseStyles,
+        neutralOutlineDiscernibleControlStyles
+    ],
+    undefined,
+    "styles.input-autofill-control",
 );
 
 /**
  * @public
  */
 export const selectableSelectedStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    typeRampBaseStyles,
-    accentFillReadableControlStyles
+    [
+        controlShapeStyles,
+        typeRampBaseStyles,
+        accentFillReadableControlStyles
+    ],
+    undefined,
+    "styles.selectable-control-selected",
 );
 
 /**
  * @public
  */
 export const selectableUnselectedStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    typeRampBaseStyles,
-    neutralOutlineDiscernibleControlStyles
+    [
+        controlShapeStyles,
+        typeRampBaseStyles,
+        neutralOutlineDiscernibleControlStyles
+    ],
+    undefined,
+    "styles.selectable-control-unselected",
 );
 
 /**
  * @public
  */
 export const itemStyles: Styles = Styles.compose(
-    controlShapeStyles,
-    controlDensityStyles,
-    typeRampBaseStyles,
-    neutralFillStealthControlStyles
+    [
+        controlShapeStyles,
+        controlDensityStyles,
+        typeRampBaseStyles,
+        neutralFillStealthControlStyles
+    ],
+    undefined,
+    "styles.item-control",
 );
 
 /**
  * @public
  */
 export const plainTextStyles: Styles = Styles.compose(
-    typeRampBaseStyles,
-    neutralForegroundStrongElementStyles
+    [
+        typeRampBaseStyles,
+        neutralForegroundStrongElementStyles
+    ],
+    undefined,
+    "styles.text-plain",
 );
 
 /**
  * @public
  */
 export const labelTextStyles: Styles = Styles.compose(
-    typeRampBaseStyles,
-    neutralForegroundStrongElementStyles
+    [
+        typeRampBaseStyles,
+        neutralForegroundStrongElementStyles
+    ],
+    undefined,
+    "styles.text-label",
 );

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -44,7 +44,7 @@ function propertyInteractive<T = string>(
 }
 
 function createElementStyleModules(styles: Styles): StyleModuleEvaluate[] {
-    const modules: StyleModuleEvaluate[] = Object.entries(styles.effectiveProperties).map(([key, value]) => {
+    const modules: StyleModuleEvaluate[] = new Array(...styles.effectiveProperties.entries()).map(([key, value]) => {
         const property = stylePropertyToCssProperty(key as StyleProperty);
         if (typeof value === "string" || value instanceof CSSDesignToken) {
             return propertySingle(property, value);

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -23,12 +23,22 @@ export class Styles {
     // Effective properties from composed styles and additional properties
     private _composedProperties?: StyleProperties;
 
-    private constructor(propertiesOrStyles: StyleProperties | Styles[]) {
+    private constructor(
+        /**
+         * The style module name.
+         */
+        public readonly name: string | undefined,
+        propertiesOrStyles: StyleProperties | Styles[]
+    ) {
         if (Array.isArray(propertiesOrStyles)) {
             this._composed = propertiesOrStyles;
             this.createEffectiveProperties();
         } else {
             this._properties = propertiesOrStyles;
+        }
+
+        if (name) {
+            Styles.Shared.set(name, this);
         }
     }
 
@@ -89,14 +99,19 @@ export class Styles {
         }
     }
 
+    public static Shared: Map<string, Styles> = new Map();
+
     /**
      * Creates a new Styles object for the composed styles.
      *
      * @param styles - An array of styles to compose.
      * @returns A new Styles object representing the composed styles.
      */
-    public static compose(...styles: Styles[]): Styles {
-        return new Styles(styles);
+    public static compose(styles: Styles[], properties?: StyleProperties, name?: string): Styles {
+        if (properties) {
+            styles.push(Styles.fromProperties(properties));
+        }
+        return new Styles(name, styles);
     }
 
     /**
@@ -105,7 +120,7 @@ export class Styles {
      * @param properties - Individual properties for the new style module.
      * @returns A new Styles object representing the properties.
      */
-    public static fromProperties(properties: StyleProperties): Styles {
-        return new Styles(properties);
+    public static fromProperties(properties: StyleProperties, name?: string): Styles {
+        return new Styles(name, properties);
     }
 }

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
@@ -25,8 +25,10 @@ export const styleModules: StyleModules = [
             part: AccordionItemAnatomy.parts.heading,
         },
         Styles.compose(
-            controlShapeStyles,
-            controlDensityStyles,
+            [
+                controlShapeStyles,
+                controlDensityStyles,
+            ],
         )
     ],
     [

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
@@ -23,8 +23,10 @@ export const styleModules: StyleModules = [
             part: BadgeAnatomy.parts.control,
         },
         Styles.compose(
-            controlShapeStyles,
-            neutralFillReadableControlStyles,
+            [
+                controlShapeStyles,
+                neutralFillReadableControlStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -25,9 +25,11 @@ export const styleModules: StyleModules = [
             part: BreadcrumbItemAnatomy.parts.control,
         },
         Styles.compose(
-            controlShapeStyles,
-            controlDensityStyles,
-            accentForegroundReadableControlStyles
+            [
+                controlShapeStyles,
+                controlDensityStyles,
+                accentForegroundReadableControlStyles,
+            ],
         )
     ],
     [

--- a/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
@@ -15,8 +15,10 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            layerShapeStyles,
-            plainTextStyles,
+            [
+                layerShapeStyles,
+                plainTextStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
@@ -24,8 +24,10 @@ export const styleModules: StyleModules = [
             part: ComboboxAnatomy.parts.listbox
         },
         Styles.compose(
-            layerShapeStyles,
-            itemContainerDensityStyles,
+            [
+                layerShapeStyles,
+                itemContainerDensityStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -16,9 +16,11 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            controlShapeStyles,
-            controlDensityStyles,
-            plainTextStyles,
+            [
+                controlShapeStyles,
+                controlDensityStyles,
+                plainTextStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
@@ -24,9 +24,11 @@ export const styleModules: StyleModules = [
             part: DisclosureAnatomy.parts.invoker
         },
         Styles.compose(
-            controlShapeStyles,
-            controlDensityStyles,
-            accentFillReadableControlStyles,
+            [
+                controlShapeStyles,
+                controlDensityStyles,
+                accentFillReadableControlStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -16,11 +16,13 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            controlShapeStyles,
-            itemContainerDensityStyles,
-            Styles.fromProperties({
-                borderFill: neutralStrokeSubtleRest
-            }),
+            [
+                controlShapeStyles,
+                itemContainerDensityStyles,
+            ],
+            {
+                borderFill: neutralStrokeSubtleRest,
+            },
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
@@ -15,8 +15,10 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            layerShapeStyles
-            ,itemContainerDensityStyles,
+            [
+                layerShapeStyles,
+                itemContainerDensityStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
@@ -15,8 +15,10 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            layerShapeStyles,
-            itemContainerDensityStyles,
+            [
+                layerShapeStyles,
+                itemContainerDensityStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
@@ -8,9 +8,11 @@ import {
 import { PickerAnatomy } from "./picker.template.js";
 
 const menuStyles = Styles.compose(
-    plainTextStyles,
-    layerShapeStyles,
-    itemContainerDensityStyles,
+    [
+        plainTextStyles,
+        layerShapeStyles,
+        itemContainerDensityStyles,
+    ],
 );
 
 /**

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -37,8 +37,10 @@ export const styleModules: StyleModules = [
             part: SearchAnatomy.parts.clearButton
         },
         Styles.compose(
-            controlShapeStyles,
-            neutralFillStealthControlStyles,
+            [
+                controlShapeStyles,
+                neutralFillStealthControlStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
@@ -24,8 +24,10 @@ export const styleModules: StyleModules = [
             part: SelectAnatomy.parts.listbox
         },
         Styles.compose(
-            layerShapeStyles,
-            itemContainerDensityStyles,
+            [
+                layerShapeStyles,
+                itemContainerDensityStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
@@ -15,8 +15,10 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            plainTextStyles,
-            controlDensityStyles
+            [
+                plainTextStyles,
+                controlDensityStyles,
+            ],
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -16,11 +16,13 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.compose(
-            controlShapeStyles,
-            plainTextStyles,
-            Styles.fromProperties({
-                borderFill: neutralStrokeSubtleRest
-            }),
+            [
+                controlShapeStyles,
+                plainTextStyles,
+            ],
+            {
+                borderFill: neutralStrokeSubtleRest,
+            },
         )
     ],
 ];


### PR DESCRIPTION
# Pull Request

## Description

Adds support for applying and evaluating style modules in the Figma Designer plugin.

### Issues

Closes #77 

## Reviewer Notes

I split the change into two commits. The first updates the style modules API to support naming. The second updates the plugin portion.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Basic style modules work, but I need to do some cleanup on some of the base style definitions and some UI enhancements.