### PR TITLE
fix: picker gets taller when items selected

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-0de560ad-b55b-48a1-b602-f7e4436daebe.json
+++ b/change/@adaptive-web-adaptive-web-components-0de560ad-b55b-48a1-b602-f7e4436daebe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "picker styles",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.modules.ts
@@ -1,5 +1,9 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { inputStyles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import {
+    controlShapeStyles,
+    neutralOutlineDiscernibleControlStyles,
+    typeRampBaseStyles
+} from "@adaptive-web/adaptive-ui/reference";
 
 /**
  * Visual styles composed by modules.
@@ -10,6 +14,12 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        inputStyles
+        Styles.compose(
+            [
+                controlShapeStyles,
+                typeRampBaseStyles,
+                neutralOutlineDiscernibleControlStyles
+            ],
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -1,4 +1,5 @@
 import {
+    densityControl,
     focusStrokeOuter,
     focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
@@ -14,13 +15,14 @@ export const templateStyles: ElementStyles = css`
         flex-wrap: wrap;
         outline: none;
         user-select: none;
+        gap: ${densityControl.horizontalGap};
     }
 
     ::slotted([role="combobox"]) {
         width: auto;
         border: none;
         outline: none;
-        padding: unset;
+        padding: ${densityControl.verticalPadding} ${densityControl.horizontalPadding};
         user-select: none;
         font: inherit;
     }

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -15,14 +15,12 @@ export const templateStyles: ElementStyles = css`
         flex-wrap: wrap;
         outline: none;
         user-select: none;
-        gap: ${densityControl.horizontalGap};
     }
 
     ::slotted([role="combobox"]) {
         width: auto;
         border: none;
         outline: none;
-        padding: ${densityControl.verticalPadding} ${densityControl.horizontalPadding};
         user-select: none;
         font: inherit;
     }
@@ -35,9 +33,14 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         fill: currentcolor;
+        gap: ${densityControl.horizontalGap};
     }
 
     :host(:not([disabled]):focus-within) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
+    }
+
+    ::slotted([role="combobox"]) {
+        padding: ${densityControl.verticalPadding} ${densityControl.horizontalPadding};
     }
 `;


### PR DESCRIPTION
# Pull Request

## Description

![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/7649425/b7bc417b-cbef-49fe-a499-2c6156a950fe)

Picker with no selected items was shorter than with selected items.  With this change picker maintains a constant height regardless of whether items are selected or not.

### Issues
ad hoc

## Checklist

### General
- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component