### PR TITLE
Update styles to normalize to `border-box` sizing

### DIFF
--- a/change/@adaptive-web-adaptive-ui-c5541eb5-a043-4841-9783-4f449af6f27d.json
+++ b/change/@adaptive-web-adaptive-ui-c5541eb5-a043-4841-9783-4f449af6f27d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update styles to normalize to `border-box` sizing",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-29c191a0-f10e-4247-83e5-59a516148022.json
+++ b/change/@adaptive-web-adaptive-web-components-29c191a0-f10e-4247-83e5-59a516148022.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update styles to normalize to `border-box` sizing",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -384,7 +384,7 @@ export interface ComponentAnatomy<TConditions extends ComponentConditions, TPart
 }
 
 // @public
-export const componentBaseStyles = "\n    :host([hidden]) {\n        display: none !important;\n    }\n";
+export const componentBaseStyles = "\n    :host([hidden]) {\n        display: none !important;\n    }\n\n    :host {\n        box-sizing: border-box;\n    }\n\n    *, *:before, *:after {\n        box-sizing: inherit;\n    }\n";
 
 // @public
 export type ComponentConditions = Record<string, string>;

--- a/packages/adaptive-ui/src/styles.ts
+++ b/packages/adaptive-ui/src/styles.ts
@@ -9,4 +9,12 @@ export const componentBaseStyles = /* css */`
     :host([hidden]) {
         display: none !important;
     }
+
+    :host {
+        box-sizing: border-box;
+    }
+
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
 `;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -40,10 +40,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        box-sizing: border-box;
-    }
-
     .control {
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -41,7 +41,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
         max-width: calc(${heightNumber} * 1px);
     }

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -45,7 +45,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .control {
-        box-sizing: border-box;
         text-decoration: none;
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -46,10 +46,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        box-sizing: border-box;
-    }
-
     .control {
         white-space: nowrap;
         fill: currentcolor;

--- a/packages/adaptive-web-components/src/components/card/card.styles.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.ts
@@ -24,7 +24,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         height: 100%;
         width: 100%;
         background: ${layerFillInteractiveRest};

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -66,7 +66,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .control {
-        box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         fill: currentcolor;

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -48,7 +48,6 @@ export const templateStyles: ElementStyles = css`
     }
 
     .listbox {
-        box-sizing: border-box;
         z-index: 1;
         display: flex;
         flex-direction: column;
@@ -77,7 +76,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         min-width: 250px;
         fill: currentcolor;
     }
@@ -92,7 +90,6 @@ export const aestheticStyles: ElementStyles = css`
     } */
 
     .control {
-        box-sizing: border-box;
         min-height: 100%;
         width: 100%;
     }

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -14,7 +14,6 @@ import { heightNumber } from "../../styles/index.js";
 export const templateStyles: ElementStyles = css`
     :host {
         display: grid;
-        box-sizing: border-box;
         width: 100%;
     }
 

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.ts
@@ -18,8 +18,4 @@ export const templateStyles: ElementStyles = css`
  * Visual styles including Adaptive UI tokens.
  * @public
  */
-export const aestheticStyles: ElementStyles = css`
-    :host {
-        box-sizing: content-box;
-    }
-`;
+export const aestheticStyles: ElementStyles = css``;

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -36,7 +36,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -22,7 +22,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         background: ${layerFillFixedPlus1};
     }
 

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -125,7 +125,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         --col-width: minmax(20px, auto);
-        box-sizing: border-box;
         overflow: visible;
         fill: currentcolor;
     }

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -80,7 +80,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .root {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -26,7 +26,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -17,7 +17,6 @@ export const templateStyles: ElementStyles = css`
     }
 
     ::slotted([role="combobox"]) {
-        box-sizing: border-box;
         width: auto;
         border: none;
         outline: none;
@@ -33,7 +32,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -28,7 +28,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.ts
@@ -7,7 +7,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  */
 export const templateStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         width: 100%;
         display: flex;
         flex-direction: column;

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -67,7 +67,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .control {
-        box-sizing: border-box;
         width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         border-radius: 50% !important;

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -97,7 +97,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -51,7 +51,6 @@ export const templateStyles: ElementStyles = css`
     }
 
     .listbox {
-        box-sizing: border-box;
         z-index: 1;
         display: flex;
         flex-direction: column;
@@ -79,7 +78,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 
@@ -91,10 +89,6 @@ export const aestheticStyles: ElementStyles = css`
     :host(:focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
         outline: calc(${focusStrokeWidth} * 1px) solid ${focusStrokeOuter};
     } */
-
-    .control {
-        box-sizing: border-box;
-    }
 
     .listbox {
         max-height: calc((var(--size, 0) * ${heightNumber} + (${designUnit} * ${strokeWidth} * 2)) * 1px);

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -54,7 +54,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .switch {
         position: relative;
-        box-sizing: border-box;
         width: calc(((${heightNumber} / 2) + ${designUnit}) * 2px);
         height: calc(((${heightNumber} / 2) + ${designUnit}) * 1px);
         border-radius: calc(${heightNumber} * 1px) !important;

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -28,7 +28,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -62,7 +62,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .control {
         /* position: relative; */
-        box-sizing: border-box;
         height: calc(${heightNumber} * 2px);
         width: 100%;
     }

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -67,7 +67,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         /*position: relative;*/
-        box-sizing: border-box;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -29,7 +29,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         position: fixed;
-        box-sizing: border-box;
         height: fit-content;
         width: fit-content;
         padding: 4px 12px;

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -111,7 +111,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .control {
-        box-sizing: border-box;
         fill: currentcolor;
     }
 
@@ -121,7 +120,6 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .expand-collapse-button {
-        box-sizing: border-box;
         width: var(--expand-collapse-button-size);
         height: var(--expand-collapse-button-size);
         padding: 6px;


### PR DESCRIPTION
# Pull Request

## Description

The way the design tokens apply to elements it's proven to be beneficial to use `border-box` sizing so padding and border size is included in any width or height settings.

This change makes that standard and consistent in the base styles used by all components by default. The selector is setup to allow overriding back to `content-box` should there be a need.

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component