### PR TITLE
fix:  select inner control width

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-c04ae354-a56c-4f7d-9083-4b10f9b7d4cb.json
+++ b/change/@adaptive-web-adaptive-web-components-c04ae354-a56c-4f7d-9083-4b10f9b7d4cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "select control width",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -34,6 +34,7 @@ export const templateStyles: ElementStyles = css`
         display: flex;
         align-items: center;
         cursor: pointer;
+        width: 100%;
     }
 
     ::slotted([slot="start"]),


### PR DESCRIPTION
## Description
The inner control of the select component would not resize according to the width of the outer component.  This change sets the width of the inner control to 100% so authors can control the width of the select.

## Checklist

### General
- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
