### PR TITLE
fix: inner control of text/number fields not tracking component width

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-f7feeb4e-447d-44bc-afae-280f0e7eb583.json
+++ b/change/@adaptive-web-adaptive-web-components-f7feeb4e-447d-44bc-afae-280f0e7eb583.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "text field control resizing",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -31,6 +31,7 @@ export const templateStyles: ElementStyles = css`
 
     .control {
         -webkit-appearance: none;
+        width: 100%;
         font: inherit;
         background: transparent;
         border: 0;

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -22,6 +22,7 @@ export const templateStyles: ElementStyles = css`
 
     .control {
         -webkit-appearance: none;
+        width: 100%;
         margin: 0;
         padding: unset;
         border: none;


### PR DESCRIPTION
## Description
![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/7649425/fc331885-385e-43fd-9215-314d6effa9b6)

Added 100% width to styles for text field and number field inner controls as they were not tracking the parent component width changes.


### Issues
ad-hoc

## Reviewer Notes
@bheston - should this be part of a module style instead?

## Checklist

### General
- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
