### PR TITLE
Adaptive UI: Update grouped tokens to use period instead of underscore

### DIFF
--- a/change/@adaptive-web-adaptive-ui-f0a16521-5d26-45eb-a365-13fdf9e51031.json
+++ b/change/@adaptive-web-adaptive-ui-f0a16521-5d26-45eb-a365-13fdf9e51031.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI: Update grouped tokens to use period instead of underscore",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -252,7 +252,7 @@ const textTokens: DesignTokenStore = [
 ];
 
 export function nameToTitle(name: string): string {
-    const base = name.replace(/-/g, ' ').replace(/density_/, '');
+    const base = name.replace(/-/g, ' ').replace(/density./, '');
     return base.charAt(0).toUpperCase() + base.substring(1);
 }
 

--- a/packages/adaptive-ui/src/design-tokens/density.ts
+++ b/packages/adaptive-ui/src/design-tokens/density.ts
@@ -3,14 +3,14 @@ import { DensityPaddingAndGapTokenGroup } from "../density/index.js";
 /**
  * @public
  */
-export const densityControl = new DensityPaddingAndGapTokenGroup("density_control", 3, 2, 2, 1);
+export const densityControl = new DensityPaddingAndGapTokenGroup("density.control", 3, 2, 2, 1);
 
 /**
  * @public
  */
-export const densityItemContainer = new DensityPaddingAndGapTokenGroup("density_item-container", 1, 0, 1, 0);
+export const densityItemContainer = new DensityPaddingAndGapTokenGroup("density.item-container", 1, 0, 1, 0);
 
 /**
  * @public
  */
-export const densityLayer = new DensityPaddingAndGapTokenGroup("density_layer", 4, 4, 4, 4);
+export const densityLayer = new DensityPaddingAndGapTokenGroup("density.layer", 4, 4, 4, 4);


### PR DESCRIPTION
# Pull Request

## Description

The convention used on the style modules is a `.` to separate groups, which follows the design token community group alias format. The density tokens were inadvertently using an underscore.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.