### PR TITLE
Adaptive UI - Updated color palette based on okhsl

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,8 @@
     },
     "cSpell.words": [
         "Appliable",
+        "culori",
+        "okhsl",
         "Unregisters"
     ],
     "editor.insertSpaces": true,

--- a/change/@adaptive-web-adaptive-ui-49a1a1c3-cb47-4350-a4e7-ed80ccaeb2eb.json
+++ b/change/@adaptive-web-adaptive-ui-49a1a1c3-cb47-4350-a4e7-ed80ccaeb2eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI - Updated color palette based on okhsl",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12549,6 +12549,11 @@
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
+        "node_modules/@types/culori": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/culori/-/culori-2.0.0.tgz",
+            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg=="
+        },
         "node_modules/@types/debug": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -16573,6 +16578,14 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
             "dev": true
+        },
+        "node_modules/culori": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/culori/-/culori-3.2.0.tgz",
+            "integrity": "sha512-HIEbTSP7vs1mPq/2P9In6QyFE0Tkpevh0k9a+FkjhD+cwsYm9WRSbn4uMdW9O0yXlNYC3ppxL3gWWPOcvEl57w==",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
         },
         "node_modules/currently-unhandled": {
             "version": "0.4.1",
@@ -30968,7 +30981,9 @@
             "license": "MIT",
             "dependencies": {
                 "@microsoft/fast-colors": "^5.3.1",
-                "@microsoft/fast-foundation": "3.0.0-alpha.28"
+                "@microsoft/fast-foundation": "3.0.0-alpha.28",
+                "@types/culori": "^2.0.0",
+                "culori": "^3.2.0"
             },
             "devDependencies": {
                 "@microsoft/api-extractor": "^7.34.4",
@@ -31647,8 +31662,10 @@
                 "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-foundation": "3.0.0-alpha.28",
                 "@types/chai": "^4.3.4",
+                "@types/culori": "^2.0.0",
                 "@types/mocha": "^10.0.1",
                 "chai": "^4.3.7",
+                "culori": "^3.2.0",
                 "mocha": "^10.2.0",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.7.0"
@@ -41178,6 +41195,11 @@
             "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
             "dev": true
         },
+        "@types/culori": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/culori/-/culori-2.0.0.tgz",
+            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg=="
+        },
         "@types/debug": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -44399,6 +44421,11 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
             "dev": true
+        },
+        "culori": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/culori/-/culori-3.2.0.tgz",
+            "integrity": "sha512-HIEbTSP7vs1mPq/2P9In6QyFE0Tkpevh0k9a+FkjhD+cwsYm9WRSbn4uMdW9O0yXlNYC3ppxL3gWWPOcvEl57w=="
         },
         "currently-unhandled": {
             "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12552,7 +12552,8 @@
         "node_modules/@types/culori": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/culori/-/culori-2.0.0.tgz",
-            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg=="
+            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg==",
+            "dev": true
         },
         "node_modules/@types/debug": {
             "version": "4.1.7",
@@ -30982,12 +30983,12 @@
             "dependencies": {
                 "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-foundation": "3.0.0-alpha.28",
-                "@types/culori": "^2.0.0",
                 "culori": "^3.2.0"
             },
             "devDependencies": {
                 "@microsoft/api-extractor": "^7.34.4",
                 "@types/chai": "^4.3.4",
+                "@types/culori": "^2.0.0",
                 "@types/mocha": "^10.0.1",
                 "chai": "^4.3.7",
                 "mocha": "^10.2.0",
@@ -41198,7 +41199,8 @@
         "@types/culori": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@types/culori/-/culori-2.0.0.tgz",
-            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg=="
+            "integrity": "sha512-bKpEra39sQS9UZ+1JoWhuGJEzwKS0dUkNCohVYmn6CAEBkqyIXimKiPDRZWtiOB7sKgkWMaTUpHFimygRoGIlg==",
+            "dev": true
         },
         "@types/debug": {
             "version": "4.1.7",

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -49,8 +49,6 @@ export class AdaptiveComponent extends FASTElement {
     @observable
     public styles?: Styles;
     protected stylesChanged(prev: Styles, next: Styles) {
-        // console.log("stylesChanged", next);
-        
         // if (prev) {
         //     prev.forEach((s) => this.$fastController.removeStyles(s));
         // }

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -49,7 +49,7 @@ export class AdaptiveComponent extends FASTElement {
     @observable
     public styles?: Styles;
     protected stylesChanged(prev: Styles, next: Styles) {
-        console.log("stylesChanged", next);
+        // console.log("stylesChanged", next);
         
         // if (prev) {
         //     prev.forEach((s) => this.$fastController.removeStyles(s));

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Color } from 'culori';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import type { CSSDirective } from '@microsoft/fast-element';
@@ -346,6 +347,14 @@ export const PaletteDirectionValue: Readonly<{
 
 // @public
 export type PaletteDirectionValue = typeof PaletteDirectionValue[keyof typeof PaletteDirectionValue];
+
+// @public (undocumented)
+export class PaletteOkhsl extends BasePalette<SwatchRGB> {
+    // (undocumented)
+    static from(source: SwatchRGB | string): PaletteOkhsl;
+    // (undocumented)
+    static swatchToColor(swatch: SwatchRGB): Color;
+}
 
 // @public
 export class PaletteRGB extends BasePalette<SwatchRGB> {

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -36,12 +36,12 @@
     "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
         "@microsoft/fast-foundation": "3.0.0-alpha.28",
-        "@types/culori": "^2.0.0",
         "culori": "^3.2.0"
     },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.34.4",
         "@types/chai": "^4.3.4",
+        "@types/culori": "^2.0.0",
         "@types/mocha": "^10.0.1",
         "chai": "^4.3.7",
         "mocha": "^10.2.0",

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -35,7 +35,9 @@
     },
     "dependencies": {
         "@microsoft/fast-colors": "^5.3.1",
-        "@microsoft/fast-foundation": "3.0.0-alpha.28"
+        "@microsoft/fast-foundation": "3.0.0-alpha.28",
+        "@types/culori": "^2.0.0",
+        "culori": "^3.2.0"
     },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.34.4",

--- a/packages/adaptive-ui/src/color/index.ts
+++ b/packages/adaptive-ui/src/color/index.ts
@@ -1,5 +1,6 @@
 export * from "./recipes/index.js";
 export * from "./utilities/index.js";
+export * from "./palette-okhsl.js";
 export * from "./palette-rgb.js";
 export * from "./palette.js";
 export * from "./recipe.js";

--- a/packages/adaptive-ui/src/color/palette-okhsl.ts
+++ b/packages/adaptive-ui/src/color/palette-okhsl.ts
@@ -1,0 +1,47 @@
+import { clampChroma, Color, interpolate, okhsl, parse, rgb, samples} from "culori";
+import { BasePalette } from "./palette.js";
+import { SwatchRGB } from "./swatch.js";
+
+const stepCount = 56;
+
+export class PaletteOkhsl extends BasePalette<SwatchRGB> {
+    static swatchToColor(swatch: SwatchRGB): Color {
+        return {mode: "rgb", r: swatch.r, g: swatch.g, b: swatch.b};
+    }
+
+    static from(source: SwatchRGB | string): PaletteOkhsl {
+        let swatch;
+        if (source instanceof SwatchRGB) {
+            swatch = source;
+        } else {
+            const color = parse(source);
+            if (color === undefined) {
+                throw new Error(`Unable to parse Color as hex string: ${source}`);
+            }
+            swatch = SwatchRGB.from(rgb(color));
+        }
+
+        const sourceRgb = this.swatchToColor(swatch);
+        const sourceHsl = okhsl(sourceRgb);
+
+        const lo = Object.assign({}, sourceHsl, {l: 0.01});
+        const hi = Object.assign({}, sourceHsl, {l: 0.99});
+
+        const y = 1 - sourceHsl.l; // Position for the source color in the ramp
+        const stepCountLeft = Math.round(y * stepCount);
+        const stepCountRight = stepCount- stepCountLeft;
+        const colorsLeft: any = [hi, sourceHsl];
+        const colorsRight: any = [sourceHsl, lo];
+        const interpolateLeft = interpolate(colorsLeft, "okhsl");
+        const interpolateRight = interpolate(colorsRight, "okhsl");
+        const samplesLeft = samples(stepCountLeft).map(interpolateLeft);
+        const samplesRight = samples(stepCountRight).map(interpolateRight);
+
+        const ramp = [...samplesLeft, ...samplesRight.slice(1)];
+        const swatches = ramp.map((value) =>
+            SwatchRGB.from(rgb(clampChroma(value, "okhsl")))
+        );
+
+        return new PaletteOkhsl(swatch, swatches);
+    }
+}

--- a/packages/adaptive-ui/src/design-tokens/palette.ts
+++ b/packages/adaptive-ui/src/design-tokens/palette.ts
@@ -1,50 +1,24 @@
-import { parseColorHexRGB } from "@microsoft/fast-colors";
-import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import type { DesignTokenResolver } from "@microsoft/fast-foundation";
 import { DesignTokenType } from "../adaptive-design-tokens.js";
-import { Palette, Swatch, SwatchRGB } from "../color/index.js";
-import { PaletteRGB } from "../color/palette-rgb.js";
+import { Palette, PaletteOkhsl } from "../color/index.js";
 import { createNonCss, createTokenNonCss } from "../token-helpers.js";
 
 /** @public */
 export const neutralBaseColor = createTokenNonCss<string>("neutral-base-color", DesignTokenType.color).withDefault("#808080");
 
-/** @public @deprecated The "BaseSwatch" will be removed and the "Palette" will use the "BaseColor" directly */
-export const neutralBaseSwatch = createNonCss<Swatch>("neutral-base-swatch").withDefault(
-    (resolve: DesignTokenResolver) => {
-        const hex = resolve(neutralBaseColor);
-        const rgb = parseColorHexRGB(hex);
-        if (rgb === null) {
-            throw new Error(`Unable to parse neutralBaseColor as hex string: ${hex}`);
-        }
-        return SwatchRGB.from(rgb);
-    }
-);
-
 /** @public */
 export const neutralPalette = createNonCss<Palette>("neutral-palette").withDefault(
     (resolve: DesignTokenResolver) =>
-        PaletteRGB.from(resolve(neutralBaseSwatch) as SwatchRGB)
+        PaletteOkhsl.from(resolve(neutralBaseColor))
 );
 
 /** @public */
 export const accentBaseColor = createTokenNonCss<string>("accent-base-color", DesignTokenType.color).withDefault("#F26C0D");
 
-/** @public @deprecated The "BaseSwatch" will be removed and the "Palette" will use the "BaseColor" directly */
-export const accentBaseSwatch = createNonCss<Swatch>("accent-base-swatch").withDefault(
-    (resolve: DesignTokenResolver) => {
-        const hex = resolve(accentBaseColor);
-        const rgb = parseColorHexRGB(hex);
-        if (rgb === null) {
-            throw new Error(`Unable to parse accentBaseColor as hex string: ${hex}`);
-        }
-        return SwatchRGB.from(rgb);
-    }
-);
-
 /** @public */
 export const accentPalette = createNonCss<Palette>("accent-palette").withDefault(
     (resolve: DesignTokenResolver) =>
-        PaletteRGB.from(resolve(accentBaseSwatch) as SwatchRGB)
+        PaletteOkhsl.from(resolve(accentBaseColor))
 );
 
 /** @public */
@@ -53,5 +27,5 @@ export const highlightBaseColor = createTokenNonCss<string>("highlight-base-colo
 /** @public */
 export const highlightPalette = createNonCss<Palette>("highlight-palette").withDefault(
     (resolve: DesignTokenResolver) =>
-        PaletteRGB.from(resolve(highlightBaseColor))
+        PaletteOkhsl.from(resolve(highlightBaseColor))
 );


### PR DESCRIPTION
# Pull Request

## Description

Updated the color palette logic to use the OKHSL color model. OK is a new-ish perceptual color system that improves upon LAB in a few ways. The HSL variation maps the coordinates to the familiar HSL model, but the perceptual aspect means it produces more human accurate results than the RGB model.

Here is a comparison of the old palettes to the new:
![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/5d6c5341-dc57-4678-884c-bd88a8b4b3db)

And here is the Microsoft default blue:
![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/53794174-b4fe-4b75-a790-45d917da3bbf)

The new palette is more of the fade to white and black and doesn't produce as much hue and saturation shift. It's not as differentiated in the dark end as the old model, but that's a subjective opinion based on my screen and lighting conditions, etc.

Notice also in the palettes that the source color is marked with a `~` in the old palette meaning it's approximate, and a `⚬` in the new one indicating an exact match, resolving a common frustration with the old model.

Introducing the `culori` library, with plans to migrate from `fast-colors`.

## Test Plan

Tested in Adaptive UI Explorer and Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Migrate to `culori` from `fast-colors`.