### PR TITLE
Improved typing and metadata on color recipes

### DIFF
--- a/change/@adaptive-web-adaptive-ui-23ce4046-3241-426a-918b-cc361a6bfdff.json
+++ b/change/@adaptive-web-adaptive-ui-23ce4046-3241-426a-918b-cc361a6bfdff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Improved typing and metadata on color recipes",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -174,7 +174,7 @@ function registerStore<T>(
         
         const entryIntendedFor = (token instanceof TypedCSSDesignToken ? (token as TypedCSSDesignToken<any>).intendedFor : undefined);
 
-        const entryFormControlId = token.allowedType.includes(DesignTokenType.color) ? FormControlId.color : FormControlId.text;
+        const entryFormControlId = token.type === DesignTokenType.color ? FormControlId.color : FormControlId.text;
 
         const definition: DesignTokenDefinition = {
             id: token.name,

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -33,12 +33,7 @@ export const _black: SwatchRGB;
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
 
 // @public
-export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, minContrast: number, defaultBlack: boolean): {
-    rest: Swatch;
-    hover: Swatch;
-    active: Swatch;
-    focus: Swatch;
-};
+export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
 
 // @public (undocumented)
 export const BorderFill: {
@@ -55,26 +50,21 @@ export const BorderThickness: {
     all: (value: StyleValue) => StyleProperties;
 };
 
-// Warning: (ae-forgotten-export) The symbol "RecipeOptional" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
 
-// Warning: (ae-forgotten-export) The symbol "Recipe" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
 
-// Warning: (ae-forgotten-export) The symbol "RecipeEvaluateOptional" needs to be exported by the entry point index.d.ts
-//
+// @public
+export type ColorRecipeBySetEvaluate<T = Swatch> = RecipeEvaluate<InteractiveSwatchSet, T>;
+
 // @public
 export type ColorRecipeEvaluate<T = Swatch> = RecipeEvaluateOptional<ColorRecipeParams, T>;
 
 // @public
 export type ColorRecipePalette<T = Swatch> = Recipe<ColorRecipePaletteParams, T>;
 
-// Warning: (ae-forgotten-export) The symbol "RecipeEvaluate" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type ColorRecipePaletteEvaluate<T = Swatch> = RecipeEvaluate<ColorRecipePaletteParams, T>;
 
@@ -127,10 +117,10 @@ export const CornerRadius: {
 export const create: typeof DesignToken.create;
 
 // @public
-export function createForegroundSet(foregroundRecipe: DesignToken<InteractiveColorRecipe>, foregroundState: keyof InteractiveSet<any>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
+export function createForegroundSet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>, foregroundState: keyof InteractiveSet<any>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
 
 // @public
-export function createForegroundSetBySet(foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
+export function createForegroundSetBySet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
 
 // Warning: (ae-internal-missing-underscore) The name "createNonCss" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -141,22 +131,25 @@ export function createNonCss<T>(name: string): DesignToken<T>;
 export function createTokenColor(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<string>;
 
 // @public
-export function createTokenColorRecipe<T = Swatch>(baseName: string, evaluate: ColorRecipeEvaluate<T>): DesignToken<ColorRecipe<T>>;
+export function createTokenColorRecipe<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeEvaluate<T>): TypedDesignToken<ColorRecipe<T>>;
 
 // @public
-export function createTokenColorRecipeForPalette<T = Swatch>(baseName: string, evaluate: ColorRecipePaletteEvaluate<T>): DesignToken<ColorRecipePalette<T>>;
+export function createTokenColorRecipeBySet<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeBySetEvaluate<T>): TypedDesignToken<ColorRecipeBySet<T>>;
 
 // @public
-export function createTokenColorRecipeValue(recipeToken: DesignToken<ColorRecipe<Swatch>>, intendedFor: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch>;
+export function createTokenColorRecipeForPalette<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipePaletteEvaluate<T>): TypedDesignToken<ColorRecipePalette<T>>;
 
 // @public
-export function createTokenColorRecipeWithPalette<T>(recipeToken: DesignToken<Recipe<ColorRecipePaletteParams, T>>, paletteToken: DesignToken<Palette>): DesignToken<RecipeOptional<ColorRecipeParams, T>>;
+export function createTokenColorRecipeValue(recipeToken: TypedDesignToken<ColorRecipe<Swatch>>): TypedCSSDesignToken<Swatch>;
 
 // @public
-export function createTokenColorSet(recipeToken: DesignToken<InteractiveColorRecipe>, intendedFor: StyleProperty | StyleProperty[]): InteractiveTokenGroup<Swatch>;
+export function createTokenColorRecipeWithPalette<T>(recipeToken: TypedDesignToken<Recipe<ColorRecipePaletteParams, T>>, paletteToken: DesignToken<Palette>): TypedDesignToken<RecipeOptional<ColorRecipeParams, T>>;
 
 // @public
-export function createTokenDelta(baseName: string, state: keyof InteractiveSwatchSet, value: number | DesignToken<number>): DesignToken<number>;
+export function createTokenColorSet(recipeToken: TypedDesignToken<InteractiveColorRecipe>): InteractiveTokenGroup<Swatch>;
+
+// @public
+export function createTokenDelta(baseName: string, state: keyof InteractiveSwatchSet, value: number | DesignToken<number>): TypedDesignToken<number>;
 
 // @public
 export function createTokenDimension(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<string>;
@@ -177,10 +170,10 @@ export function createTokenFontWeight(name: string): TypedCSSDesignToken<number>
 export function createTokenLineHeight(name: string): TypedCSSDesignToken<string>;
 
 // @public
-export function createTokenMinContrast(baseName: string, value: number | DesignToken<number>): DesignToken<number>;
+export function createTokenMinContrast(baseName: string, value: number | DesignToken<number>): TypedDesignToken<number>;
 
 // @public
-export function createTokenNonCss<T>(name: string, allowedType: DesignTokenType): TypedDesignToken<T>;
+export function createTokenNonCss<T>(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedDesignToken<T>;
 
 // @public
 export function createTokenNumber(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<number>;
@@ -215,8 +208,11 @@ export class DensityPaddingAndGapTokenGroup implements TokenGroup {
 // @public
 export class DesignTokenMetadata {
     // (undocumented)
-    get allowedType(): DesignTokenType;
-    protected set allowedType(value: DesignTokenType);
+    protected init(type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): void;
+    get intendedFor(): StyleProperty[] | undefined;
+    protected set intendedFor(value: StyleProperty[] | undefined);
+    get type(): DesignTokenType;
+    protected set type(value: DesignTokenType);
 }
 
 // @public
@@ -236,6 +232,7 @@ export const DesignTokenType: {
     readonly typography: "typography";
     readonly fontStyle: "fontStyle";
     readonly fontVariations: "fontVariations";
+    readonly recipe: "recipe";
 };
 
 // @public
@@ -252,8 +249,8 @@ export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;
 
 // @public (undocumented)
 export const Fill: {
-    backgroundAndForeground: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: DesignToken<InteractiveColorRecipe>) => StyleProperties;
-    backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
+    backgroundAndForeground: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>) => StyleProperties;
+    backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
 };
 
 // @public
@@ -267,6 +264,9 @@ export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
 
 // @public
 export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;
+
+// @public
+export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractiveSwatchSet>;
 
 // @public
 export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractiveSwatchSet>;
@@ -357,6 +357,22 @@ export interface PaletteRGBOptions {
     preserveSource: boolean;
     stepContrast: number;
     stepContrastRamp: number;
+}
+
+// @public
+export interface Recipe<TParam, TResult> {
+    evaluate: RecipeEvaluate<TParam, TResult>;
+}
+
+// @public (undocumented)
+export type RecipeEvaluate<TParam, TResult> = (resolver: DesignTokenResolver, params: TParam) => TResult;
+
+// @public (undocumented)
+export type RecipeEvaluateOptional<TParam, TResult> = (resolver: DesignTokenResolver, params?: TParam) => TResult;
+
+// @public
+export interface RecipeOptional<TParam, TResult> {
+    evaluate: RecipeEvaluateOptional<TParam, TResult>;
 }
 
 // @public
@@ -498,7 +514,9 @@ export class SwatchRGB implements Swatch {
 
 // @public
 export interface TokenGroup {
+    intendedFor?: StyleProperty | StyleProperty[];
     name: string;
+    type?: DesignTokenType;
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
@@ -506,10 +524,8 @@ export interface TokenGroup {
 //
 // @public
 export class TypedCSSDesignToken<T> extends CSSDesignToken<T> implements DesignTokenMetadata {
-    constructor(name: string, allowedType: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]);
-    static createTyped<T>(name: string, allowedType: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<T>;
-    // (undocumented)
-    readonly intendedFor?: StyleProperty[];
+    constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]);
+    static createTyped<T>(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<T>;
 }
 
 // @internal (undocumented)
@@ -521,8 +537,8 @@ export interface TypedCSSDesignToken<T> extends DesignTokenMetadata {
 //
 // @public
 export class TypedDesignToken<T> extends DesignToken<T> implements DesignTokenMetadata {
-    constructor(name: string, allowedType: DesignTokenType);
-    static createTyped<T>(name: string, allowedType: DesignTokenType): TypedDesignToken<T>;
+    constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]);
+    static createTyped<T>(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedDesignToken<T>;
 }
 
 // @internal (undocumented)

--- a/packages/adaptive-ui/src/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/adaptive-design-tokens.ts
@@ -25,6 +25,7 @@ export const DesignTokenType = {
     // Added in Adaptive UI
     fontStyle: "fontStyle",
     fontVariations: "fontVariations",
+    recipe: "recipe",
 } as const;
 
 /**
@@ -35,43 +36,71 @@ export const DesignTokenType = {
 export type DesignTokenType = ValuesOf<typeof DesignTokenType> | string;
 
 /**
- * Metadata describing the allowed types of a DesignToken.
+ * Metadata describing the value type and intended styling uses of a DesignToken.
  *
  * @public
  */
 export class DesignTokenMetadata {
     // TODO: This needs to support multiple types, tokens in Adaptive UI might represent different value
     // types, like a Swatch type commonly refers to a `color` but may also be a `gradient`. (see `create.ts`)
-    private _allowedType: DesignTokenType;
+    private _type: DesignTokenType;
 
-    public get allowedType(): DesignTokenType {
-        return this._allowedType;
+    /**
+     * Gets the value type for this token.
+     */
+    public get type(): DesignTokenType {
+        return this._type;
     }
 
-    protected set allowedType(value: DesignTokenType) {
-        this._allowedType = value;
+    protected set type(value: DesignTokenType) {
+        this._type = value;
+    }
+
+    private _intendedFor?: StyleProperty[];
+
+    /**
+     * Gets intended styling uses for this token.
+     */
+    public get intendedFor(): StyleProperty[] | undefined {
+        return this._intendedFor;
+    }
+
+    protected set intendedFor(value: StyleProperty[] | undefined) {
+        this._intendedFor = value;
+    }
+
+    protected init(type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
+        this.type = type;
+        if (intendedFor) {
+            if (Array.isArray(intendedFor)) {
+                this.intendedFor = intendedFor;
+            } else {
+                this.intendedFor = [intendedFor];
+            }
+        }
     }
 }
 
 /**
- * A DesignToken with allowed types.
+ * A DesignToken with value type and intended styling uses.
  *
  * @public
  */
 export class TypedDesignToken<T> extends DesignToken<T> implements DesignTokenMetadata {
-    constructor(name: string, allowedType: DesignTokenType) {
+    constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
         super({ name });
-        this.allowedType = allowedType;
+        this.init(type, intendedFor);
     }
 
     /**
-     * Factory to create a DesignToken with allowed types.
+     * Factory to create a DesignToken with value type and intended styling uses.
      */
     public static createTyped<T>(
         name: string,
-        allowedType: DesignTokenType,
+        type: DesignTokenType,
+        intendedFor?: StyleProperty | StyleProperty[],
     ): TypedDesignToken<T> {
-        return new TypedDesignToken<T>(name, allowedType);
+        return new TypedDesignToken<T>(name, type, intendedFor);
     }
 }
 
@@ -83,36 +112,27 @@ export interface TypedDesignToken<T> extends DesignTokenMetadata {}
 applyMixins(TypedDesignToken, DesignTokenMetadata);
 
 /**
- * A CSSDesignToken with allowed types and intended styling uses.
+ * A CSSDesignToken with value type and intended styling uses.
  *
  * @public
  */
 @cssDirective()
 @htmlDirective()
 export class TypedCSSDesignToken<T> extends CSSDesignToken<T> implements DesignTokenMetadata {
-    public readonly intendedFor?: StyleProperty[];
-
-    constructor(name: string, allowedType: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
+    constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
         super({ name, cssCustomPropertyName: name });
-        this.allowedType = allowedType;
-        if (intendedFor) {
-            if (Array.isArray(intendedFor)) {
-                this.intendedFor = intendedFor;
-            } else {
-                this.intendedFor = [intendedFor];
-            }
-        }
+        this.init(type, intendedFor);
     }
 
     /**
-     * Factory to create a DesignToken with allowed types and intended styling uses.
+     * Factory to create a DesignToken with value type and intended styling uses.
      */
     public static createTyped<T>(
         name: string,
-        allowedType: DesignTokenType,
+        type: DesignTokenType,
         intendedFor?: StyleProperty | StyleProperty[],
     ): TypedCSSDesignToken<T> {
-        return new TypedCSSDesignToken<T>(name, allowedType, intendedFor);
+        return new TypedCSSDesignToken<T>(name, type, intendedFor);
     }
 }
 

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -100,8 +100,22 @@ export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {}
 export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
 
 /**
+ * The type of the `evaluate` function for {@link ColorRecipeBySet}.
+ *
+ * @public
+ */
+export type ColorRecipeBySetEvaluate<T = Swatch> = RecipeEvaluate<InteractiveSwatchSet, T>;
+
+/**
  * A recipe that evaluates a color value for rest, hover, active, and focus states.
  *
  * @public
  */
 export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;
+
+/**
+ * The type of the `evaluate` function for {@link InteractiveColorRecipeBySet}.
+ *
+ * @public
+ */
+export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractiveSwatchSet>;

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
@@ -1,3 +1,4 @@
+import { InteractiveSwatchSet } from "../recipe.js";
 import { Swatch } from "../swatch.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
@@ -27,7 +28,7 @@ export function blackOrWhiteByContrastSet(
     focusReference: Swatch,
     minContrast: number,
     defaultBlack: boolean
-) {
+): InteractiveSwatchSet {
     const defaultRule: (reference: Swatch) => Swatch = (reference) =>
         blackOrWhiteByContrast(reference, minContrast, defaultBlack);
 

--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -3,6 +3,7 @@ export * from "./density/index.js";
 export * from "./elevation/index.js";
 export * from "./modules/index.js";
 export * from "./adaptive-design-tokens.js";
+export * from "./recipes.js";
 export * from "./styles.js";
 export * from "./token-helpers-color.js";
 export * from "./token-helpers.js";

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -1,7 +1,8 @@
 import type { CSSDirective } from "@microsoft/fast-element";
-import type { CSSDesignToken, DesignToken } from "@microsoft/fast-foundation";
+import type { CSSDesignToken } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
+import { TypedDesignToken } from "../adaptive-design-tokens.js";
 import { InteractiveTokenGroup } from "../types.js";
 import { createForegroundSet, createForegroundSetBySet } from "../token-helpers-color.js";
 import { StyleProperty } from "./types.js";
@@ -36,7 +37,7 @@ export type StylePropertiesMap = Map<StyleProperty, StyleValue>;
 export const Fill = {
     backgroundAndForeground: function(
         background: InteractiveTokenGroup<Swatch>,
-        foregroundRecipe: DesignToken<InteractiveColorRecipe>
+        foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>
     ): StyleProperties {
         return {
             backgroundFill: background,
@@ -45,7 +46,7 @@ export const Fill = {
     },
     backgroundAndForegroundBySet: function(
         background: InteractiveTokenGroup<Swatch>,
-        foregroundRecipe: DesignToken<InteractiveColorRecipeBySet>
+        foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>
     ): StyleProperties {
         return {
             backgroundFill: background,

--- a/packages/adaptive-ui/src/token-helpers.ts
+++ b/packages/adaptive-ui/src/token-helpers.ts
@@ -27,12 +27,12 @@ export function createTokenColor(name: string, intendedFor?: StyleProperty | Sty
  * Creates a DesignToken that can be used by other DesignTokens, but not directly in styles.
  *
  * @param name - The token name in `css-identifier` casing.
- * @param allowedType - The allowed types for the token value.
+ * @param type - The allowed types for the token value.
  *
  * @public
  */
-export function createTokenNonCss<T>(name: string, allowedType: DesignTokenType): TypedDesignToken<T> {
-    return TypedDesignToken.createTyped<T>(name, allowedType);
+export function createTokenNonCss<T>(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedDesignToken<T> {
+    return TypedDesignToken.createTyped<T>(name, type, intendedFor);
 }
 
 /**

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -1,4 +1,5 @@
-import type { TypedCSSDesignToken } from "./adaptive-design-tokens.js";
+import type { DesignTokenType, TypedCSSDesignToken } from "./adaptive-design-tokens.js";
+import { StyleProperty } from "./modules/types.js";
 
 /**
  * A group of tokens.
@@ -10,6 +11,16 @@ export interface TokenGroup {
      * The name of the token group. Contained tokens should extend this name like `group-name` -> `group-name-child`.
      */
     name: string;
+
+    /**
+     * The default type for any tokens within this group.
+     */
+    type?: DesignTokenType;
+
+    /**
+     * The style properties where tokens within this group are intended to be used.
+     */
+    intendedFor?: StyleProperty | StyleProperty[]
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Improved the way color recipes are created by chaining the token typed metadata. This makes the base recipes even more reusable since semantically a given recipe is always intended for a single use, like background fill or foreground fill.

Builds upon #105 and #106.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

This work precedes adding the highlight color palette.