### PR TITLE
Small Adaptive UI and Designer fixes

### DIFF
--- a/change/@adaptive-web-adaptive-ui-e3098e7a-5d85-4d96-a94a-e749705ad9bf.json
+++ b/change/@adaptive-web-adaptive-ui-e3098e7a-5d85-4d96-a94a-e749705ad9bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjusted adaptive density styles",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-ac53355b-9197-4617-a00d-9fa90edbb090.json
+++ b/change/@adaptive-web-adaptive-web-components-ac53355b-9197-4617-a00d-9fa90edbb090.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Button style reset",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -104,6 +104,7 @@ import {
     typeRampPlus5LineHeight,
     typeRampPlus6FontSize,
     typeRampPlus6LineHeight,
+    wcagContrastLevel,
 } from "@adaptive-web/adaptive-ui/reference";
 import { DesignTokenDefinition, DesignTokenRegistry, FormControlId } from "./design-token-registry.js";
 import { blackOrWhiteDiscernibleRest, blackOrWhiteReadableRest, docBaseColor, docFill, docForeground } from "./custom-recipes.js";
@@ -120,6 +121,7 @@ const designTokens: DesignTokenStore = [
     neutralBaseColor,
     layerFillBaseLuminance,
     docBaseColor,
+    wcagContrastLevel,
     densityAdjustmentUnits,
     densityControl.horizontalPaddingUnits,
     densityControl.horizontalGapUnits,

--- a/packages/adaptive-ui-figma-designer/src/ui/app.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/app.ts
@@ -244,6 +244,7 @@ const template = html<App>`
                     html<App>`
                         <designer-drawer name="Shape">
                             <div slot="collapsed-content">
+                                ${(x) => appliedStylesTemplate("Shape")}
                                 ${(x) => appliedTokensTemplate(x.cornerRadiusTokens, null)}
                                 ${(x) => appliedTokensTemplate(x.borderThicknessTokens, null)}
                             </div>

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-styles.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-styles.ts
@@ -81,9 +81,13 @@ export class StylesController {
             })
         });
 
-        return new Array(...allModules.entries())
+        const modules = new Array(...allModules.entries())
             .sort(this.styleModuleSort)
             .reduce<StyleModuleDisplayList>(this.styleModuleReduce, new Map());
+
+        // console.log("getAppliedStyleModules", modules);
+        
+        return modules;
     }
 
     /**

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -237,6 +237,7 @@ export const DesignTokenType: {
     readonly fontStyle: "fontStyle";
     readonly fontVariations: "fontVariations";
     readonly recipe: "recipe";
+    readonly string: "string";
 };
 
 // @public

--- a/packages/adaptive-ui/src/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/adaptive-design-tokens.ts
@@ -27,6 +27,7 @@ export const DesignTokenType = {
     fontStyle: "fontStyle",
     fontVariations: "fontVariations",
     recipe: "recipe",
+    string: "string",
 } as const;
 
 /**

--- a/packages/adaptive-ui/src/density/index.ts
+++ b/packages/adaptive-ui/src/density/index.ts
@@ -139,7 +139,7 @@ export class DensityPaddingAndGapTokenGroup implements TokenGroup {
             [StyleProperty.paddingTop, StyleProperty.paddingRight, StyleProperty.paddingBottom, StyleProperty.paddingLeft],
         ).withDefault(
             (resolve: DesignTokenResolver) =>
-                `calc(((${resolve(this.horizontalPaddingUnits)} + ${resolve(densityAdjustmentUnits)}) * ${resolve(designUnit)}) - ${resolve(strokeThickness)})`
+                `calc((${resolve(this.horizontalPaddingUnits) + resolve(densityAdjustmentUnits)} * ${resolve(designUnit)}) - ${resolve(strokeThickness)})`
         );
 
         this.horizontalGapUnits = createTokenNonCss<number>(
@@ -165,7 +165,7 @@ export class DensityPaddingAndGapTokenGroup implements TokenGroup {
             [StyleProperty.paddingTop, StyleProperty.paddingRight, StyleProperty.paddingBottom, StyleProperty.paddingLeft],
         ).withDefault(
             (resolve: DesignTokenResolver) =>
-                `calc(((${resolve(this.verticalPaddingUnits)} + ${resolve(densityAdjustmentUnits)}) * ${resolve(designUnit)}) - ${resolve(strokeThickness)})`
+                `calc((${resolve(this.verticalPaddingUnits) + resolve(densityAdjustmentUnits)} * ${resolve(designUnit)}) - ${resolve(strokeThickness)})`
         );
 
         this.verticalGapUnits = createTokenNonCss<number>(

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -102,7 +102,7 @@ export const WcagContrastLevel = {
 export type WcagContrastLevel = ValuesOf<typeof WcagContrastLevel>;
 
 /** @public */
-export const wcagContrastLevel = createNonCss<WcagContrastLevel>("wcag-contrast-level").withDefault("aa");
+export const wcagContrastLevel = createTokenNonCss<WcagContrastLevel>("wcag-contrast-level", DesignTokenType.string).withDefault("aa");
 
 /** @public */
 export const minContrastSafety = createTokenNonCss<number>("min-contrast-safety", DesignTokenType.number).withDefault(

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,4 +1,4 @@
-import { BorderFill, BorderStyle, BorderThickness, CornerRadius, Fill, Padding, Styles } from "../modules/styles.js";
+import { BorderFill, BorderStyle, BorderThickness, CornerRadius, Fill, Padding, Styles, StyleValue } from "../modules/styles.js";
 import { cornerRadiusControl, cornerRadiusLayer, strokeThickness } from "./appearance.js";
 import {
     accentFillDiscernible,
@@ -9,7 +9,6 @@ import {
     accentStrokeReadable,
     accentStrokeReadableRecipe,
     accentStrokeSafety,
-    accentStrokeSubtle,
     blackOrWhiteDiscernibleRecipe,
     blackOrWhiteReadableRecipe,
     criticalFillDiscernible,
@@ -20,7 +19,6 @@ import {
     criticalStrokeReadable,
     criticalStrokeReadableRecipe,
     criticalStrokeSafety,
-    criticalStrokeSubtle,
     fillColor,
     highlightFillDiscernible,
     highlightFillReadable,
@@ -30,7 +28,6 @@ import {
     highlightStrokeReadable,
     highlightStrokeReadableRecipe,
     highlightStrokeSafety,
-    highlightStrokeSubtle,
     neutralFillDiscernible,
     neutralFillReadable,
     neutralFillStealth,
@@ -227,21 +224,15 @@ export const layerDensityStyles: Styles = Styles.fromProperties(
     "density.layer",
 );
 
-/**
- * Style module for the safety border.
- *
- * By default, sets the border thickness and style. The color is set to the safety recipe, which will turn on for increased contrast.
- *
- * @public
- */
-export const safetyBorderStyles: Styles = Styles.fromProperties(
-    {
+// TODO: There's a bit of an overlap right now where density calculations assume a border thickness,
+// but setting the color is done elsewhere or not at all, producing inconsistent and unpredictable styling.
+const densityBorderStyles = (fillValue: StyleValue) => {
+    return {
         ...BorderThickness.all(strokeThickness),
         ...BorderStyle.all("solid"),
-        ...BorderFill.all(neutralStrokeSafety),
-    },
-    "color.safety-border",
-);
+        ...BorderFill.all(fillValue),
+    }
+};
 
 /**
  * Convenience style module for an accent-filled stealth control (interactive).
@@ -256,7 +247,7 @@ export const safetyBorderStyles: Styles = Styles.fromProperties(
 export const accentFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(accentFillStealth, accentStrokeReadableRecipe),
-        ...BorderFill.all(accentStrokeSafety),
+        ...densityBorderStyles(accentStrokeSafety),
     },
     "color.accent-fill-stealth-control",
 );
@@ -267,14 +258,14 @@ export const accentFillStealthControlStyles: Styles = Styles.fromProperties(
  * By default, only the foreground color meets accessibility, useful for a button or similar:
  * - accent subtle background
  * - accent readable foreground (a11y)
- * - accent subtle border
+ * - accent safety border
  *
  * @public
  */
 export const accentFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(accentFillSubtle, accentStrokeReadableRecipe),
-        ...BorderFill.all(accentStrokeSubtle),
+        ...densityBorderStyles(accentStrokeSafety),
     },
     "color.accent-fill-subtle-control",
 );
@@ -325,7 +316,7 @@ export const accentFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        ...BorderFill.all(accentStrokeDiscernible),
+        ...densityBorderStyles(accentStrokeDiscernible),
         foregroundFill: accentStrokeReadable,
         backgroundFill: fillColor,
     },
@@ -335,7 +326,7 @@ export const accentOutlineDiscernibleControlStyles: Styles = Styles.fromProperti
 /**
  * Convenience style module for an accent-colored text or icon control (interactive).
  *
- * By default, the foreground color meets accessibility, useful for a button, link, or similar:
+ * By default, the foreground color meets accessibility, useful for a link, or similar:
  * - no background
  * - accent readable foreground (a11y)
  * - no border
@@ -362,7 +353,7 @@ export const accentForegroundReadableControlStyles: Styles = Styles.fromProperti
 export const highlightFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(highlightFillStealth, highlightStrokeReadableRecipe),
-        ...BorderFill.all(highlightStrokeSafety),
+        ...densityBorderStyles(highlightStrokeSafety),
     },
     "color.highlight-fill-stealth-control",
 );
@@ -373,14 +364,14 @@ export const highlightFillStealthControlStyles: Styles = Styles.fromProperties(
  * By default, only the foreground color meets accessibility, useful for a button or similar:
  * - highlight subtle background
  * - highlight readable foreground (a11y)
- * - highlight subtle border
+ * - highlight safety border
  *
  * @public
  */
 export const highlightFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(highlightFillSubtle, highlightStrokeReadableRecipe),
-        ...BorderFill.all(highlightStrokeSubtle),
+        ...densityBorderStyles(highlightStrokeSafety),
     },
     "color.highlight-fill-subtle-control",
 );
@@ -431,7 +422,7 @@ export const highlightFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const highlightOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        ...BorderFill.all(highlightStrokeDiscernible),
+        ...densityBorderStyles(highlightStrokeDiscernible),
         foregroundFill: highlightStrokeReadable,
         backgroundFill: fillColor,
     },
@@ -441,7 +432,7 @@ export const highlightOutlineDiscernibleControlStyles: Styles = Styles.fromPrope
 /**
  * Convenience style module for an highlight-colored text or icon control (interactive).
  *
- * By default, the foreground color meets accessibility, useful for a button, link, or similar:
+ * By default, the foreground color meets accessibility, useful for a link, or similar:
  * - no background
  * - highlight readable foreground (a11y)
  * - no border
@@ -468,7 +459,7 @@ export const highlightForegroundReadableControlStyles: Styles = Styles.fromPrope
 export const criticalFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(criticalFillStealth, criticalStrokeReadableRecipe),
-        ...BorderFill.all(criticalStrokeSafety),
+        ...densityBorderStyles(criticalStrokeSafety),
     },
     "color.critical-fill-stealth-control",
 );
@@ -479,14 +470,14 @@ export const criticalFillStealthControlStyles: Styles = Styles.fromProperties(
  * By default, only the foreground color meets accessibility, useful for a button or similar:
  * - critical subtle background
  * - critical readable foreground (a11y)
- * - critical subtle border
+ * - critical safety border
  *
  * @public
  */
 export const criticalFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(criticalFillSubtle, criticalStrokeReadableRecipe),
-        ...BorderFill.all(criticalStrokeSubtle),
+        ...densityBorderStyles(criticalStrokeSafety),
     },
     "color.critical-fill-subtle-control",
 );
@@ -537,7 +528,7 @@ export const criticalFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const criticalOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        ...BorderFill.all(criticalStrokeDiscernible),
+        ...densityBorderStyles(criticalStrokeDiscernible),
         foregroundFill: criticalStrokeReadable,
         backgroundFill: fillColor,
     },
@@ -547,7 +538,7 @@ export const criticalOutlineDiscernibleControlStyles: Styles = Styles.fromProper
 /**
  * Convenience style module for an critical-colored text or icon control (interactive).
  *
- * By default, the foreground color meets accessibility, useful for a button, link, or similar:
+ * By default, the foreground color meets accessibility, useful for a link, or similar:
  * - no background
  * - critical readable foreground (a11y)
  * - no border
@@ -574,7 +565,7 @@ export const criticalForegroundReadableControlStyles: Styles = Styles.fromProper
 export const neutralFillStealthControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(neutralFillStealth, neutralStrokeStrongRecipe),
-        ...BorderFill.all(neutralStrokeSafety),
+        ...densityBorderStyles(neutralStrokeSafety),
     },
     "color.neutral-fill-stealth-control",
 );
@@ -585,14 +576,14 @@ export const neutralFillStealthControlStyles: Styles = Styles.fromProperties(
  * By default, only the foreground color meets accessibility, useful for a button or similar:
  * - neutral subtle background
  * - neutral strong foreground (a11y)
- * - neutral subtle border
+ * - neutral safety border
  *
  * @public
  */
 export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties(
     {
         ...Fill.backgroundAndForeground(neutralFillSubtle, neutralStrokeStrongRecipe),
-        ...BorderFill.all(neutralStrokeSubtle),
+        ...densityBorderStyles(neutralStrokeSafety),
     },
     "color.neutral-fill-subtle-control",
 );
@@ -643,7 +634,7 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
  */
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
-        ...BorderFill.all(neutralStrokeDiscernible),
+        ...densityBorderStyles(neutralStrokeDiscernible),
         foregroundFill: neutralStrokeStrongRest,
         backgroundFill: fillColor,
     },
@@ -867,13 +858,14 @@ export const typeRampPlus6Styles: Styles = Styles.fromProperties(
  */
 export const actionStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         controlDensityStyles,
         typeRampBaseStyles,
         neutralFillSubtleControlStyles,
     ],
-    undefined,
+    {
+        ...densityBorderStyles(neutralStrokeSubtle),
+    },
     "styles.action-control",
 );
 
@@ -882,7 +874,6 @@ export const actionStyles: Styles = Styles.compose(
  */
 export const inputStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         controlDensityStyles,
         typeRampBaseStyles,
@@ -897,7 +888,6 @@ export const inputStyles: Styles = Styles.compose(
  */
 export const inputAutofillStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         autofillOuterDensityStyles,
         typeRampBaseStyles,
@@ -912,7 +902,6 @@ export const inputAutofillStyles: Styles = Styles.compose(
  */
 export const selectableSelectedStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         typeRampBaseStyles,
         highlightFillReadableControlStyles,
@@ -926,7 +915,6 @@ export const selectableSelectedStyles: Styles = Styles.compose(
  */
 export const selectableUnselectedStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         typeRampBaseStyles,
         neutralOutlineDiscernibleControlStyles,
@@ -940,7 +928,6 @@ export const selectableUnselectedStyles: Styles = Styles.compose(
  */
 export const itemStyles: Styles = Styles.compose(
     [
-        safetyBorderStyles,
         controlShapeStyles,
         controlDensityStyles,
         typeRampBaseStyles,

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -21,6 +21,10 @@ export const templateStyles: ElementStyles = css`
         white-space: nowrap;
         outline: none;
         font: inherit;
+        /* reset */
+        border: none;
+        margin: 0;
+        padding: 0;
     }
 
     .control::-moz-focus-inner {


### PR DESCRIPTION
# Pull Request

## Description

- Removed subtle stroke from subtle fill styles
- Fixed border style handling
- Added WCAG contrast token to Designer

## Reviewer Notes

Temporary solution to better address the separation of border color and thickness from adjusting density based on the border thickness. Density now assumes border is specified as the safest way to decouple them.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.