### PR TITLE
Adaptive UI: Formalized `Recipe` structure to enable better composition

### DIFF
--- a/change/@adaptive-web-adaptive-ui-46eea0a4-4401-4a9a-b0cb-dc3dfb1a9eac.json
+++ b/change/@adaptive-web-adaptive-ui-46eea0a4-4401-4a9a-b0cb-dc3dfb1a9eac.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adaptive UI: Formalized `Recipe` structure to enable better composition",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-cb0d66f8-ea09-4e3b-96e0-40390e01607a.json
+++ b/change/@adaptive-web-adaptive-web-components-cb0d66f8-ea09-4e3b-96e0-40390e01607a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adaptive UI: Formalized `Recipe` structure to enable better composition",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
@@ -2,6 +2,7 @@ import {
     blackOrWhiteDiscernibleRecipe,
     blackOrWhiteReadableRecipe,
     ColorRecipe,
+    ColorRecipeParams,
     contrastSwatch,
     createNonCss,
     createTokenNonCss,
@@ -27,10 +28,10 @@ export const docPalette = createNonCss<Palette>("doc-palette").withDefault(
 );
 
 export const docForegroundRecipe = DesignToken.create<ColorRecipe>("doc-foreground-recipe").withDefault({
-    evaluate: (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
+    evaluate: (resolve: DesignTokenResolver, params?: ColorRecipeParams): Swatch =>
         contrastSwatch(
             resolve(docPalette),
-            reference || resolve(fillColor),
+            params?.reference || resolve(fillColor),
             4.5,
         ),
 });
@@ -40,10 +41,10 @@ export const docForeground = createTokenSwatch("doc-foreground", [...styleProper
 );
 
 export const docFillRecipe = DesignToken.create<ColorRecipe>("doc-fill-recipe").withDefault({
-    evaluate: (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
+    evaluate: (resolve: DesignTokenResolver, params?: ColorRecipeParams): Swatch =>
         contrastSwatch(
             resolve(docPalette),
-            reference || resolve(fillColor),
+            params?.reference || resolve(fillColor),
             5,
         ),
 });

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -41,8 +41,10 @@ export const accentFillDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 // @public (undocumented)
 export const accentFillDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
+// Warning: (ae-forgotten-export) The symbol "RecipeOptional" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export const accentFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentFillDiscernibleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentFillDiscernibleRest: TypedCSSDesignToken<Swatch>;
@@ -84,7 +86,7 @@ export const accentFillReadableHover: TypedCSSDesignToken<Swatch>;
 export const accentFillReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentFillReadableRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentFillReadableRest: TypedCSSDesignToken<Swatch>;
@@ -93,7 +95,7 @@ export const accentFillReadableRest: TypedCSSDesignToken<Swatch>;
 export const accentFillReadableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const accentFillRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentFillRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const accentFillRest: TypedCSSDesignToken<Swatch>;
@@ -117,7 +119,7 @@ export const accentFillStealthFocus: TypedCSSDesignToken<Swatch>;
 export const accentFillStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentFillStealthRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentFillStealthRest: TypedCSSDesignToken<Swatch>;
@@ -138,7 +140,7 @@ export const accentFillSubtleFocus: TypedCSSDesignToken<Swatch>;
 export const accentFillSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentFillSubtleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentFillSubtleRest: TypedCSSDesignToken<Swatch>;
@@ -165,7 +167,7 @@ export const accentForegroundHoverDelta: DesignToken<number>;
 export const accentForegroundReadableControlStyles: Styles;
 
 // @public @deprecated (undocumented)
-export const accentForegroundRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentForegroundRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const accentForegroundRest: TypedCSSDesignToken<Swatch>;
@@ -192,7 +194,7 @@ export const accentStrokeDiscernibleFocus: TypedCSSDesignToken<Swatch>;
 export const accentStrokeDiscernibleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeDiscernibleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeDiscernibleRest: TypedCSSDesignToken<Swatch>;
@@ -219,7 +221,7 @@ export const accentStrokeReadableHover: TypedCSSDesignToken<Swatch>;
 export const accentStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const accentStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeReadableRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeReadableRest: TypedCSSDesignToken<Swatch>;
@@ -240,7 +242,7 @@ export const accentStrokeSafetyFocus: TypedCSSDesignToken<Swatch>;
 export const accentStrokeSafetyHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeSafetyRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeSafetyRest: TypedCSSDesignToken<Swatch>;
@@ -258,7 +260,7 @@ export const accentStrokeStealthFocus: TypedCSSDesignToken<Swatch>;
 export const accentStrokeStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeStealthRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeStealthRest: TypedCSSDesignToken<Swatch>;
@@ -276,7 +278,7 @@ export const accentStrokeStrongFocus: TypedCSSDesignToken<Swatch>;
 export const accentStrokeStrongHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeStrongRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeStrongRest: TypedCSSDesignToken<Swatch>;
@@ -294,7 +296,7 @@ export const accentStrokeSubtleFocus: TypedCSSDesignToken<Swatch>;
 export const accentStrokeSubtleHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const accentStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+export const accentStrokeSubtleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const accentStrokeSubtleRest: TypedCSSDesignToken<Swatch>;
@@ -364,14 +366,35 @@ export const BorderThickness: {
 };
 
 // @public
-export interface ColorRecipe<T = Swatch> {
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
-}
+export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
+
+// Warning: (ae-forgotten-export) The symbol "Recipe" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
+
+// Warning: (ae-forgotten-export) The symbol "RecipeEvaluateOptional" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type ColorRecipeEvaluate<T = Swatch> = RecipeEvaluateOptional<ColorRecipeParams, T>;
 
 // @public
-export interface ColorRecipeBySet<T = InteractiveSwatchSet> {
-    evaluate(resolver: DesignTokenResolver, reference: InteractiveSwatchSet): T;
-}
+export type ColorRecipePalette<T = Swatch> = Recipe<ColorRecipePaletteParams, T>;
+
+// Warning: (ae-forgotten-export) The symbol "RecipeEvaluate" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type ColorRecipePaletteEvaluate<T = Swatch> = RecipeEvaluate<ColorRecipePaletteParams, T>;
+
+// @public
+export type ColorRecipePaletteParams = ColorRecipeParams & {
+    palette: Palette;
+};
+
+// @public
+export type ColorRecipeParams = {
+    reference?: Swatch;
+};
 
 // @public
 export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
@@ -575,12 +598,13 @@ export const elevationFlyout: CSSDesignToken<string>;
 export const elevationFlyoutSize: DesignToken<number>;
 
 // @public
-export interface ElevationRecipe {
-    evaluate(resolver: DesignTokenResolver, size: number): string;
-}
+export type ElevationRecipe = Recipe<number, string>;
 
 // @public (undocumented)
 export const elevationRecipe: DesignToken<ElevationRecipe>;
+
+// @public
+export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;
 
 // @public (undocumented)
 export const elevationTooltip: CSSDesignToken<string>;
@@ -601,6 +625,9 @@ export const fillDiscernibleFocusDelta: DesignToken<number>;
 export const fillDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const fillDiscernibleRecipe: DesignToken<InteractiveColorRecipePalette>;
+
+// @public (undocumented)
 export const fillDiscernibleRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -611,6 +638,9 @@ export const fillReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const fillReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillReadableRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public (undocumented)
 export const fillReadableRestDelta: DesignToken<number>;
@@ -625,6 +655,9 @@ export const fillStealthFocusDelta: DesignToken<number>;
 export const fillStealthHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const fillStealthRecipe: DesignToken<InteractiveColorRecipePalette>;
+
+// @public (undocumented)
 export const fillStealthRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -635,6 +668,9 @@ export const fillSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const fillSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const fillSubtleRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public (undocumented)
 export const fillSubtleRestDelta: DesignToken<number>;
@@ -682,7 +718,7 @@ export const foregroundOnAccentFillReadableFocus: TypedCSSDesignToken<Swatch>;
 export const foregroundOnAccentFillReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+export const foregroundOnAccentFillReadableRecipe: DesignToken<ColorRecipe<InteractiveSwatchSet>>;
 
 // @public @deprecated (undocumented)
 export const foregroundOnAccentFillReadableRest: TypedCSSDesignToken<Swatch>;
@@ -694,7 +730,7 @@ export const foregroundOnAccentFocus: TypedCSSDesignToken<Swatch>;
 export const foregroundOnAccentHover: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const foregroundOnAccentRecipe: DesignToken<InteractiveColorRecipe>;
+export const foregroundOnAccentRecipe: DesignToken<ColorRecipe<InteractiveSwatchSet>>;
 
 // @public @deprecated (undocumented)
 export const foregroundOnAccentRest: TypedCSSDesignToken<Swatch>;
@@ -709,12 +745,19 @@ export const inputAutofillStyles: Styles;
 export const inputStyles: Styles;
 
 // @public
-export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet> {
-}
+export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
 
 // @public
-export interface InteractiveColorRecipeBySet extends ColorRecipeBySet {
-}
+export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;
+
+// @public
+export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractiveSwatchSet>;
+
+// @public
+export type InteractiveColorRecipePalette = ColorRecipePalette<InteractiveSwatchSet>;
+
+// @public
+export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractiveSwatchSet>;
 
 // @public
 export interface InteractiveSet<T> {
@@ -911,7 +954,7 @@ export const neutralFillDiscernibleHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillDiscernibleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralFillDiscernibleRest: TypedCSSDesignToken<Swatch>;
@@ -950,7 +993,7 @@ export const neutralFillInputHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillInputHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillInputRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillInputRecipe: DesignToken<ColorRecipe<InteractiveSwatchSet>>;
 
 // @public @deprecated (undocumented)
 export const neutralFillInputRest: TypedCSSDesignToken<Swatch>;
@@ -974,13 +1017,13 @@ export const neutralFillReadableFocus: TypedCSSDesignToken<Swatch>;
 export const neutralFillReadableHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralFillReadableRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillReadableRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralFillReadableRest: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const neutralFillRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const neutralFillRest: TypedCSSDesignToken<Swatch>;
@@ -1007,7 +1050,7 @@ export const neutralFillSecondaryHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillSecondaryHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillSecondaryRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillSecondaryRecipe: DesignToken<ColorRecipe<InteractiveSwatchSet>>;
 
 // @public @deprecated (undocumented)
 export const neutralFillSecondaryRest: TypedCSSDesignToken<Swatch>;
@@ -1040,7 +1083,7 @@ export const neutralFillStealthHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillStealthHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillStealthRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillStealthRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralFillStealthRest: TypedCSSDesignToken<Swatch>;
@@ -1067,7 +1110,7 @@ export const neutralFillStrongHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillStrongHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralFillStrongRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillStrongRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const neutralFillStrongRest: TypedCSSDesignToken<Swatch>;
@@ -1100,7 +1143,7 @@ export const neutralFillSubtleHover: TypedCSSDesignToken<Swatch>;
 export const neutralFillSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralFillSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralFillSubtleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralFillSubtleRest: TypedCSSDesignToken<Swatch>;
@@ -1124,7 +1167,7 @@ export const neutralForegroundFocusDelta: DesignToken<number>;
 export const neutralForegroundHint: TypedCSSDesignToken<Swatch>;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundHintRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralForegroundHintRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundHover: TypedCSSDesignToken<Swatch>;
@@ -1139,7 +1182,7 @@ export const neutralForegroundMinContrast: DesignToken<number>;
 export const neutralForegroundReadableElementStyles: Styles;
 
 // @public @deprecated (undocumented)
-export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralForegroundRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const neutralForegroundRest: TypedCSSDesignToken<Swatch>;
@@ -1184,7 +1227,7 @@ export const neutralStrokeDiscernibleHover: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeDiscernibleRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeDiscernibleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeDiscernibleRest: TypedCSSDesignToken<Swatch>;
@@ -1232,7 +1275,7 @@ export const neutralStrokeInputHover: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeInputHoverDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeInputRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeInputRecipe: DesignToken<ColorRecipe<InteractiveSwatchSet>>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeInputRest: TypedCSSDesignToken<Swatch>;
@@ -1262,7 +1305,7 @@ export const neutralStrokeReadableHover: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeReadableHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeReadableRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeReadableRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeReadableRest: TypedCSSDesignToken<Swatch>;
@@ -1271,7 +1314,7 @@ export const neutralStrokeReadableRest: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeReadableRestDelta: DesignToken<number>;
 
 // @public @deprecated (undocumented)
-export const neutralStrokeRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public @deprecated (undocumented)
 export const neutralStrokeRest: TypedCSSDesignToken<Swatch>;
@@ -1292,7 +1335,7 @@ export const neutralStrokeSafetyFocus: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeSafetyHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeSafetyRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeSafetyRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeSafetyRest: TypedCSSDesignToken<Swatch>;
@@ -1310,7 +1353,7 @@ export const neutralStrokeStealthFocus: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeStealthHover: TypedCSSDesignToken<Swatch>;
 
 // @public (undocumented)
-export const neutralStrokeStealthRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeStealthRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeStealthRest: TypedCSSDesignToken<Swatch>;
@@ -1340,7 +1383,7 @@ export const neutralStrokeStrongHoverDelta: DesignToken<number>;
 export const neutralStrokeStrongMinContrast: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeStrongRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeStrongRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeStrongRest: TypedCSSDesignToken<Swatch>;
@@ -1370,7 +1413,7 @@ export const neutralStrokeSubtleHover: TypedCSSDesignToken<Swatch>;
 export const neutralStrokeSubtleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
-export const neutralStrokeSubtleRecipe: DesignToken<InteractiveColorRecipe>;
+export const neutralStrokeSubtleRecipe: DesignToken<RecipeOptional<ColorRecipeParams, InteractiveSwatchSet>>;
 
 // @public (undocumented)
 export const neutralStrokeSubtleRest: TypedCSSDesignToken<Swatch>;
@@ -1464,6 +1507,9 @@ export const strokeDiscernibleFocusDelta: DesignToken<number>;
 export const strokeDiscernibleHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const strokeDiscernibleRecipe: DesignToken<InteractiveColorRecipePalette>;
+
+// @public (undocumented)
 export const strokeDiscernibleRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -1474,6 +1520,9 @@ export const strokeReadableFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const strokeReadableHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeReadableRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public (undocumented)
 export const strokeReadableRestDelta: DesignToken<number>;
@@ -1488,6 +1537,9 @@ export const strokeSafetyFocusDelta: DesignToken<number>;
 export const strokeSafetyHoverDelta: DesignToken<number>;
 
 // @public (undocumented)
+export const strokeSafetyRecipe: DesignToken<InteractiveColorRecipePalette>;
+
+// @public (undocumented)
 export const strokeSafetyRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -1498,6 +1550,9 @@ export const strokeStealthFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const strokeStealthHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeStealthRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public (undocumented)
 export const strokeStealthRestDelta: DesignToken<number>;
@@ -1515,6 +1570,9 @@ export const strokeStrongHoverDelta: DesignToken<number>;
 export const strokeStrongMinContrast: DesignToken<number>;
 
 // @public (undocumented)
+export const strokeStrongRecipe: DesignToken<InteractiveColorRecipePalette>;
+
+// @public (undocumented)
 export const strokeStrongRestDelta: DesignToken<number>;
 
 // @public (undocumented)
@@ -1525,6 +1583,9 @@ export const strokeSubtleFocusDelta: DesignToken<number>;
 
 // @public (undocumented)
 export const strokeSubtleHoverDelta: DesignToken<number>;
+
+// @public (undocumented)
+export const strokeSubtleRecipe: DesignToken<InteractiveColorRecipePalette>;
 
 // @public (undocumented)
 export const strokeSubtleRestDelta: DesignToken<number>;

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -1,28 +1,86 @@
-import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import { Recipe, RecipeEvaluate, RecipeEvaluateOptional, RecipeOptional } from "../recipes.js";
 import { InteractiveSet } from "../types.js";
+import { Palette } from "./palette.js";
 import { Swatch } from "./swatch.js";
 
 /**
- * A recipe that evaluates based on a single optional reference color value.
+ * Parameters provided to {@link ColorRecipe}.
  *
  * @public
  */
-export interface ColorRecipe<T = Swatch> {
+export type ColorRecipeParams = {
     /**
-     * Evaluate a color recipe.
-     *
-     * @param resolver - A function that resolves design tokens
-     * @param reference - The reference color, implementation defaults to `fillColor`, but allows for overriding for nested color recipes
+     * The reference color, implementation defaults to `fillColor`, but allows for overriding for nested color recipes.
      */
-    evaluate(resolver: DesignTokenResolver, reference?: Swatch): T;
-}
+    reference?: Swatch,
+};
+
+/**
+ * A recipe that evaluates based on {@link ColorRecipeParams}.
+ *
+ * @public
+ */
+export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
+
+/**
+ * The type of the `evaluate` function for {@link ColorRecipe}.
+ *
+ * @public
+ */
+export type ColorRecipeEvaluate<T = Swatch> = RecipeEvaluateOptional<ColorRecipeParams, T>;
+
+/**
+ * Parameters provided to {@link ColorRecipePalette}.
+ * @public
+ */
+export type ColorRecipePaletteParams = ColorRecipeParams & {
+    /**
+     * The Palette to provide to the recipe.
+     */
+    palette: Palette,
+};
+
+/**
+ * A recipe that evaluates based on {@link ColorRecipePaletteParams}.
+ *
+ * @public
+ */
+export type ColorRecipePalette<T = Swatch> = Recipe<ColorRecipePaletteParams, T>;
+
+/**
+ * The type of the `evaluate` function for {@link ColorRecipePalette}.
+ *
+ * @public
+ */
+export type ColorRecipePaletteEvaluate<T = Swatch> = RecipeEvaluate<ColorRecipePaletteParams, T>;
 
 /**
  * A recipe that evaluates a color value for rest, hover, active, and focus states.
  *
  * @public
  */
-export interface InteractiveColorRecipe extends ColorRecipe<InteractiveSwatchSet> {}
+export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
+
+/**
+ * The type of the `evaluate` function for {@link InteractiveColorRecipe}.
+ *
+ * @public
+ */
+export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractiveSwatchSet>;
+
+/**
+ * A recipe that evaluates a color value for rest, hover, active, and focus states using the provided Palette.
+ *
+ * @public
+ */
+export type InteractiveColorRecipePalette = ColorRecipePalette<InteractiveSwatchSet>;
+
+/**
+ * The type of the `evaluate` function for {@link InteractiveColorRecipePalette}.
+ *
+ * @public
+ */
+export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractiveSwatchSet>;
 
 /**
  * A set of {@link Swatch}es to use for an interactive control's states.
@@ -33,25 +91,17 @@ export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {}
 
 /**
  * A recipe that evaluates based on an interactive set of color values.
- * 
+ *
  * @remarks
  * This offers more control than {@link ColorRecipe} for cases where the recipe needs to take the full set into consideration.
  *
  * @public
  */
-export interface ColorRecipeBySet<T = InteractiveSwatchSet> {
-    /**
-     * Evaluate a color recipe set.
-     *
-     * @param resolver - A function that resolves design tokens
-     * @param reference - The reference set, since there is no equivalent to `fillColor` here, it must be provided
-     */
-    evaluate(resolver: DesignTokenResolver, reference: InteractiveSwatchSet): T;
-}
+export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
 
 /**
  * A recipe that evaluates a color value for rest, hover, active, and focus states.
  *
  * @public
  */
-export interface InteractiveColorRecipeBySet extends ColorRecipeBySet {}
+export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;

--- a/packages/adaptive-ui/src/design-tokens/layer.ts
+++ b/packages/adaptive-ui/src/design-tokens/layer.ts
@@ -1,7 +1,7 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
 import { DesignTokenType } from "../adaptive-design-tokens.js";
 import { Palette, PaletteDirectionValue } from "../color/palette.js";
-import { InteractiveColorRecipe, InteractiveSwatchSet } from "../color/recipe.js";
+import { ColorRecipeParams, InteractiveColorRecipe, InteractiveSwatchSet } from "../color/recipe.js";
 import { deltaSwatch, deltaSwatchSet } from "../color/recipes/index.js";
 import { Swatch } from "../color/swatch.js";
 import { luminanceSwatch } from "../color/utilities/luminance-swatch.js";
@@ -241,10 +241,10 @@ export const layerFillFixedPlus4 = createTokenSwatch("layer-fill-fixed-plus-4", 
  * @public
  */
 export const layerFillInteractiveRecipe = createNonCss<InteractiveColorRecipe>("layer-fill-interactive-recipe").withDefault({
-    evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+    evaluate: (resolve: DesignTokenResolver, params?: ColorRecipeParams): InteractiveSwatchSet =>
         deltaSwatchSet(
             resolve(layerPalette),
-            reference || resolve(fillColor),
+            params?.reference || resolve(fillColor),
             resolve(layerFillDelta),
             resolve(layerFillHoverDelta),
             resolve(layerFillActiveDelta),

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -88,7 +88,9 @@ export const createForegroundSet = (
     ): TypedCSSDesignToken<Swatch> {
         return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
-                resolve(foregroundRecipe).evaluate(resolve, resolve(background[state]))[foregroundState]
+                resolve(foregroundRecipe).evaluate(resolve, {
+                    reference: resolve(background[state])
+                })[foregroundState]
         );
     }
 

--- a/packages/adaptive-ui/src/elevation/recipe.ts
+++ b/packages/adaptive-ui/src/elevation/recipe.ts
@@ -1,16 +1,15 @@
-import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import { Recipe, RecipeEvaluate } from "../recipes.js";
 
 /**
  * A recipe that evaluates to an elevation treatment, commonly, but not limited to, a box shadow.
  *
  * @public
  */
-export interface ElevationRecipe {
-    /**
-     * Evaluate an elevation treatment.
-     *
-     * @param resolver - A function that resolves design tokens
-     * @param size - The size of the elevation
-     */
-    evaluate(resolver: DesignTokenResolver, size: number): string;
-}
+export type ElevationRecipe = Recipe<number, string>;
+
+/**
+ * The type of the `evaluate` function for {@link ElevationRecipe}.
+ *
+ * @public
+ */
+export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;

--- a/packages/adaptive-ui/src/recipes.ts
+++ b/packages/adaptive-ui/src/recipes.ts
@@ -1,0 +1,35 @@
+import { DesignTokenResolver } from "@microsoft/fast-foundation";
+
+export type RecipeEvaluate<TParam, TResult> = (resolver: DesignTokenResolver, params: TParam) => TResult;
+
+export type RecipeEvaluateOptional<TParam, TResult> = (resolver: DesignTokenResolver, params?: TParam) => TResult;
+
+/**
+ * A `Recipe` is a derived `DesignToken` value that enables reusable _and_ customizable design logic.
+ *
+ * @public
+ */
+export interface Recipe<TParam, TResult> {
+    /**
+     * Evaluate a recipe.
+     *
+     * @param resolver - A function that resolves design tokens.
+     * @param params - Any params that are needed to evaluate.
+     */
+    evaluate: RecipeEvaluate<TParam, TResult>;
+}
+
+/**
+ * A `Recipe` is a derived `DesignToken` value that enables reusable _and_ customizable design logic.
+ *
+ * @public
+ */
+export interface RecipeOptional<TParam, TResult> {
+    /**
+     * Evaluate a recipe.
+     *
+     * @param resolver - A function that resolves design tokens.
+     * @param params - Any params that are optional for evaluation.
+     */
+    evaluate: RecipeEvaluateOptional<TParam, TResult>;
+}

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -15,7 +15,7 @@ import { heightNumber } from "../../styles/index.js";
 const expandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collapse-hover").withDefault(
     (resolve: DesignTokenResolver) => {
         const recipe = resolve(neutralFillStealthRecipe);
-        return recipe.evaluate(resolve, recipe.evaluate(resolve).hover).hover;
+        return recipe.evaluate(resolve, { reference: recipe.evaluate(resolve).hover }).hover;
     }
 );
 
@@ -23,7 +23,7 @@ const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand
     (resolve: DesignTokenResolver) => {
         const baseRecipe = resolve(neutralFillSubtleRecipe);
         const buttonRecipe = resolve(neutralFillStealthRecipe);
-        return buttonRecipe.evaluate(resolve, baseRecipe.evaluate(resolve).rest).hover;
+        return buttonRecipe.evaluate(resolve, { reference: baseRecipe.evaluate(resolve).rest }).hover;
     }
 );
 


### PR DESCRIPTION
# Pull Request

## Description

This follows #54 and #69 regarding semantic color recipes. The base recipes have been updated to be configured without a Palette, and the Recipe structure has been updated to allow derivative configurations, like using the same underlying recipe for accent and neutral palettes.

## Reviewer Notes

I chose to break the current optional `reference` `Swatch` in favor of the extension model for color config because it simplified the creation of the various tokens. I feel this is a better long term approach, however I did not follow the `object` model when updating elevation. Right now I feel that system is too simple to require it, but perhaps we will revisit when I get to migrating that to modules.

## Test Plan

Tested in Adaptive UI Explorer and Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Adding a third palette for selection/highlight.