### PR TITLE
fix: sticky header styles

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-a02b023a-6d04-4b29-be99-fa4c1b31c347.json
+++ b/change/@adaptive-web-adaptive-web-components-a02b023a-6d04-4b29-be99-fa4c1b31c347.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix sticky header styles",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -17,7 +17,7 @@ export const templateStyles: ElementStyles = css`
         width: 100%;
     }
 
-    :host([cell-type="sticky-header"]) {
+    :host([row-type="sticky-header"]) {
         position: sticky;
         top: 0;
     }
@@ -32,7 +32,7 @@ export const aestheticStyles: ElementStyles = css`
         padding: 1px 0;
     }
 
-    :host([cell-type="sticky-header"]) {
+    :host([row-type="sticky-header"]) {
         background: ${neutralFillSubtleRest};
     }
 


### PR DESCRIPTION
## Description
Data grid sticky header styles were incorrectly pointing at cell type, not row type.  This change fixes that.

### Issues
ad-hoc

## Checklist

### General
- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
