### PR TITLE
Update compound properties (padding, border, etc.)

### DIFF
--- a/change/@adaptive-web-adaptive-ui-9cf489bb-f08c-4dbd-ab63-c0fc340423d2.json
+++ b/change/@adaptive-web-adaptive-ui-9cf489bb-f08c-4dbd-ab63-c0fc340423d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update compound properties (padding, border, etc.)",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-9feaf463-744b-48f4-ac29-48a76f7c3144.json
+++ b/change/@adaptive-web-adaptive-web-components-9feaf463-744b-48f4-ac29-48a76f7c3144.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update compound properties (padding, border, etc.)",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -2,6 +2,7 @@ import {
     accentFillReadableControlStyles,
     accentStrokeReadable,
     accentStrokeReadableRecipe,
+    BorderFill,
     createForegroundSet,
     neutralFillSubtle,
     Styles,
@@ -36,7 +37,7 @@ AdaptiveDesignSystem.defineComponents({
 // Define a custom style module.
 const accentOutlineReadableControlStyles: Styles = Styles.fromProperties({
     backgroundFill: neutralFillSubtle,
-    borderFill: accentStrokeReadable,
+    ...BorderFill.all(accentStrokeReadable),
     foregroundFill: createForegroundSet(accentStrokeReadableRecipe, "rest", neutralFillSubtle),
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2516,6 +2516,58 @@
                 "node": ">=0.1.90"
             }
         },
+        "node_modules/@csstools/css-calc": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.1.1.tgz",
+            "integrity": "sha512-Nh+iLCtjlooTzuR0lpmB8I6hPX/VupcGQ3Z1U2+wgJJ4fa8+cWkub+lCsbZcYPzBGsZLEL8fQAg+Na5dwEFJxg==",
+            "dev": true,
+            "engines": {
+                "node": "^14 || ^16 || >=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^2.1.1",
+                "@csstools/css-tokenizer": "^2.1.1"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
+            "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "engines": {
+                "node": "^14 || ^16 || >=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^2.1.1"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
+            "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==",
+            "dev": true,
+            "engines": {
+                "node": "^14 || ^16 || >=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            }
+        },
         "node_modules/@custom-elements-manifest/analyzer": {
             "version": "0.6.8",
             "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.6.8.tgz",
@@ -31077,6 +31129,9 @@
                 "@microsoft/fast-colors": "^5.3.1"
             },
             "devDependencies": {
+                "@csstools/css-calc": "^1.1.1",
+                "@csstools/css-parser-algorithms": "^2.2.0",
+                "@csstools/css-tokenizer": "^2.1.1",
                 "@figma/plugin-typings": "^1.58.0",
                 "concurrently": "^7.6.0",
                 "esbuild": "^0.17.10",
@@ -31683,6 +31738,9 @@
             "version": "file:packages/adaptive-ui-figma-designer",
             "requires": {
                 "@adaptive-web/adaptive-web-components": "0.2.0",
+                "@csstools/css-calc": "^1.1.1",
+                "@csstools/css-parser-algorithms": "^2.2.0",
+                "@csstools/css-tokenizer": "^2.1.1",
                 "@figma/plugin-typings": "^1.58.0",
                 "@microsoft/fast-colors": "^5.3.1",
                 "concurrently": "^7.6.0",
@@ -33695,6 +33753,26 @@
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
             "optional": true
+        },
+        "@csstools/css-calc": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.1.1.tgz",
+            "integrity": "sha512-Nh+iLCtjlooTzuR0lpmB8I6hPX/VupcGQ3Z1U2+wgJJ4fa8+cWkub+lCsbZcYPzBGsZLEL8fQAg+Na5dwEFJxg==",
+            "dev": true,
+            "requires": {}
+        },
+        "@csstools/css-parser-algorithms": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz",
+            "integrity": "sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==",
+            "dev": true,
+            "requires": {}
+        },
+        "@csstools/css-tokenizer": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz",
+            "integrity": "sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==",
+            "dev": true
         },
         "@custom-elements-manifest/analyzer": {
             "version": "0.6.8",

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -145,7 +145,7 @@ export class StyleExample extends FASTElement {
             }
         }
 
-        const borderValue = this.styles?.effectiveProperties?.get(StyleProperty.borderFill);
+        const borderValue = this.styles?.effectiveProperties?.get(StyleProperty.borderFillTop);
         if (borderValue) {
             if (typeof borderValue === "string") {
                 // ignore for now

--- a/packages/adaptive-ui-figma-designer/package.json
+++ b/packages/adaptive-ui-figma-designer/package.json
@@ -43,6 +43,9 @@
         "@microsoft/fast-foundation": "3.0.0-alpha.27"
     },
     "devDependencies": {
+        "@csstools/css-calc": "^1.1.1",
+        "@csstools/css-parser-algorithms": "^2.2.0",
+        "@csstools/css-tokenizer": "^2.1.1",
         "@figma/plugin-typings": "^1.58.0",
         "concurrently": "^7.6.0",
         "esbuild": "^0.17.10",

--- a/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
@@ -12,6 +12,7 @@ import {
     Palette,
     PaletteRGB,
     StyleProperty,
+    stylePropertyBorderFillAll,
     Swatch,
 } from "@adaptive-web/adaptive-ui";
 import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
@@ -34,7 +35,7 @@ export const docForegroundRecipe = DesignToken.create<ColorRecipe>("doc-foregrou
         ),
 });
 
-export const docForeground = createTokenSwatch("doc-foreground", [StyleProperty.borderFill, StyleProperty.foregroundFill]).withDefault(
+export const docForeground = createTokenSwatch("doc-foreground", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]).withDefault(
     (resolve: DesignTokenResolver) => resolve(docForegroundRecipe).evaluate(resolve)
 );
 

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -281,15 +281,27 @@ export class FigmaPluginNode extends PluginNode {
                         isContainerNode,
                         isShapeNode,
                     ].some((test: (node: BaseNode) => boolean) => test(this._node));
-                case StyleProperty.borderFill:
-                case StyleProperty.borderStyle:
-                case StyleProperty.borderThickness:
+                case StyleProperty.borderFillTop:
+                case StyleProperty.borderFillRight:
+                case StyleProperty.borderFillBottom:
+                case StyleProperty.borderFillLeft:
+                case StyleProperty.borderStyleTop:
+                case StyleProperty.borderStyleRight:
+                case StyleProperty.borderStyleBottom:
+                case StyleProperty.borderStyleLeft:
+                case StyleProperty.borderThicknessTop:
+                case StyleProperty.borderThicknessRight:
+                case StyleProperty.borderThicknessBottom:
+                case StyleProperty.borderThicknessLeft:
                     return [
                         isContainerNode,
                         isShapeNode,
                         isLineNode,
                     ].some((test: (node: BaseNode) => boolean) => test(this._node));
-                case StyleProperty.cornerRadius:
+                case StyleProperty.cornerRadiusTopLeft:
+                case StyleProperty.cornerRadiusTopRight:
+                case StyleProperty.cornerRadiusBottomRight:
+                case StyleProperty.cornerRadiusBottomLeft:
                     return [
                         isContainerNode,
                         isShapeNode,
@@ -330,18 +342,30 @@ export class FigmaPluginNode extends PluginNode {
             });
         } else {
             switch (target) {
-                case StyleProperty.borderFill:
+                case StyleProperty.borderFillTop:
+                case StyleProperty.borderFillRight:
+                case StyleProperty.borderFillBottom:
+                case StyleProperty.borderFillLeft:
                 case StyleProperty.backgroundFill:
                 case StyleProperty.foregroundFill:
                     this.paintColor(target, data);
                     break;
-                case StyleProperty.borderStyle:
+                case StyleProperty.borderStyleTop:
+                case StyleProperty.borderStyleRight:
+                case StyleProperty.borderStyleBottom:
+                case StyleProperty.borderStyleLeft:
                     // Ignore for now, "solid" only
                     break;
-                case StyleProperty.borderThickness:
+                case StyleProperty.borderThicknessTop:
+                case StyleProperty.borderThicknessRight:
+                case StyleProperty.borderThicknessBottom:
+                case StyleProperty.borderThicknessLeft:
                     this.paintStrokeWidth(data);
                     break;
-                case StyleProperty.cornerRadius:
+                case StyleProperty.cornerRadiusTopLeft:
+                case StyleProperty.cornerRadiusTopRight:
+                case StyleProperty.cornerRadiusBottomRight:
+                case StyleProperty.cornerRadiusBottomLeft:
                     this.paintCornerRadius(data);
                     break;
                 case StyleProperty.fontFamily:
@@ -368,6 +392,9 @@ export class FigmaPluginNode extends PluginNode {
                 case StyleProperty.fontWeight:
                     // Ignore, but don't throw an error.
                     break;
+                case StyleProperty.fontVariationSettings:
+                    // Ignore, but don't throw an error.
+                    break;
                 case StyleProperty.lineHeight:
                     if (isTextNode(this._node)) {
                         const textNode = this._node as TextNode;
@@ -378,6 +405,21 @@ export class FigmaPluginNode extends PluginNode {
                             };
                         });
                     }
+                    break;
+                case StyleProperty.paddingTop:
+                    (this._node as BaseFrameMixin).paddingTop = Number.parseFloat(data.value); // Removes unit, so assumes px
+                    break;
+                case StyleProperty.paddingRight:
+                    (this._node as BaseFrameMixin).paddingRight = Number.parseFloat(data.value); // Removes unit, so assumes px
+                    break;
+                case StyleProperty.paddingBottom:
+                    (this._node as BaseFrameMixin).paddingBottom = Number.parseFloat(data.value); // Removes unit, so assumes px
+                    break;
+                case StyleProperty.paddingLeft:
+                    (this._node as BaseFrameMixin).paddingLeft = Number.parseFloat(data.value); // Removes unit, so assumes px
+                    break;
+                case StyleProperty.gap:
+                    (this._node as BaseFrameMixin).itemSpacing = Number.parseFloat(data.value); // Removes unit, so assumes px
                     break;
                 default:
                     throw new Error(`Applied design token could not be painted for ${target}: ${JSON.stringify(data)}`);
@@ -562,7 +604,8 @@ export class FigmaPluginNode extends PluginNode {
                 case StyleProperty.foregroundFill:
                     (this._node as MinimalFillsMixin).fills = [paint];
                     break;
-                case StyleProperty.borderFill:
+                case StyleProperty.borderFillTop:
+                    // TODO: Figma only supports on border color, though it can be hacked using inner shadow.
                     (this._node as MinimalStrokesMixin).strokes = [paint];
                     break;
             }

--- a/packages/adaptive-ui-figma-designer/src/ui/app.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/app.ts
@@ -188,7 +188,7 @@ const template = html<App>`
                                 ${(x) => availableTokensTemplate(StyleProperty.backgroundFill, "Fill")}
                                 ${(x) =>
                                     availableTokensTemplate(
-                                        StyleProperty.borderFill,
+                                        StyleProperty.borderFillTop,
                                         "Stroke",
                                         "stack",
                                         TokenGlyphType.borderSwatch
@@ -208,7 +208,7 @@ const template = html<App>`
                             <div>
                                 ${(x) =>
                                     availableTokensTemplate(
-                                        StyleProperty.borderThickness,
+                                        StyleProperty.borderThicknessTop,
                                         null,
                                         "stack",
                                         TokenGlyphType.icon
@@ -227,7 +227,7 @@ const template = html<App>`
                             <div>
                                 ${(x) =>
                                     availableTokensTemplate(
-                                        StyleProperty.cornerRadius,
+                                        StyleProperty.cornerRadiusTopLeft,
                                         null,
                                         "stack",
                                         TokenGlyphType.icon
@@ -484,17 +484,17 @@ export class App extends FASTElement {
                 (node) =>
                     node.supports.includes(StyleProperty.backgroundFill) ||
                     node.supports.includes(StyleProperty.foregroundFill) ||
-                    node.supports.includes(StyleProperty.borderFill)
+                    node.supports.includes(StyleProperty.borderFillTop)
             ) || false;
-        this.supportsStrokeWidth = this.controller.supports(StyleProperty.borderThickness);
-        this.supportsCornerRadius = this.controller.supports(StyleProperty.cornerRadius);
+        this.supportsStrokeWidth = this.controller.supports(StyleProperty.borderThicknessTop);
+        this.supportsCornerRadius = this.controller.supports(StyleProperty.cornerRadiusTopLeft);
         this.supportsText = this.controller.supports(StyleProperty.fontFamily);
 
         this.backgroundTokens = this.controller.appliedDesignTokens(StyleProperty.backgroundFill);
         this.foregroundTokens = this.controller.appliedDesignTokens(StyleProperty.foregroundFill);
-        this.strokeTokens = this.controller.appliedDesignTokens(StyleProperty.borderFill);
-        this.strokeWidthTokens = this.controller.appliedDesignTokens(StyleProperty.borderThickness);
-        this.cornerRadiusTokens = this.controller.appliedDesignTokens(StyleProperty.cornerRadius);
+        this.strokeTokens = this.controller.appliedDesignTokens(StyleProperty.borderFillTop);
+        this.strokeWidthTokens = this.controller.appliedDesignTokens(StyleProperty.borderThicknessTop);
+        this.cornerRadiusTokens = this.controller.appliedDesignTokens(StyleProperty.cornerRadiusTopLeft);
         this.textTokens = [
             ...this.controller.appliedDesignTokens(StyleProperty.fontFamily),
             ...this.controller.appliedDesignTokens(StyleProperty.fontSize),

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -348,6 +348,21 @@ export const bodyFont: TypedCSSDesignToken_2<string>;
 // @public (undocumented)
 export const bodyFontFamily: TypedCSSDesignToken_2<string>;
 
+// @public (undocumented)
+export const BorderFill: {
+    all: (value: StyleValue) => StyleProperties;
+};
+
+// @public (undocumented)
+export const BorderStyle: {
+    all: (value: StyleValue) => StyleProperties;
+};
+
+// @public (undocumented)
+export const BorderThickness: {
+    all: (value: StyleValue) => StyleProperties;
+};
+
 // @public
 export interface ColorRecipe<T = Swatch> {
     evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
@@ -400,6 +415,11 @@ export const controlDensityStyles: Styles;
 
 // @public
 export const controlShapeStyles: Styles;
+
+// @public (undocumented)
+export const CornerRadius: {
+    all: (value: StyleValue) => StyleProperties;
+};
 
 // @public (undocumented)
 export const cornerRadiusControl: TypedCSSDesignToken_2<string>;
@@ -1358,6 +1378,12 @@ export const neutralStrokeSubtleRest: TypedCSSDesignToken<Swatch>;
 // @public @deprecated (undocumented)
 export const neutralStrokeSubtleRestDelta: DesignToken<number>;
 
+// @public (undocumented)
+export const Padding: {
+    all: (value: StyleValue) => StyleProperties;
+    verticalHorizontal: (valueVertical: StyleValue, valueHorizontal: StyleValue) => StyleProperties;
+};
+
 // @public
 export interface Palette<T extends Swatch = Swatch> {
     closestIndexOf(reference: RelativeLuminance): number;
@@ -1523,19 +1549,31 @@ export interface StyleModuleTarget {
 }
 
 // @public
-export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>>;
+export type StyleProperties = Partial<Record<StyleProperty, StyleValue>>;
 
 // @public
-export type StylePropertiesMap = Map<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>;
+export type StylePropertiesMap = Map<StyleProperty, StyleValue>;
 
 // @public
 export const StyleProperty: {
     readonly backgroundFill: "backgroundFill";
     readonly foregroundFill: "foregroundFill";
-    readonly borderFill: "borderFill";
-    readonly borderThickness: "borderThickness";
-    readonly borderStyle: "borderStyle";
-    readonly cornerRadius: "cornerRadius";
+    readonly borderFillTop: "borderFillTop";
+    readonly borderFillRight: "borderFillRight";
+    readonly borderFillBottom: "borderFillBottom";
+    readonly borderFillLeft: "borderFillLeft";
+    readonly borderThicknessTop: "borderThicknessTop";
+    readonly borderThicknessRight: "borderThicknessRight";
+    readonly borderThicknessBottom: "borderThicknessBottom";
+    readonly borderThicknessLeft: "borderThicknessLeft";
+    readonly borderStyleTop: "borderStyleTop";
+    readonly borderStyleRight: "borderStyleRight";
+    readonly borderStyleBottom: "borderStyleBottom";
+    readonly borderStyleLeft: "borderStyleLeft";
+    readonly cornerRadiusTopLeft: "cornerRadiusTopLeft";
+    readonly cornerRadiusTopRight: "cornerRadiusTopRight";
+    readonly cornerRadiusBottomRight: "cornerRadiusBottomRight";
+    readonly cornerRadiusBottomLeft: "cornerRadiusBottomLeft";
     readonly fontFamily: "fontFamily";
     readonly fontSize: "fontSize";
     readonly fontWeight: "fontWeight";
@@ -1543,7 +1581,10 @@ export const StyleProperty: {
     readonly fontVariationSettings: "fontVariationSettings";
     readonly letterSpacing: "letterSpacing";
     readonly lineHeight: "lineHeight";
-    readonly padding: "padding";
+    readonly paddingTop: "paddingTop";
+    readonly paddingRight: "paddingRight";
+    readonly paddingBottom: "paddingBottom";
+    readonly paddingLeft: "paddingLeft";
     readonly gap: "gap";
     readonly height: "height";
     readonly width: "width";
@@ -1553,6 +1594,21 @@ export const StyleProperty: {
 
 // @public
 export type StyleProperty = ValuesOf<typeof StyleProperty>;
+
+// @public (undocumented)
+export const stylePropertyBorderFillAll: ("borderFillTop" | "borderFillRight" | "borderFillBottom" | "borderFillLeft")[];
+
+// @public (undocumented)
+export const stylePropertyBorderStyleAll: ("borderStyleTop" | "borderStyleRight" | "borderStyleBottom" | "borderStyleLeft")[];
+
+// @public (undocumented)
+export const stylePropertyBorderThicknessAll: ("borderThicknessTop" | "borderThicknessRight" | "borderThicknessBottom" | "borderThicknessLeft")[];
+
+// @public (undocumented)
+export const stylePropertyCornerRadiusAll: ("cornerRadiusTopLeft" | "cornerRadiusTopRight" | "cornerRadiusBottomRight" | "cornerRadiusBottomLeft")[];
+
+// @public (undocumented)
+export const stylePropertyPaddingAll: ("paddingBottom" | "paddingLeft" | "paddingRight" | "paddingTop")[];
 
 // @public
 export class Styles {
@@ -1569,6 +1625,9 @@ export class Styles {
     // (undocumented)
     static Shared: Map<string, Styles>;
 }
+
+// @public
+export type StyleValue = CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string;
 
 // @public
 export interface Swatch extends RelativeLuminance {

--- a/packages/adaptive-ui/src/design-tokens/appearance.ts
+++ b/packages/adaptive-ui/src/design-tokens/appearance.ts
@@ -1,4 +1,4 @@
-import { StyleProperty } from "../modules/types.js";
+import { stylePropertyBorderThicknessAll, stylePropertyCornerRadiusAll } from "../modules/types.js";
 import { create, createTokenDimension, createTokenNumber } from "./create.js";
 
 /** @public @deprecated This is changing to a `dimension` type like `4px`, which breaks non-modular styling. See designUnitDimension */
@@ -11,22 +11,22 @@ export const designUnitDimension = createTokenDimension("design-unit-dimension")
 export const controlCornerRadius = create<number>("control-corner-radius").withDefault(4);
 
 /** @public */
-export const cornerRadiusControl = createTokenDimension("corner-radius-control", StyleProperty.cornerRadius).withDefault("4px");
+export const cornerRadiusControl = createTokenDimension("corner-radius-control", stylePropertyCornerRadiusAll).withDefault("4px");
 
 /** @public @deprecated Use `cornerRadiusLayer` instead */
 export const layerCornerRadius = create<number>("layer-corner-radius").withDefault(8);
 
 /** @public */
-export const cornerRadiusLayer = createTokenDimension("corner-radius-layer", StyleProperty.cornerRadius).withDefault("8px");
+export const cornerRadiusLayer = createTokenDimension("corner-radius-layer", stylePropertyCornerRadiusAll).withDefault("8px");
 
 /** @public @deprecated Use `strokeThickness` instead */
 export const strokeWidth = create<number>("stroke-width").withDefault(1);
 
 /** @public */
-export const strokeThickness = createTokenDimension("stroke-thickness", StyleProperty.borderThickness).withDefault("1px");
+export const strokeThickness = createTokenDimension("stroke-thickness", stylePropertyBorderThicknessAll).withDefault("1px");
 
 /** @public @deprecated Use `focusStrokeThickness` instead */
 export const focusStrokeWidth = create<number>("focus-stroke-width").withDefault(2);
 
 /** @public */
-export const focusStrokeThickness = createTokenDimension("focus-stroke-thickness", StyleProperty.borderThickness).withDefault("2px");
+export const focusStrokeThickness = createTokenDimension("focus-stroke-thickness", stylePropertyBorderThicknessAll).withDefault("2px");

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -9,7 +9,7 @@ import { Swatch } from "../color/swatch.js";
 import { _white } from "../color/utilities/color-constants.js";
 import { conditionalSwatchSet } from "../color/utilities/conditional.js";
 import { interactiveSwatchSetAsOverlay, swatchAsOverlay } from "../color/utilities/opacity.js";
-import { StyleProperty } from "../modules/types.js";
+import { StyleProperty, stylePropertyBorderFillAll } from "../modules/types.js";
 import type { InteractiveTokenGroup } from "../types.js";
 import { TypedCSSDesignToken } from "../adaptive-design-tokens.js";
 import { createNonCss, createTokenSwatch } from "./create.js";
@@ -558,16 +558,16 @@ export const accentStrokeSafetyRecipe = createRecipeInteractive(accentStrokeSafe
 const accentStrokeSafetySet = createSet(accentStrokeSafetyRecipe);
 
 /** @public */
-export const accentStrokeSafetyRest = createStateToken(accentStrokeSafetySet, "rest", StyleProperty.borderFill);
+export const accentStrokeSafetyRest = createStateToken(accentStrokeSafetySet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSafetyHover = createStateToken(accentStrokeSafetySet, "hover", StyleProperty.borderFill);
+export const accentStrokeSafetyHover = createStateToken(accentStrokeSafetySet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSafetyActive = createStateToken(accentStrokeSafetySet, "active", StyleProperty.borderFill);
+export const accentStrokeSafetyActive = createStateToken(accentStrokeSafetySet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSafetyFocus = createStateToken(accentStrokeSafetySet, "focus", StyleProperty.borderFill);
+export const accentStrokeSafetyFocus = createStateToken(accentStrokeSafetySet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const accentStrokeSafety: InteractiveTokenGroup<Swatch> = {
@@ -599,16 +599,16 @@ export const accentStrokeStealthRecipe = createRecipeInteractive(accentStrokeSte
 const accentStrokeStealthSet = createSet(accentStrokeStealthRecipe);
 
 /** @public */
-export const accentStrokeStealthRest = createStateToken(accentStrokeStealthSet, "rest", StyleProperty.borderFill);
+export const accentStrokeStealthRest = createStateToken(accentStrokeStealthSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeStealthHover = createStateToken(accentStrokeStealthSet, "hover", StyleProperty.borderFill);
+export const accentStrokeStealthHover = createStateToken(accentStrokeStealthSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeStealthActive = createStateToken(accentStrokeStealthSet, "active", StyleProperty.borderFill);
+export const accentStrokeStealthActive = createStateToken(accentStrokeStealthSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeStealthFocus = createStateToken(accentStrokeStealthSet, "focus", StyleProperty.borderFill);
+export const accentStrokeStealthFocus = createStateToken(accentStrokeStealthSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const accentStrokeStealth: InteractiveTokenGroup<Swatch> = {
@@ -640,16 +640,16 @@ export const accentStrokeSubtleRecipe = createRecipeInteractive(accentStrokeSubt
 const accentStrokeSubtleSet = createSet(accentStrokeSubtleRecipe);
 
 /** @public */
-export const accentStrokeSubtleRest = createStateToken(accentStrokeSubtleSet, "rest", StyleProperty.borderFill);
+export const accentStrokeSubtleRest = createStateToken(accentStrokeSubtleSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSubtleHover = createStateToken(accentStrokeSubtleSet, "hover", StyleProperty.borderFill);
+export const accentStrokeSubtleHover = createStateToken(accentStrokeSubtleSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSubtleActive = createStateToken(accentStrokeSubtleSet, "active", StyleProperty.borderFill);
+export const accentStrokeSubtleActive = createStateToken(accentStrokeSubtleSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeSubtleFocus = createStateToken(accentStrokeSubtleSet, "focus", StyleProperty.borderFill);
+export const accentStrokeSubtleFocus = createStateToken(accentStrokeSubtleSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const accentStrokeSubtle: InteractiveTokenGroup<Swatch> = {
@@ -681,16 +681,16 @@ export const accentStrokeDiscernibleRecipe = createRecipeInteractive(accentStrok
 const accentStrokeDiscernibleSet = createSet(accentStrokeDiscernibleRecipe);
 
 /** @public */
-export const accentStrokeDiscernibleRest = createStateToken(accentStrokeDiscernibleSet, "rest", StyleProperty.borderFill);
+export const accentStrokeDiscernibleRest = createStateToken(accentStrokeDiscernibleSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeDiscernibleHover = createStateToken(accentStrokeDiscernibleSet, "hover", StyleProperty.borderFill);
+export const accentStrokeDiscernibleHover = createStateToken(accentStrokeDiscernibleSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeDiscernibleActive = createStateToken(accentStrokeDiscernibleSet, "active", StyleProperty.borderFill);
+export const accentStrokeDiscernibleActive = createStateToken(accentStrokeDiscernibleSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const accentStrokeDiscernibleFocus = createStateToken(accentStrokeDiscernibleSet, "focus", StyleProperty.borderFill);
+export const accentStrokeDiscernibleFocus = createStateToken(accentStrokeDiscernibleSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const accentStrokeDiscernible: InteractiveTokenGroup<Swatch> = {
@@ -734,16 +734,16 @@ export const accentStrokeReadableRecipe = createRecipeInteractive(accentStrokeRe
 const accentStrokeReadableSet = createSet(accentStrokeReadableRecipe);
 
 /** @public */
-export const accentStrokeReadableRest = createStateToken(accentStrokeReadableSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeReadableRest = createStateToken(accentStrokeReadableSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeReadableHover = createStateToken(accentStrokeReadableSet, "hover", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeReadableHover = createStateToken(accentStrokeReadableSet, "hover", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeReadableActive = createStateToken(accentStrokeReadableSet, "active", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeReadableActive = createStateToken(accentStrokeReadableSet, "active", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeReadableFocus = createStateToken(accentStrokeReadableSet, "focus", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeReadableFocus = createStateToken(accentStrokeReadableSet, "focus", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
 export const accentStrokeReadable: InteractiveTokenGroup<Swatch> = {
@@ -775,16 +775,16 @@ export const accentStrokeStrongRecipe = createRecipeInteractive(accentStrokeStro
 const accentStrokeStrongSet = createSet(accentStrokeStrongRecipe);
 
 /** @public */
-export const accentStrokeStrongRest = createStateToken(accentStrokeStrongSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeStrongRest = createStateToken(accentStrokeStrongSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeStrongHover = createStateToken(accentStrokeStrongSet, "hover", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeStrongHover = createStateToken(accentStrokeStrongSet, "hover", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeStrongActive = createStateToken(accentStrokeStrongSet, "active", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeStrongActive = createStateToken(accentStrokeStrongSet, "active", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const accentStrokeStrongFocus = createStateToken(accentStrokeStrongSet, "focus", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const accentStrokeStrongFocus = createStateToken(accentStrokeStrongSet, "focus", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
 export const accentStrokeStrong: InteractiveTokenGroup<Swatch> = {
@@ -1033,16 +1033,16 @@ export const neutralStrokeSafetyRecipe = createRecipeInteractive(neutralStrokeSa
 const neutralStrokeSafetySet = createSet(neutralStrokeSafetyRecipe);
 
 /** @public */
-export const neutralStrokeSafetyRest = createStateToken(neutralStrokeSafetySet, "rest", StyleProperty.borderFill);
+export const neutralStrokeSafetyRest = createStateToken(neutralStrokeSafetySet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSafetyHover = createStateToken(neutralStrokeSafetySet, "hover", StyleProperty.borderFill);
+export const neutralStrokeSafetyHover = createStateToken(neutralStrokeSafetySet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSafetyActive = createStateToken(neutralStrokeSafetySet, "active", StyleProperty.borderFill);
+export const neutralStrokeSafetyActive = createStateToken(neutralStrokeSafetySet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSafetyFocus = createStateToken(neutralStrokeSafetySet, "focus", StyleProperty.borderFill);
+export const neutralStrokeSafetyFocus = createStateToken(neutralStrokeSafetySet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const neutralStrokeSafety: InteractiveTokenGroup<Swatch> = {
@@ -1078,16 +1078,16 @@ export const neutralStrokeStealthRecipe = createRecipeInteractive(neutralStrokeS
 const neutralStrokeStealthSet = createSet(neutralStrokeStealthRecipe);
 
 /** @public */
-export const neutralStrokeStealthRest = createStateToken(neutralStrokeStealthSet, "rest", StyleProperty.borderFill);
+export const neutralStrokeStealthRest = createStateToken(neutralStrokeStealthSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeStealthHover = createStateToken(neutralStrokeStealthSet, "hover", StyleProperty.borderFill);
+export const neutralStrokeStealthHover = createStateToken(neutralStrokeStealthSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeStealthActive = createStateToken(neutralStrokeStealthSet, "active", StyleProperty.borderFill);
+export const neutralStrokeStealthActive = createStateToken(neutralStrokeStealthSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeStealthFocus = createStateToken(neutralStrokeStealthSet, "focus", StyleProperty.borderFill);
+export const neutralStrokeStealthFocus = createStateToken(neutralStrokeStealthSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const neutralStrokeStealth: InteractiveTokenGroup<Swatch> = {
@@ -1135,16 +1135,16 @@ export const neutralStrokeSubtleRecipe = createRecipeInteractive(neutralStrokeSu
 const neutralStrokeSubtleSet = createSet(neutralStrokeSubtleRecipe);
 
 /** @public */
-export const neutralStrokeSubtleRest = createStateToken(neutralStrokeSubtleSet, "rest", StyleProperty.borderFill);
+export const neutralStrokeSubtleRest = createStateToken(neutralStrokeSubtleSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSubtleHover = createStateToken(neutralStrokeSubtleSet, "hover", StyleProperty.borderFill);
+export const neutralStrokeSubtleHover = createStateToken(neutralStrokeSubtleSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet, "active", StyleProperty.borderFill);
+export const neutralStrokeSubtleActive = createStateToken(neutralStrokeSubtleSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus", StyleProperty.borderFill);
+export const neutralStrokeSubtleFocus = createStateToken(neutralStrokeSubtleSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const neutralStrokeSubtle: InteractiveTokenGroup<Swatch> = {
@@ -1192,16 +1192,16 @@ export const neutralStrokeDiscernibleRecipe = createRecipeInteractive(neutralStr
 const neutralStrokeDiscernibleSet = createSet(neutralStrokeDiscernibleRecipe);
 
 /** @public */
-export const neutralStrokeDiscernibleRest = createStateToken(neutralStrokeDiscernibleSet, "rest", StyleProperty.borderFill);
+export const neutralStrokeDiscernibleRest = createStateToken(neutralStrokeDiscernibleSet, "rest", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeDiscernibleHover = createStateToken(neutralStrokeDiscernibleSet, "hover", StyleProperty.borderFill);
+export const neutralStrokeDiscernibleHover = createStateToken(neutralStrokeDiscernibleSet, "hover", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeDiscernibleActive = createStateToken(neutralStrokeDiscernibleSet, "active", StyleProperty.borderFill);
+export const neutralStrokeDiscernibleActive = createStateToken(neutralStrokeDiscernibleSet, "active", stylePropertyBorderFillAll);
 
 /** @public */
-export const neutralStrokeDiscernibleFocus = createStateToken(neutralStrokeDiscernibleSet, "focus", StyleProperty.borderFill);
+export const neutralStrokeDiscernibleFocus = createStateToken(neutralStrokeDiscernibleSet, "focus", stylePropertyBorderFillAll);
 
 /** @public */
 export const neutralStrokeDiscernible: InteractiveTokenGroup<Swatch> = {
@@ -1249,16 +1249,16 @@ export const neutralStrokeReadableRecipe = createRecipeInteractive(neutralStroke
 const neutralStrokeReadableSet = createSet(neutralStrokeReadableRecipe);
 
 /** @public */
-export const neutralStrokeReadableRest = createStateToken(neutralStrokeReadableSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeReadableRest = createStateToken(neutralStrokeReadableSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeReadableHover = createStateToken(neutralStrokeReadableSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeReadableHover = createStateToken(neutralStrokeReadableSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeReadableActive = createStateToken(neutralStrokeReadableSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeReadableActive = createStateToken(neutralStrokeReadableSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeReadableFocus = createStateToken(neutralStrokeReadableSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeReadableFocus = createStateToken(neutralStrokeReadableSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
 export const neutralStrokeReadable: InteractiveTokenGroup<Swatch> = {
@@ -1309,16 +1309,16 @@ export const neutralStrokeStrongRecipe = createRecipeInteractive(neutralStrokeSt
 const neutralStrokeStrongSet = createSet(neutralStrokeStrongRecipe);
 
 /** @public */
-export const neutralStrokeStrongRest = createStateToken(neutralStrokeStrongSet, "rest", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeStrongRest = createStateToken(neutralStrokeStrongSet, "rest", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeStrongHover = createStateToken(neutralStrokeStrongSet, "hover", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeStrongHover = createStateToken(neutralStrokeStrongSet, "hover", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeStrongActive = createStateToken(neutralStrokeStrongSet, "active", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeStrongActive = createStateToken(neutralStrokeStrongSet, "active", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
-export const neutralStrokeStrongFocus = createStateToken(neutralStrokeStrongSet, "focus", [StyleProperty.borderFill, StyleProperty.foregroundFill]);
+export const neutralStrokeStrongFocus = createStateToken(neutralStrokeStrongSet, "focus", [...stylePropertyBorderFillAll, StyleProperty.foregroundFill]);
 
 /** @public */
 export const neutralStrokeStrong: InteractiveTokenGroup<Swatch> = {
@@ -1340,7 +1340,7 @@ export const focusStrokeOuterRecipe = createRecipe(focusStrokeOuterName,
 );
 
 /** @public */
-export const focusStrokeOuter = createRecipeToken(focusStrokeOuterRecipe, StyleProperty.borderFill);
+export const focusStrokeOuter = createRecipeToken(focusStrokeOuterRecipe, stylePropertyBorderFillAll);
 
 // Focus Stroke Inner
 
@@ -1353,7 +1353,7 @@ export const focusStrokeInnerRecipe = createRecipe(focusStrokeInnerName,
 );
 
 /** @public */
-export const focusStrokeInner = createRecipeToken(focusStrokeInnerRecipe, StyleProperty.borderFill);
+export const focusStrokeInner = createRecipeToken(focusStrokeInnerRecipe, stylePropertyBorderFillAll);
 
 // Deprecated tokens
 

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,9 +1,8 @@
-import { css } from "@microsoft/fast-element";
 import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet, InteractiveSwatchSet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
 import type { InteractiveSet, InteractiveTokenGroup } from "../types.js";
-import { StyleProperties, Styles } from "../modules/styles.js";
+import { BorderFill, BorderStyle, BorderThickness, CornerRadius, Padding, StyleProperties, Styles } from "../modules/styles.js";
 import { TypedCSSDesignToken } from "../adaptive-design-tokens.js";
 import { cornerRadiusControl, cornerRadiusLayer, strokeThickness } from "./appearance.js";
 import {
@@ -170,10 +169,10 @@ function backgroundAndForegroundBySet(
  */
 export const controlShapeStyles: Styles = Styles.fromProperties(
     {
-        borderThickness: strokeThickness,
-        borderStyle: "solid",
-        borderFill: "transparent",
-        cornerRadius: cornerRadiusControl,
+        ...BorderThickness.all(strokeThickness),
+        ...BorderStyle.all("solid"),
+        ...BorderFill.all("transparent"),
+        ...CornerRadius.all(cornerRadiusControl),
     },
     "shape.control",
 );
@@ -187,10 +186,10 @@ export const controlShapeStyles: Styles = Styles.fromProperties(
  */
 export const layerShapeStyles: Styles = Styles.fromProperties(
     {
-        borderThickness: strokeThickness,
-        borderStyle: "solid",
-        borderFill: "transparent",
-        cornerRadius: cornerRadiusLayer,
+        ...BorderThickness.all(strokeThickness),
+        ...BorderStyle.all("solid"),
+        ...BorderFill.all("transparent"),
+        ...CornerRadius.all(cornerRadiusLayer),
     },
     "shape.layer",
 );
@@ -206,7 +205,7 @@ export const layerShapeStyles: Styles = Styles.fromProperties(
  */
 export const controlDensityStyles: Styles = Styles.fromProperties(
     {
-        padding: css.partial`${densityControl.verticalPadding} ${densityControl.horizontalPadding}`,
+        ...Padding.verticalHorizontal(densityControl.verticalPadding, densityControl.horizontalPadding),
         gap: densityControl.horizontalGap,
     },
     "density.control",
@@ -223,7 +222,10 @@ export const controlDensityStyles: Styles = Styles.fromProperties(
  */
 export const autofillOuterDensityStyles: Styles = Styles.fromProperties(
     {
-        padding: css.partial`0 ${densityControl.horizontalPadding}`,
+        paddingTop: "0",
+        paddingRight: densityControl.horizontalPadding,
+        paddingBottom: "0",
+        paddingLeft: densityControl.horizontalPadding,
         gap: densityControl.horizontalGap,
     },
     "density.autofill-outer",
@@ -240,7 +242,10 @@ export const autofillOuterDensityStyles: Styles = Styles.fromProperties(
  */
 export const autofillInnerDensityStyles: Styles = Styles.fromProperties(
     {
-        padding: css.partial`${densityControl.verticalPadding} 0`,
+        paddingTop: densityControl.verticalPadding,
+        paddingRight: "0",
+        paddingBottom: densityControl.verticalPadding,
+        paddingLeft: "0",
     },
     "density.autofill-inner",
 );
@@ -256,7 +261,7 @@ export const autofillInnerDensityStyles: Styles = Styles.fromProperties(
  */
 export const itemContainerDensityStyles: Styles = Styles.fromProperties(
     {
-        padding: css.partial`${densityItemContainer.verticalPadding} ${densityItemContainer.horizontalPadding}`,
+        ...Padding.verticalHorizontal(densityItemContainer.verticalPadding, densityItemContainer.horizontalPadding),
         gap: densityItemContainer.horizontalGap,
     },
     "density.item-container",
@@ -275,7 +280,7 @@ export const itemContainerDensityStyles: Styles = Styles.fromProperties(
 export const accentFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForeground(accentFillStealth, accentStrokeReadableRecipe),
-        borderFill: accentStrokeSafety,
+        ...BorderFill.all(accentStrokeSafety),
     },
     "color.accent-fill-stealth-control",
 );
@@ -293,7 +298,7 @@ export const accentFillStealthControlStyles: Styles = Styles.fromProperties(
 export const accentFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForeground(accentFillSubtle, accentStrokeReadableRecipe),
-        borderFill: accentStrokeSubtle,
+        ...BorderFill.all(accentStrokeSubtle),
     },
     "color.accent-fill-subtle-control",
 );
@@ -344,7 +349,7 @@ export const accentFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        borderFill: accentStrokeDiscernible,
+        ...BorderFill.all(accentStrokeDiscernible),
         foregroundFill: accentStrokeReadable,
     },
     "color.accent-outline-discernible-control",
@@ -380,7 +385,7 @@ export const accentForegroundReadableControlStyles: Styles = Styles.fromProperti
 export const neutralFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForeground(neutralFillStealth, neutralStrokeStrongRecipe),
-        borderFill: neutralStrokeSafety,
+        ...BorderFill.all(neutralStrokeSafety),
     },
     "color.neutral-fill-stealth-control",
 );
@@ -398,7 +403,7 @@ export const neutralFillStealthControlStyles: Styles = Styles.fromProperties(
 export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...backgroundAndForeground(neutralFillSubtle, neutralStrokeStrongRecipe),
-        borderFill: neutralStrokeSubtle,
+        ...BorderFill.all(neutralStrokeSubtle),
     },
     "color.neutral-fill-subtle-control",
 );
@@ -449,7 +454,7 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        borderFill: neutralStrokeDiscernible,
+        ...BorderFill.all(neutralStrokeDiscernible),
         foregroundFill: neutralStrokeStrongRest,
     },
     "color.neutral-outline-discernible-control",

--- a/packages/adaptive-ui/src/modules/css.ts
+++ b/packages/adaptive-ui/src/modules/css.ts
@@ -13,14 +13,38 @@ export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
             return "background-color";
         case StyleProperty.foregroundFill:
             return "color";
-        case StyleProperty.borderFill:
-            return "border-color";
-        case StyleProperty.borderThickness:
-            return "border-width";
-        case StyleProperty.borderStyle:
-            return "border-style";
-        case StyleProperty.cornerRadius:
-            return "border-radius";
+        case StyleProperty.borderFillTop:
+            return "border-top-color";
+        case StyleProperty.borderFillRight:
+            return "border-right-color";
+        case StyleProperty.borderFillBottom:
+            return "border-bottom-color";
+        case StyleProperty.borderFillLeft:
+            return "border-left-color";
+        case StyleProperty.borderThicknessTop:
+            return "border-top-width";
+        case StyleProperty.borderThicknessRight:
+            return "border-right-width";
+        case StyleProperty.borderThicknessBottom:
+            return "border-bottom-width";
+        case StyleProperty.borderThicknessLeft:
+            return "border-left-width";
+        case StyleProperty.borderStyleTop:
+            return "border-top-style";
+        case StyleProperty.borderStyleRight:
+            return "border-right-style";
+        case StyleProperty.borderStyleBottom:
+            return "border-bottom-style";
+        case StyleProperty.borderStyleLeft:
+            return "border-left-style";
+        case StyleProperty.cornerRadiusTopLeft:
+            return "border-top-left-radius";
+        case StyleProperty.cornerRadiusTopRight:
+            return "border-top-right-radius";
+        case StyleProperty.cornerRadiusBottomRight:
+            return "border-bottom-right-radius";
+        case StyleProperty.cornerRadiusBottomLeft:
+            return "border-bottom-left-radius";
         case StyleProperty.fontFamily:
             return "font-family";
         case StyleProperty.fontSize:
@@ -35,8 +59,14 @@ export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
             return "letter-spacing";
         case StyleProperty.lineHeight:
             return "line-height";
-        case StyleProperty.padding:
-            return "padding";
+        case StyleProperty.paddingTop:
+            return "padding-top";
+        case StyleProperty.paddingRight:
+            return "padding-right";
+        case StyleProperty.paddingBottom:
+            return "padding-bottom";
+        case StyleProperty.paddingLeft:
+            return "padding-left";
         case StyleProperty.gap:
             return "gap";
         case StyleProperty.height:

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -4,6 +4,13 @@ import { InteractiveTokenGroup } from "../types.js";
 import { StyleProperty } from "./types.js";
 
 /**
+ * Supported values for a style property.
+ *
+ * @public
+ */
+export type StyleValue = CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string;
+
+/**
  * An object of style definitions, where the key is the {@link (StyleProperty:type)} and the value is the token or final value.
  *
  * @remarks
@@ -11,14 +18,92 @@ import { StyleProperty } from "./types.js";
  *
  * @public
  */
-export type StyleProperties = Partial<Record<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>>;
+export type StyleProperties = Partial<Record<StyleProperty, StyleValue>>;
 
 /**
  * A `Map` of style definitions, where the key is the {@link (StyleProperty:type)} and the value is the token or final value.
  *
  * @public
  */
-export type StylePropertiesMap = Map<StyleProperty, CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string>;
+export type StylePropertiesMap = Map<StyleProperty, StyleValue>;
+
+/**
+ * @public
+ */
+export const BorderFill = {
+    all: function(value: StyleValue): StyleProperties {
+        return {
+            borderFillTop: value,
+            borderFillRight: value,
+            borderFillBottom: value,
+            borderFillLeft: value,
+        };
+    },
+}
+
+/**
+ * @public
+ */
+export const BorderThickness = {
+    all: function(value: StyleValue): StyleProperties {
+        return {
+            borderThicknessTop: value,
+            borderThicknessRight: value,
+            borderThicknessBottom: value,
+            borderThicknessLeft: value,
+        };
+    },
+}
+
+/**
+ * @public
+ */
+export const BorderStyle = {
+    all: function(value: StyleValue): StyleProperties {
+        return {
+            borderStyleTop: value,
+            borderStyleRight: value,
+            borderStyleBottom: value,
+            borderStyleLeft: value,
+        };
+    },
+}
+
+/**
+ * @public
+ */
+export const CornerRadius = {
+    all: function(value: StyleValue): StyleProperties {
+        return {
+            cornerRadiusTopLeft: value,
+            cornerRadiusTopRight: value,
+            cornerRadiusBottomRight: value,
+            cornerRadiusBottomLeft: value,
+        };
+    },
+}
+
+/**
+ * @public
+ */
+export const Padding = {
+    all: function(value: StyleValue): StyleProperties {
+        return {
+            paddingTop: value,
+            paddingRight: value,
+            paddingBottom: value,
+            paddingLeft: value,
+        };
+    },
+    verticalHorizontal: function(valueVertical: StyleValue, valueHorizontal: StyleValue): StyleProperties {
+        return {
+            paddingTop: valueVertical,
+            paddingRight: valueHorizontal,
+            paddingBottom: valueVertical,
+            paddingLeft: valueHorizontal,
+        };
+    },
+}
 
 /**
  * A modular definition of style properties, either an alias to another style module or a collection of style properties.

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -118,10 +118,22 @@ export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDef
 export const StyleProperty = {
     backgroundFill: "backgroundFill",
     foregroundFill: "foregroundFill",
-    borderFill: "borderFill",
-    borderThickness: "borderThickness",
-    borderStyle: "borderStyle",
-    cornerRadius: "cornerRadius",
+    borderFillTop: "borderFillTop",
+    borderFillRight: "borderFillRight",
+    borderFillBottom: "borderFillBottom",
+    borderFillLeft: "borderFillLeft",
+    borderThicknessTop: "borderThicknessTop",
+    borderThicknessRight: "borderThicknessRight",
+    borderThicknessBottom: "borderThicknessBottom",
+    borderThicknessLeft: "borderThicknessLeft",
+    borderStyleTop: "borderStyleTop",
+    borderStyleRight: "borderStyleRight",
+    borderStyleBottom: "borderStyleBottom",
+    borderStyleLeft: "borderStyleLeft",
+    cornerRadiusTopLeft: "cornerRadiusTopLeft",
+    cornerRadiusTopRight: "cornerRadiusTopRight",
+    cornerRadiusBottomRight: "cornerRadiusBottomRight",
+    cornerRadiusBottomLeft: "cornerRadiusBottomLeft",
     fontFamily: "fontFamily",
     fontSize: "fontSize",
     fontWeight: "fontWeight",
@@ -129,13 +141,41 @@ export const StyleProperty = {
     fontVariationSettings: "fontVariationSettings",
     letterSpacing: "letterSpacing",
     lineHeight: "lineHeight",
-    padding: "padding",
+    paddingTop: "paddingTop",
+    paddingRight: "paddingRight",
+    paddingBottom: "paddingBottom",
+    paddingLeft: "paddingLeft",
     gap: "gap",
     height: "height",
     width: "width",
     layoutDirection: "layoutDirection",
     opacity: "opacity",
 } as const;
+
+/**
+ * @public
+ */
+export const stylePropertyBorderFillAll = [StyleProperty.borderFillTop, StyleProperty.borderFillRight, StyleProperty.borderFillBottom, StyleProperty.borderFillLeft];
+
+/**
+ * @public
+ */
+export const stylePropertyBorderThicknessAll = [StyleProperty.borderThicknessTop, StyleProperty.borderThicknessRight, StyleProperty.borderThicknessBottom, StyleProperty.borderThicknessLeft];
+
+/**
+ * @public
+ */
+export const stylePropertyBorderStyleAll = [StyleProperty.borderStyleTop, StyleProperty.borderStyleRight, StyleProperty.borderStyleBottom, StyleProperty.borderStyleLeft];
+
+/**
+ * @public
+ */
+export const stylePropertyCornerRadiusAll = [StyleProperty.cornerRadiusTopLeft, StyleProperty.cornerRadiusTopRight, StyleProperty.cornerRadiusBottomRight, StyleProperty.cornerRadiusBottomLeft];
+
+/**
+ * @public
+ */
+export const stylePropertyPaddingAll = [StyleProperty.paddingTop, StyleProperty.paddingRight, StyleProperty.paddingBottom, StyleProperty.paddingLeft];
 
 /**
  * The style property, like background color or border thickness.

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
@@ -3,7 +3,9 @@ import {
     controlDensityStyles,
     controlShapeStyles,
     neutralForegroundStrongElementStyles,
+    neutralStrokeSubtleRest,
     plainTextStyles,
+    strokeThickness,
     StyleModules,
     Styles,
 } from "@adaptive-web/adaptive-ui";
@@ -18,7 +20,16 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        plainTextStyles
+        Styles.compose(
+            [
+                plainTextStyles
+            ],
+            {
+                borderFillBottom: neutralStrokeSubtleRest,
+                borderStyleBottom: "solid",
+                borderThicknessBottom: strokeThickness,
+            }
+        ),
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -2,8 +2,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     focusStrokeOuter,
     focusStrokeWidth,
-    neutralStrokeSubtleRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -98,10 +96,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-    }
-
     :host(:not([disabled])) .button:focus-visible::before {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     }

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.modules.ts
@@ -1,6 +1,9 @@
 import {
+    neutralStrokeSubtleRest,
     plainTextStyles,
+    strokeThickness,
     StyleModules,
+    Styles,
 } from "@adaptive-web/adaptive-ui";
 
 /**
@@ -12,6 +15,15 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        plainTextStyles
+        Styles.compose(
+            [
+                plainTextStyles
+            ],
+            {
+                borderFillTop: neutralStrokeSubtleRest,
+                borderStyleTop: "solid",
+                borderThicknessTop: strokeThickness,
+            }
+        ),
     ],
 ];

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.ts
@@ -1,5 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -16,8 +15,4 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  * @public
  */
-export const aestheticStyles: ElementStyles = css`
-    :host {
-        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-    }
-`;
+export const aestheticStyles: ElementStyles = css``;

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
@@ -1,6 +1,4 @@
-import {
-    StyleModules,
-} from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtleRest, strokeThickness, StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +6,15 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        Styles.fromProperties(
+            {
+                borderFillBottom: neutralStrokeSubtleRest,
+                borderStyleBottom: "solid",
+                borderThicknessBottom: strokeThickness,
+            }
+        ),
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -4,8 +4,6 @@ import {
     controlCornerRadius,
     focusStrokeWidth,
     neutralFillSubtleRest,
-    neutralStrokeSubtleRest,
-    strokeWidth,
 } from "@adaptive-web/adaptive-ui";
 import { heightNumber } from "../../styles/index.js";
 
@@ -33,7 +31,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         padding: 1px 0;
-        border-bottom: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
     }
 
     :host([cell-type="sticky-header"]) {

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
@@ -1,6 +1,5 @@
-import {
-    StyleModules,
-} from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtleRest, strokeThickness, StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { DividerAnatomy } from "./divider.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +7,28 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+            hostCondition: DividerAnatomy.conditions.horizontal,
+        },
+        Styles.fromProperties(
+            {
+                borderFillTop: neutralStrokeSubtleRest,
+                borderStyleTop: "solid",
+                borderThicknessTop: strokeThickness,
+            }
+        ),
+    ],
+    [
+        {
+            hostCondition: DividerAnatomy.conditions.vertical,
+        },
+        Styles.fromProperties(
+            {
+                borderFillLeft: neutralStrokeSubtleRest,
+                borderStyleLeft: "solid",
+                borderThicknessLeft: strokeThickness,
+            }
+        ),
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.ts
@@ -1,4 +1,3 @@
-import { neutralStrokeSubtleRest, strokeWidth } from "@adaptive-web/adaptive-ui";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -9,6 +8,10 @@ export const templateStyles: ElementStyles = css`
     :host {
         display: block;
     }
+
+    :host([orientation="vertical"]) {
+        height: 100%;
+    }
 `;
 
 /**
@@ -18,12 +21,5 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         box-sizing: content-box;
-        border-top: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
-    }
-
-    :host([orientation="vertical"]) {
-        border-top: none;
-        height: 100%;
-        border-left: calc(${strokeWidth} * 1px) solid ${neutralStrokeSubtleRest};
     }
 `;

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    BorderFill,
     controlShapeStyles,
     itemContainerDensityStyles,
     neutralStrokeSubtleRest,
@@ -21,7 +22,7 @@ export const styleModules: StyleModules = [
                 itemContainerDensityStyles,
             ],
             {
-                borderFill: neutralStrokeSubtleRest,
+                ...BorderFill.all(neutralStrokeSubtleRest),
             },
         )
     ],

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.modules.ts
@@ -1,5 +1,7 @@
 import {
     accentFillReadableRest,
+    CornerRadius,
+    designUnitDimension,
     neutralFillSubtleRest,
     StyleModules,
     Styles
@@ -16,7 +18,8 @@ export const styleModules: StyleModules = [
         {
         },
         Styles.fromProperties({
-            backgroundFill: neutralFillSubtleRest
+            backgroundFill: neutralFillSubtleRest,
+            ...CornerRadius.all(designUnitDimension),
         })
     ],
     [
@@ -24,7 +27,8 @@ export const styleModules: StyleModules = [
             part: ProgressAnatomy.parts.indicator
         },
         Styles.fromProperties({
-            backgroundFill: accentFillReadableRest
+            backgroundFill: accentFillReadableRest,
+            ...CornerRadius.all(designUnitDimension),
         })
     ],
 ];

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.ts
@@ -46,21 +46,14 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         height: calc(${designUnit} * 1px);
-        border-radius: calc(${designUnit} * 1px);
     }
 
     .determinate {
-        border-radius: calc(${designUnit} * 1px);
         transition: all 0.2s ease-in-out;
-    }
-
-    .indeterminate {
-        border-radius: calc(${designUnit} * 1px);
     }
 
     .indeterminate .indicator {
         animation: indeterminate 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        border-radius: calc(${designUnit} * 1px);
     }
 
     @keyframes indeterminate {

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -1,4 +1,5 @@
 import {
+    BorderFill,
     controlShapeStyles,
     neutralStrokeSubtleRest,
     plainTextStyles,
@@ -21,7 +22,7 @@ export const styleModules: StyleModules = [
                 plainTextStyles,
             ],
             {
-                borderFill: neutralStrokeSubtleRest,
+                ...BorderFill.all(neutralStrokeSubtleRest),
             },
         )
     ],


### PR DESCRIPTION
# Pull Request

## Description

- Updates compound properties like `padding`, `border-*`, etc. into individual properties.
- Added support for evaluating `calc` statements like found on `padding` for use in Figma.

I was planning on individual properties to better support different tokens. When I got into implementing this, the model I ended up with here proved to be the simplest and best supported individual overrides.

CSS allows specifying many properties like `padding: top right bottom left`, but in this context that completely changed the shape and API of the merging and evaluating of styles that are composed together. It significantly complicated the logic in the plugin as well for the same reason.

One of the goals of the style module renderers is to encapsulate the complexity of CSS, so that's the appropriate place to render a better single `padding` value if we want. This allows any other consumer (like Figma) to avoid complexities the other direction.

Added convenience functions to make manual authoring closer to the efficiencies offered in CSS.

### Issues

Closes #90 

## Test Plan

Tested in Figma plugin.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.