### PR TITLE
Designer - Fix the fill color evaluation

### DIFF
--- a/change/@adaptive-web-adaptive-ui-225efc1f-77b4-4221-bde7-3e390f91e404.json
+++ b/change/@adaptive-web-adaptive-ui-225efc1f-77b4-4221-bde7-3e390f91e404.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Designer - Fix the fill color evaluation",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/src/core/model.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/model.ts
@@ -152,7 +152,7 @@ export type ReadonlyAppliedStyleValues = ReadonlyMap<StyleProperty, AppliedStyle
 /**
  * Map of additional data exchanged between the design tool and plugin. Not persisted.
  */
-export class AdditionalData extends SerializableMap<string, any> {}
+export class AdditionalData extends SerializableMap<string, string> {}
 
 /**
  * Defines the data stored by the plugin on a node instance.

--- a/packages/adaptive-ui-figma-designer/src/core/model.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/model.ts
@@ -2,9 +2,9 @@ import { StyleProperty } from "@adaptive-web/adaptive-ui";
 import { PluginNode } from "./node.js";
 
 /**
- * A key for passing the fill color from the tool to the plugin. Keeping it out of main design tokens to avoid a lo more special handling.
+ * A key for passing the fill color from the tool to the plugin. Keeping it out of main design tokens to avoid a lot more special handling.
  */
-export const TOOL_FILL_COLOR_TOKEN = "fill-color";
+export const TOOL_PARENT_FILL_COLOR = "tool-parent-fill-color";
 
 /**
  * A design token value.

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -229,8 +229,8 @@ export abstract class PluginNode {
      */
     public get additionalData(): AdditionalData {
         if (!this._additionalData.has(TOOL_PARENT_FILL_COLOR) && this.parent?.fillColor) {
-            // console.log("PluginNode.get_additionalData - adding:", TOOL_PARENT_FILL_COLOR, this.parent?.fillColor.toStringHexRGB());
-            this._additionalData.set(TOOL_PARENT_FILL_COLOR, this.parent.fillColor.toStringHexRGB());
+            // console.log("PluginNode.get_additionalData - adding:", TOOL_PARENT_FILL_COLOR, this.debugInfo, this.parent?.fillColor.toStringHexARGB());
+            this._additionalData.set(TOOL_PARENT_FILL_COLOR, this.parent.fillColor.toStringHexARGB());
         }
         return this._additionalData;
     }

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -9,7 +9,7 @@ import {
     ReadonlyAppliedDesignTokens,
     ReadonlyAppliedStyleModules,
     ReadonlyDesignTokenValues,
-    TOOL_FILL_COLOR_TOKEN,
+    TOOL_PARENT_FILL_COLOR,
 } from "./model.js";
 
 const DesignTokenCache: Map<string, ReadonlyDesignTokenValues> = new Map();
@@ -91,7 +91,7 @@ export abstract class PluginNode {
             ]);
         }
 
-        // console.log("  PluginNode.inheritedDesignTokens", this.id, this.type, designTokens.entries());
+        // console.log("  PluginNode.inheritedDesignTokens", this.debugInfo, designTokens.entries());
 
         DesignTokenCache.set(this.id, designTokens);
 
@@ -137,9 +137,14 @@ export abstract class PluginNode {
     public abstract readonly type: string;
 
     /**
-     * The name of the node, useful for debugging.
+     * The name of this node, useful for debugging.
      */
     public abstract readonly name: string;
+
+    /**
+     * The fill color of this node.
+     */
+    public abstract readonly fillColor: ColorRGBA64 | null;
 
     /**
      * Gets whether this type of node can have children or not.
@@ -223,6 +228,10 @@ export abstract class PluginNode {
      * Gets additional data associated with this node.
      */
     public get additionalData(): AdditionalData {
+        if (!this._additionalData.has(TOOL_PARENT_FILL_COLOR) && this.parent?.fillColor) {
+            // console.log("PluginNode.get_additionalData - adding:", TOOL_PARENT_FILL_COLOR, this.parent?.fillColor.toStringHexRGB());
+            this._additionalData.set(TOOL_PARENT_FILL_COLOR, this.parent.fillColor.toStringHexRGB());
+        }
         return this._additionalData;
     }
 
@@ -234,42 +243,9 @@ export abstract class PluginNode {
     public abstract paint(target: StyleProperty, value: string): void;
 
     /**
-     * Gets the effective fill color for the node.
-     * This color is communicated to color recipes as the fillColor context for a node.
-     */
-    public abstract getEffectiveFillColor(): ColorRGBA64 | null;
-
-    /**
      * Handle components that have custom dark mode configuration, like logos or illustration.
      */
     public abstract handleManualDarkMode(): boolean;
-
-    /**
-     * Setup special handling for fill color. It should either be a design token or a fixed color applied in the design tool.
-     * Must be called after design tokens are loaded.
-     */
-    protected setupFillColor(): void {
-        if (this.canHaveChildren) {
-            // console.log("  PluginNode.setupFillColor - checking", this.id, this.type);
-            // If the fill color comes from a design token, don't pass it again.
-            let foundFill = false;
-            this._appliedDesignTokens.forEach((applied, target) => {
-                // console.log("    applied design token", target, "value", applied.value);
-                if (target === StyleProperty.backgroundFill) {
-                    foundFill = true;
-                }
-            });
-            if (!foundFill) {
-                const nodeFillColor = this.getEffectiveFillColor();
-                // console.log("    fill not found - effective color", nodeFillColor?.toStringHexRGB());
-                if (nodeFillColor) {
-                    // eslint-disable-next-line max-len
-                    // console.log("      PluginNode.setupFillColor - setting", TOOL_FILL_COLOR_TOKEN, this.id, this.type, nodeFillColor.toStringHexRGB());
-                    this._additionalData.set(TOOL_FILL_COLOR_TOKEN, nodeFillColor.toStringHexRGB());
-                }
-            }
-        }
-    }
 
     /**
      * Delete entries in the design token cache for this node and any child nodes.

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -460,8 +460,9 @@ export class FigmaPluginNode extends PluginNode {
 
                 // TODO: how do we process multiple paints?
                 if (paints.length === 1) {
-                    const parsed = ColorRGBA64.fromObject(paints[0].color);
+                    const parsed = ColorRGBA64.fromObject(Object.assign({}, paints[0].color, {a: paints[0].opacity}));
                     if (parsed instanceof ColorRGBA64) {
+                        // console.log("FigmaPluginNode.getFillColor", this.debugInfo, parsed.toStringHexARGB());
                         return parsed;
                     }
                 }
@@ -518,7 +519,9 @@ export class FigmaPluginNode extends PluginNode {
     }
 
     private setBoxSizing() {
-        (this._node as BaseFrameMixin).strokesIncludedInLayout = true;
+        if (isContainerNode(this._node)) {
+            (this._node as BaseFrameMixin).strokesIncludedInLayout = true;
+        }
     }
 
     private paintColor(target: StyleProperty, value: string): void {

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
@@ -3,7 +3,8 @@ import { calc } from '@csstools/css-calc';
 import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { customElement, FASTElement, html, observable } from "@microsoft/fast-element";
 import { CSSDesignToken, type DesignToken, type StaticDesignTokenValue, type ValuesOf } from "@microsoft/fast-foundation";
-import { AppliedDesignToken, AppliedStyleValue, DesignTokenValue, PluginUINodeData, TOOL_FILL_COLOR_TOKEN } from "../core/model.js";
+import { fillColor } from "@adaptive-web/adaptive-ui/reference";
+import { AppliedDesignToken, AppliedStyleValue, DesignTokenValue, PluginUINodeData, TOOL_PARENT_FILL_COLOR } from "../core/model.js";
 import { DesignTokenDefinition, DesignTokenRegistry } from "../core/registry/design-token-registry.js";
 import { nameToTitle, registerAppliableTokens, registerTokens } from "../core/registry/recipes.js";
 
@@ -420,6 +421,15 @@ export class UIController {
         // console.log("evaluateEffectiveAppliedStyleValues", nodes.length, nodes);
         nodes.forEach(node => {
             // console.log("  evaluateEffectiveAppliedStyleValues", node);
+
+            // See `evaluateEffectiveAppliedDesignToken` for a note on this.
+            const color = node.additionalData.get(TOOL_PARENT_FILL_COLOR);
+            if (color) {
+                const parentElement = this.getElementForNode(node).parentElement as FASTElement;
+                // console.log("    setting fill color token on parent element", color, parentElement.id);
+                this.setDesignTokenForElement(parentElement, fillColor, color);
+            }
+
             const allApplied = this.collectEffectiveAppliedStyles(node);
             allApplied.forEach((info, target) => {
                 if (info.value) {
@@ -431,7 +441,7 @@ export class UIController {
                         this.evaluateEffectiveAppliedDesignToken(target, info.value, node, info.source);
                     }
                 } else {
-                    // console.warn("Token not found in appliable tokens", info.token);
+                    console.warn("Token not found in appliable tokens", info.source);
                 }
             });
 
@@ -450,7 +460,7 @@ export class UIController {
         } else if (typeof value === "string") {
             if (value.startsWith("calc")) {
                 const ret = calc(value as string);
-                console.log(`    calc ${value} returns ${ret}`);
+                // console.log(`    calc ${value} returns ${ret}`);
                 value = ret;
             }
         }
@@ -464,18 +474,24 @@ export class UIController {
             node.appliedDesignTokens.set(target, appliedToken);
         }
 
-        // TODO: The fillColor context isn't working yet, so only use it for "fixed" layer backgrounds for now.
-        if (target === StyleProperty.backgroundFill && token.name.startsWith("layer-fill-fixed")) {
-            // console.log(`      Fill style property, setting '${TOOL_FILL_COLOR_TOKEN}' design token`);
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const def = this._designTokenRegistry.get(TOOL_FILL_COLOR_TOKEN)!;
-            const element = this.getElementForNode(node);
-            node.designTokens.set(TOOL_FILL_COLOR_TOKEN, { value: applied.value });
-            this.setDesignTokenForElement(element, def.token, applied.value);
-
-            // TODO: Optimize this, currently it will process children twice.
+        // This is necessary for representing nested elements in Figma, but does not realistically represent the way the tokens work.
+        // - A node will come in with the paren't fill color provided in `additionalData`. This accounts for relative color recipes,
+        //   but addressed the fact only selected nodes are processed going down the hierarchy.
+        // - If this node calculates a new background fill we need to update that value.
+        // - See `evaluateEffectiveAppliedStyleValues` where this value is set as a design token value.
+        // 
+        // This is perhaps still the most indirect interaction in Adaptive UI, where most color recipes are based on a container fill,
+        // but there's no way to resolve the _container_ color, so the color has to be on the _child_ node.
+        // This is further complicated by the fact that token values can only be set at the component level, not for a child element.
+        // This is also one of the primary motivations of the style modules and the creation of background/foreground color sets, because
+        // the foreground can be evaluated in the context of the background color, removing the reliance on the `fill-color` token.
+        if (target === StyleProperty.backgroundFill) {
             if (node.children.length > 0) {
-                this.evaluateEffectiveAppliedStyleValues(node.children);
+                // console.log(`        Setting '${TOOL_PARENT_FILL_COLOR}' additional data on children`);
+                node.children.forEach(child => {
+                    // console.log("          Child", child.id, child.name);
+                    child.additionalData.set(TOOL_PARENT_FILL_COLOR, applied.value);
+                });
             }
         }
     }
@@ -516,15 +532,15 @@ export class UIController {
                 const color = parseColorHexRGB((value as unknown) as string);
                 if (color) {
                     // TODO fix this logic
-                    // console.log("    setting DesignToken value (color)", token.name, value);
+                    // console.log("        setting DesignToken value (color)", token.name, value);
                     if (token.name.indexOf("base-color") > -1) {
-                        // console.log("      raw value");
+                        // console.log("          raw value");
                         token.setValueFor(
                             nodeElement,
                             value as StaticDesignTokenValue<T>
                         );
                     } else {
-                        // console.log("      color object");
+                        // console.log("          color object");
                         token.setValueFor(
                             nodeElement,
                             (SwatchRGB.from(color) as unknown) as StaticDesignTokenValue<T>
@@ -533,13 +549,13 @@ export class UIController {
                 } else {
                     const num = Number.parseFloat((value as unknown) as string);
                     if (!Number.isNaN(num) && num.toString() === value) {
-                        // console.log("    setting DesignToken value (number)", token.name, value);
+                        // console.log("        setting DesignToken value (number)", token.name, value);
                         token.setValueFor(
                             nodeElement,
                             (num as unknown) as StaticDesignTokenValue<T>
                         );
                     } else {
-                        // console.log("    setting DesignToken value (unconverted)", token.name, value);
+                        // console.log("        setting DesignToken value (unconverted)", token.name, value);
                         token.setValueFor(nodeElement, value as StaticDesignTokenValue<T>);
                     }
                 }
@@ -547,7 +563,7 @@ export class UIController {
                 token.deleteValueFor(nodeElement);
             }
         } catch (e) {
-            console.warn("    token error", e);
+            console.warn("        token error", e);
             // Ignore, token not found
         }
     }
@@ -604,7 +620,8 @@ export class UIController {
         // console.log("    setting local tokens");
         node.designTokens.forEach(this.designTokenValuesHandler(nodeElement), this);
 
-        // Handle any additional data. Keys are provided as design token ids.
+        // Handle any additional data. Any keys that are for a design token will be set.
+        // console.log("    setting additional data");
         node.additionalData.forEach((value, key) => {
             const def = this._designTokenRegistry.get(key);
             if (def) {
@@ -646,6 +663,7 @@ export class UIController {
         const element = this.getElementForNode(node);
         const val = token.getValueFor(element);
         // console.log("      getDesignTokenValue", node.id, node.type, token.name, "value", this.valueToString(val));
+        // console.log("        fill color", fillColor.getValueFor(element)?.toColorString(), element);
         return val;
     }
 

--- a/packages/adaptive-ui/src/color/palette-okhsl.ts
+++ b/packages/adaptive-ui/src/color/palette-okhsl.ts
@@ -1,6 +1,7 @@
 import { clampChroma, Color, interpolate, okhsl, parse, rgb, samples} from "culori";
 import { BasePalette } from "./palette.js";
 import { SwatchRGB } from "./swatch.js";
+import { _black, _white } from "./utilities/color-constants.js";
 
 const stepCount = 56;
 
@@ -47,6 +48,10 @@ export class PaletteOkhsl extends BasePalette<SwatchRGB> {
         const swatches = ramp.map((value) =>
             SwatchRGB.from(rgb(clampChroma(value, "okhsl")))
         );
+
+        // It's important that the ends are full white and black.
+        swatches[0] = _white;
+        swatches[swatches.length - 1] = _black;
 
         return new PaletteOkhsl(swatch, swatches);
     }

--- a/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
@@ -61,7 +61,7 @@ export function contrastAndDeltaSwatchSet(
     function getSwatch(index: number): Swatch {
         const swatch = palette.get(index) as SwatchRGB;
         if (zeroAsTransparent === true && index === referenceIndex) {
-            return SwatchRGB.asOverlay(swatch, swatch);
+            return swatch.toTransparent();
         } else {
             return swatch;
         }

--- a/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
@@ -34,7 +34,7 @@ export function deltaSwatchSet(
     function getSwatch(delta: number): Swatch {
         const swatch = palette.get(referenceIndex + dir * delta) as SwatchRGB;
         if (zeroAsTransparent === true && delta === 0) {
-            return SwatchRGB.asOverlay(swatch, swatch);
+            return swatch.toTransparent();
         } else {
             return swatch;
         }

--- a/packages/adaptive-ui/src/color/swatch.ts
+++ b/packages/adaptive-ui/src/color/swatch.ts
@@ -82,7 +82,7 @@ export class SwatchRGB implements Swatch {
      * @returns The color value in string format
      */
     toColorString() {
-        return this.color.a === 0 ? "transparent" : this.color.a < 1 ? this.color.toStringWebRGBA() : this.color.toStringHexRGB();
+        return this.color.a < 1 ? this.color.toStringWebRGBA() : this.color.toStringHexRGB();
     }
 
     /**
@@ -98,6 +98,15 @@ export class SwatchRGB implements Swatch {
      * @returns The color value in a valid css string format
      */
     createCSS = this.toColorString;
+
+    /**
+     * Gets this color as full transparent.
+     *
+     * @returns The color with full transparency
+     */
+    toTransparent() {
+        return new SwatchRGB(this.r, this.g, this.b, 0, this);
+    }
 
     /**
      * Creates a new SwatchRGB from and object with R, G, and B values expressed as a number between 0 to 1.

--- a/packages/adaptive-ui/src/color/utilities/conditional.ts
+++ b/packages/adaptive-ui/src/color/utilities/conditional.ts
@@ -1,5 +1,4 @@
 import { InteractiveSwatchSet } from "../recipe.js";
-import { SwatchRGB } from "../swatch.js";
 import { _white } from "./color-constants.js";
 
 /**
@@ -17,7 +16,7 @@ export function conditionalSwatchSet(
         return set;
     }
 
-    const transparent = SwatchRGB.asOverlay(_white, _white);
+    const transparent = _white.toTransparent();
     return {
         rest: transparent,
         hover: transparent,


### PR DESCRIPTION
# Pull Request

## Description

This PR finally resolves an issue that has existed for a long time regarding evaluating colors based on the container fill color. Most color recipes use the `fill-color` token as an input, but chaining this down is complicated. It's been causing flipping of recipes where one time it's based on the container and next time it's based on itself. This finally resolves the issue by passing the container color as the context and letting a recipe evaluate with that context on the child element. Note that this is different in Figma than the way it works in code, but in code this is one of the reasons the style modules work the way they do with background / foreground color sets.

I added a comment to this in this code as well.

## Reviewer Notes

Basically what I said above. This has long been a complicated issue and I don't see a way around it that works in the coded components, which is why we have the background / foreground style modules. In Figma we need to convey the recipe value from a container layer, or even a manual value applied to a layer.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.