### PR TITLE
Adaptive UI: Consolidate css selectors

### DIFF
--- a/change/@adaptive-web-adaptive-ui-9016eb50-55d5-48a1-9dfc-eb50601c8f61.json
+++ b/change/@adaptive-web-adaptive-ui-9016eb50-55d5-48a1-9dfc-eb50601c8f61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI: Consolidate css selectors",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-a8561622-586a-4f6c-af9f-4171cee09919.json
+++ b/change/@adaptive-web-adaptive-web-components-a8561622-586a-4f6c-af9f-4171cee09919.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI: Consolidate css selectors",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -1,8 +1,9 @@
-import { renderElementStyles } from "@adaptive-web/adaptive-ui";
+import { ElementStylesRenderer } from "@adaptive-web/adaptive-ui";
 import type { Styles } from "@adaptive-web/adaptive-ui";
 import {
     css,
     customElement,
+    ElementStyles,
     ElementViewTemplate,
     FASTElement,
     html,
@@ -49,10 +50,15 @@ export class AdaptiveComponent extends FASTElement {
     @observable
     public styles?: Styles;
     protected stylesChanged(prev: Styles, next: Styles) {
-        // if (prev) {
-        //     prev.forEach((s) => this.$fastController.removeStyles(s));
-        // }
-        const elementStyles = renderElementStyles(next, params);
-        elementStyles.forEach((s) => this.$fastController.addStyles(s));
+        if (prev) {
+            this.$fastController.removeStyles(this._addedStyles);
+        }
+        if (next) {
+            this._addedStyles = new ElementStylesRenderer(next).render(params);
+            this.$fastController.addStyles(this._addedStyles);
+        }
     }
+
+    // Keep track of the styles we added so we can remove them without recreating.
+    private _addedStyles: ElementStyles;
 }

--- a/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
@@ -1,7 +1,7 @@
 import { attr, css, customElement, ElementStyles, FASTElement, html, observable } from "@microsoft/fast-element";
 import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
 import { parseColor } from "@microsoft/fast-colors";
-import { renderElementStyles, Styles } from "@adaptive-web/adaptive-ui";
+import { ElementStylesRenderer, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
 import BlobIcon from "../../assets/blob.svg";
 
@@ -148,11 +148,11 @@ export class TokenGlyph extends FASTElement {
     public styles?: Styles;
     protected stylesChanged(prev: Styles, next: Styles) {
         if (prev) {
-            this._addedStyles.forEach((s) => this.$fastController.removeStyles(s));
+            this.$fastController.removeStyles(this._addedStyles);
         }
         if (next) {
-            this._addedStyles = renderElementStyles(next, params);
-            this._addedStyles.forEach((s) => this.$fastController.addStyles(s));
+            this._addedStyles = new ElementStylesRenderer(next).render(params);
+            this.$fastController.addStyles(this._addedStyles);
         }
     }
 
@@ -160,5 +160,5 @@ export class TokenGlyph extends FASTElement {
     public interactive: boolean = false;
 
     // Keep track of the styles we added so we can remove them without recreating.
-    private _addedStyles: ElementStyles[];
+    private _addedStyles: ElementStyles;
 }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -10,7 +10,7 @@ import { CSSDesignToken } from '@microsoft/fast-foundation';
 import type { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
 import { DesignTokenResolver } from '@microsoft/fast-foundation';
-import type { ElementStyles } from '@microsoft/fast-element';
+import { ElementStyles } from '@microsoft/fast-element';
 import { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public
@@ -247,6 +247,12 @@ export type DesignTokenType = ValuesOf<typeof DesignTokenType> | string;
 export function directionByIsDark(color: RelativeLuminance): PaletteDirectionValue;
 
 // @public
+export class ElementStylesRenderer {
+    constructor(styles: Styles);
+    render(params: StyleModuleEvaluateParameters): ElementStyles;
+}
+
+// @public
 export type ElevationRecipe = Recipe<number, string>;
 
 // @public
@@ -392,9 +398,6 @@ export interface RecipeOptional<TParam, TResult> {
 export interface RelativeLuminance {
     readonly relativeLuminance: number;
 }
-
-// @public
-export function renderElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[];
 
 // @public
 export function resolvePaletteDirection(direction: PaletteDirection): PaletteDirectionValue;

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -1,5 +1,5 @@
-import { css } from "@microsoft/fast-element";
-import type { CSSDirective, ElementStyles } from "@microsoft/fast-element";
+import { css, HostBehavior } from "@microsoft/fast-element";
+import { type CSSDirective, ElementStyles } from "@microsoft/fast-element";
 import { CSSDesignToken } from "@microsoft/fast-foundation";
 import type { StyleProperty } from "../modules/types.js";
 import type { InteractiveTokenGroup } from "../types.js";
@@ -8,70 +8,124 @@ import type { FocusSelector, StyleModuleEvaluateParameters } from "./types.js";
 import { stylePropertyToCssProperty } from "./css.js";
 import { Styles } from "./styles.js";
 
-type StyleModuleEvaluate = (params: StyleModuleEvaluateParameters) => ElementStyles;
-
-function propertySingle<T = string>(
-    property: string,
-    value: string | CSSDesignToken<T> | CSSDirective,
-): StyleModuleEvaluate {
-    return (params: StyleModuleEvaluateParameters): ElementStyles =>
-        css`${makeSelector(params)} { ${property}: ${value}; }`;
-}
-
-function propertyInteractive<T = string>(
-    property: string,
-    values: InteractiveTokenGroup<T>,
-    focusSelector: FocusSelector = "focus-visible",
-): StyleModuleEvaluate {
-    return (params: StyleModuleEvaluateParameters): ElementStyles => css`
-        ${makeSelector(params)} { ${property}: ${values.rest}; }
-        ${
-            params.interactivitySelector !== undefined && values.hover
-                ? css.partial`${makeSelector(params, "hover")} { ${property}: ${values.hover}; }`
-                : ``
-        }
-        ${
-            params.interactivitySelector !== undefined && values.active
-                ? css.partial`${makeSelector(params, "active")} { ${property}: ${values.active}; }`
-                : ``
-        }
-        ${
-            params.interactivitySelector !== undefined && values.focus
-                ? css.partial`${makeSelector(params, focusSelector)} { ${property}: ${values.focus}; }`
-                : ``
-        }
-    `;
-}
-
-function createElementStyleModules(styles: Styles): StyleModuleEvaluate[] {
-    const modules: StyleModuleEvaluate[] = new Array(...styles.effectiveProperties.entries()).map(([key, value]) => {
-        const property = stylePropertyToCssProperty(key as StyleProperty);
-        if (typeof value === "string" || value instanceof CSSDesignToken) {
-            return propertySingle(property, value);
-        } else if (value && typeof (value as any).createCSS === "function") {
-            return propertySingle(property, value as CSSDirective);
-        } else {
-            return propertyInteractive(property, value as InteractiveTokenGroup<any>);
-        }
-    });
-    return modules;
-}
-
-function createElementStyles(modules: StyleModuleEvaluate[], params: StyleModuleEvaluateParameters): ElementStyles[] {
-    return modules.map((module) =>
-        module(params)
-    );
-}
+type StyleModuleEvaluate = (params: StyleModuleEvaluateParameters) => Map<string, CSSDirective>;
 
 /**
- * Convert style definitions to `ElementStyles`.
- *
- * @param styles - A collection of individual styling properties.
- * @param params - Parameters for creating the selectors for component states.
- * @returns An array of `ElementStyles`.
+ * Renders Adaptive UI Styles as ElementStyles.
  *
  * @public
  */
-export function renderElementStyles(styles: Styles, params: StyleModuleEvaluateParameters): ElementStyles[] {
-    return createElementStyles(createElementStyleModules(styles), params);
+export class ElementStylesRenderer {
+    private readonly _evaluateFunctions: StyleModuleEvaluate[];
+
+    /**
+     * The key is the css selector and the value is an array of properties. 
+     */
+    private readonly _rules: Map<string, Array<CSSDirective>> = new Map();
+
+    /**
+     * Creates a new ElementStylesRenderer.
+     *
+     * @param styles - A collection of individual styling properties.
+     */
+    public constructor(styles: Styles) {
+        this._evaluateFunctions = this.createStyleModules(styles);
+    }
+
+    // The structure of this class may seem odd, but the "modular" intention is that you can
+    // inject other logic to produce more complicated or dependent css.
+    // Perhaps these static functions turn into a registration mechanism.
+
+    private static propertySingle(
+        property: string,
+        value: string | CSSDirective,
+    ): StyleModuleEvaluate {
+        return (params: StyleModuleEvaluateParameters): Map<string, CSSDirective> => {
+            return new Map([
+                [makeSelector(params), css.partial`${property}: ${value};`]
+            ]);
+        }
+    }
+
+    private static propertyInteractive(
+        property: string,
+        values: InteractiveTokenGroup<any>,
+        focusSelector: FocusSelector = "focus-visible",
+    ): StyleModuleEvaluate {
+        return (params: StyleModuleEvaluateParameters): Map<string, CSSDirective> => {
+            const selectors = new Map([
+                [makeSelector(params), css.partial`${property}: ${values.rest};`]
+            ]);
+
+            if (params.interactivitySelector !== undefined && values.hover) {
+                selectors.set(makeSelector(params, "hover"), css.partial`${property}: ${values.hover};`);
+            }
+            if (params.interactivitySelector !== undefined && values.active) {
+                selectors.set(makeSelector(params, "active"), css.partial`${property}: ${values.active};`);
+            }
+            if (params.interactivitySelector !== undefined && values.focus) {
+                selectors.set(makeSelector(params, focusSelector), css.partial`${property}: ${values.focus};`);
+            }
+
+            return selectors;
+        }
+    }
+
+    private createStyleModules(styles: Styles): StyleModuleEvaluate[] {
+        const modules: StyleModuleEvaluate[] = new Array(...styles.effectiveProperties.entries()).map(([key, value]) => {
+            const property = stylePropertyToCssProperty(key as StyleProperty);
+            if (typeof value === "string" || value instanceof CSSDesignToken) {
+                return ElementStylesRenderer.propertySingle(property, value);
+            } else if (value && typeof (value as any).createCSS === "function") {
+                return ElementStylesRenderer.propertySingle(property, value as CSSDirective);
+            } else {
+                return ElementStylesRenderer.propertyInteractive(property, value as InteractiveTokenGroup<any>);
+            }
+        });
+        return modules;
+    }
+
+    private appendRule(selector: string, property: CSSDirective) {
+        if (this._rules.has(selector)) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            this._rules.get(selector)!.push(property);
+        } else {
+            this._rules.set(selector, [property]);
+        }
+    }
+
+    /**
+     * Convert style definitions to `ElementStyles`.
+     *
+     * @param params - Parameters for creating the selectors for component states.
+     * @returns The rendered `ElementStyles`.
+     */
+    public render(params: StyleModuleEvaluateParameters): ElementStyles {
+        // Combine the selectors
+        this._evaluateFunctions.forEach((module) => {
+            const map = module(params);
+            for (const entry of map) {
+                this.appendRule(entry[0], entry[1]);
+            }
+        });
+
+        // Create the styles
+        const behaviors: HostBehavior<HTMLElement>[] = [];
+        const add = (behavior: HostBehavior<HTMLElement>): void => {
+            behaviors.push(behavior);
+        };
+
+        const strings = [];
+
+        for (const entry of this._rules) {
+            const properties = entry[1].map((prop) => prop.createCSS(add)).join(" ");
+            const rule = `${entry[0]} { ${properties} }`;
+            strings.push(rule);
+        }
+
+        // This is the same thing the css template helper is doing.
+        // https://github.com/microsoft/fast/blob/b78c921ec4e49ec9d7ec980f079ec114045df42e/packages/web-components/fast-element/src/styles/css.ts#L112
+        const styles = new ElementStyles(strings);
+        return behaviors.length > 0 ? styles.withBehaviors(...behaviors) : styles;
+    }
 }

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -831,7 +831,7 @@ export const dataGridTemplateStyles: ElementStyles;
 export class DesignSystem {
     // Warning: (ae-forgotten-export) The symbol "ElementStaticMap" needs to be exported by the entry point index.d.ts
     constructor(_prefix: string, _registry?: CustomElementRegistry, _statics?: ElementStaticMap);
-    static assembleStyles(defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>): ComposableStyles[];
+    static assembleStyles(defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>): ElementStyles;
     // Warning: (ae-forgotten-export) The symbol "PartialDesignSystem" needs to be exported by the entry point index.d.ts
     configure(options: PartialDesignSystem): this;
     defineComponents(components: Record<string, ((ds: DesignSystem) => FASTElementDefinition) | FASTElementDefinition>): void;

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
@@ -1,5 +1,5 @@
 import { FASTAccordionItem } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./accordion-item.styles.js";
@@ -30,7 +30,7 @@ export function composeAccordionItem(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AccordionItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionItemAnatomy.interactivity, options);
 
     return FASTAccordionItem.compose({
         name: `${ds.prefix}-accordion-item`,

--- a/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
@@ -1,5 +1,5 @@
 import { FASTAccordion } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./accordion.styles.js";
@@ -14,7 +14,7 @@ export function composeAccordion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAccordion>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AccordionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionAnatomy.interactivity, options);
 
     return FASTAccordion.compose({
         name: `${ds.prefix}-accordion`,

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveAnchor } from "./anchor.js";
@@ -14,7 +14,7 @@ export function composeAnchor(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveAnchor>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AnchorAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AnchorAnatomy.interactivity, options);
 
     return AdaptiveAnchor.compose({
         name: `${ds.prefix}-anchor`,

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -1,5 +1,5 @@
 import { FASTAnchoredRegion } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./anchored-region.styles.js";
@@ -14,7 +14,7 @@ export function composeAnchoredRegion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAnchoredRegion>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AnchoredRegionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AnchoredRegionAnatomy.interactivity, options);
 
     return FASTAnchoredRegion.compose({
         name: `${ds.prefix}-anchored-region`,

--- a/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
@@ -1,5 +1,5 @@
 import { FASTAvatar } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./avatar.styles.js";
@@ -14,7 +14,7 @@ export function composeAvatar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAvatar>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, AvatarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AvatarAnatomy.interactivity, options);
 
     return FASTAvatar.compose({
         name: `${ds.prefix}-avatar`,

--- a/packages/adaptive-web-components/src/components/badge/badge.compose.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.compose.ts
@@ -1,5 +1,5 @@
 import { FASTBadge } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./badge.styles.js";
@@ -14,7 +14,7 @@ export function composeBadge(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBadge>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, BadgeAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BadgeAnatomy.interactivity, options);
 
     return FASTBadge.compose({
         name: `${ds.prefix}-badge`,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -1,5 +1,5 @@
 import { FASTBreadcrumbItem } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb-item.styles.js";
@@ -23,7 +23,7 @@ export function composeBreadcrumbItem(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, BreadcrumbItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbItemAnatomy.interactivity, options);
 
     return FASTBreadcrumbItem.compose({
         name: `${ds.prefix}-breadcrumb-item`,

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -1,5 +1,5 @@
 import { FASTBreadcrumb } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb.styles.js";
@@ -14,7 +14,7 @@ export function composeBreadcrumb(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBreadcrumb>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, BreadcrumbAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbAnatomy.interactivity, options);
 
     return FASTBreadcrumb.compose({
         name: `${ds.prefix}-breadcrumb`,

--- a/packages/adaptive-web-components/src/components/button/button.compose.ts
+++ b/packages/adaptive-web-components/src/components/button/button.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveButton } from "./button.js";
@@ -14,7 +14,7 @@ export function composeButton(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveButton>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ButtonAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ButtonAnatomy.interactivity, options);
 
     return AdaptiveButton.compose({
         name: `${ds.prefix}-button`,

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -1,5 +1,5 @@
 import { FASTCalendar } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./calendar.styles.js";
@@ -14,7 +14,7 @@ export function composeCalendar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCalendar>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CalendarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CalendarAnatomy.interactivity, options);
 
     return FASTCalendar.compose({
         name: `${ds.prefix}-calendar`,

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -1,5 +1,5 @@
 import { FASTCard } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./card.styles.js";
@@ -14,7 +14,7 @@ export function composeCard(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCard>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CardAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CardAnatomy.interactivity, options);
 
     return FASTCard.compose({
         name: `${ds.prefix}-card`,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -1,5 +1,5 @@
 import { FASTCheckbox } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./checkbox.styles.js";
@@ -30,7 +30,7 @@ export function composeCheckbox(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, CheckboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CheckboxAnatomy.interactivity, options);
 
     return FASTCheckbox.compose({
         name: `${ds.prefix}-checkbox`,

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -1,5 +1,5 @@
 import { FASTCombobox } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from "@microsoft/fast-element";
+import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./combobox.styles.js";
@@ -23,7 +23,7 @@ export function composeCombobox(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ComboboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ComboboxAnatomy.interactivity, options);
 
     return FASTCombobox.compose({
         name: `${ds.prefix}-combobox`,

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDataGridCell } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid-cell.styles.js";
@@ -14,7 +14,7 @@ export function composeDataGridCell(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridCell>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridCellAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridCellAnatomy.interactivity, options);
 
     return FASTDataGridCell.compose({
         name: `${ds.prefix}-data-grid-cell`,

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDataGridRow } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid-row.styles.js";
@@ -14,7 +14,7 @@ export function composeDataGridRow(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridRow>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy.interactivity, options);
 
     return FASTDataGridRow.compose({
         name: `${ds.prefix}-data-grid-row`,

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDataGrid } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./data-grid.styles.js";
@@ -14,7 +14,7 @@ export function composeDataGrid(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGrid>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DataGridAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridAnatomy.interactivity, options);
 
     return FASTDataGrid.compose({
         name: `${ds.prefix}-data-grid`,

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDialog } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./dialog.styles.js";
@@ -14,7 +14,7 @@ export function composeDialog(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDialog>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DialogAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DialogAnatomy.interactivity, options);
 
     return FASTDialog.compose({
         name: `${ds.prefix}-dialog`,

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDisclosure } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./disclosure.styles.js";
@@ -14,7 +14,7 @@ export function composeDisclosure(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDisclosure>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DisclosureAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DisclosureAnatomy.interactivity, options);
 
     return FASTDisclosure.compose({
         name: `${ds.prefix}-disclosure`,

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -1,5 +1,5 @@
 import { FASTDivider } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./divider.styles.js";
@@ -14,7 +14,7 @@ export function composeDivider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDivider>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, DividerAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DividerAnatomy.interactivity, options);
 
     return FASTDivider.compose({
         name: `${ds.prefix}-divider`,

--- a/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
@@ -1,5 +1,5 @@
 import { FASTFlipper } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./flipper.styles.js";
@@ -30,7 +30,7 @@ export function composeFlipper(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, FlipperAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, FlipperAnatomy.interactivity, options);
 
     return FASTFlipper.compose({
         name: `${ds.prefix}-flipper`,

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./horizontal-scroll.styles.js";
@@ -14,7 +14,7 @@ export function composeHorizontalScroll(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveHorizontalScroll>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, HorizontalScrollAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, HorizontalScrollAnatomy.interactivity, options);
 
     return AdaptiveHorizontalScroll.compose({
         name: `${ds.prefix}-horizontal-scroll`,

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
@@ -1,5 +1,5 @@
 import { FASTListboxOption } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./listbox-option.styles.js";
@@ -14,7 +14,7 @@ export function composeListboxOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxOption>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ListboxOptionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxOptionAnatomy.interactivity, options);
 
     return FASTListboxOption.compose({
         name: `${ds.prefix}-option`,

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -1,5 +1,5 @@
 import { FASTListboxElement } from "@microsoft/fast-foundation";
-import { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./listbox.styles.js";
@@ -14,7 +14,7 @@ export function composeListbox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxElement>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ListboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxAnatomy.interactivity, options);
 
     return FASTListboxElement.compose({
         name: `${ds.prefix}-listbox`,

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveMenuItem } from "./menu-item.js";
@@ -37,7 +37,7 @@ export function composeMenuItem(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, MenuItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, MenuItemAnatomy.interactivity, options);
 
     return AdaptiveMenuItem.compose({
         name: `${ds.prefix}-menu-item`,

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveMenu } from "./menu.js";
@@ -14,7 +14,7 @@ export function composeMenu(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveMenu>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, MenuAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, MenuAnatomy.interactivity, options);
 
     return AdaptiveMenu.compose({
         name: `${ds.prefix}-menu`,

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -1,5 +1,5 @@
 import { FASTNumberField } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./number-field.styles.js";
@@ -30,7 +30,7 @@ export function composeNumberField(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, NumberFieldAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, NumberFieldAnatomy.interactivity, options);
 
     return FASTNumberField.compose({
         name: `${ds.prefix}-number-field`,

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
@@ -1,5 +1,5 @@
 import { FASTPickerListItem } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker-list-item.styles.js";
@@ -14,7 +14,7 @@ export function composePickerListItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerListItem>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerListItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListItemAnatomy.interactivity, options);
 
     return FASTPickerListItem.compose({
         name: `${ds.prefix}-picker-list-item`,

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -1,5 +1,5 @@
 import { FASTPickerList } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker-list.styles.js";
@@ -14,7 +14,7 @@ export function composePickerList(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerList>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerListAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListAnatomy.interactivity, options);
 
     return FASTPickerList.compose({
         name: `${ds.prefix}-picker-list`,

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
@@ -1,5 +1,5 @@
 import { FASTPickerMenuOption } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker-menu-option.styles.js";
@@ -14,7 +14,7 @@ export function composePickerMenuOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenuOption>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerMenuOptionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuOptionAnatomy.interactivity, options);
 
     return FASTPickerMenuOption.compose({
         name: `${ds.prefix}-picker-menu-option`,

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -1,5 +1,5 @@
 import { FASTPickerMenu } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker-menu.styles.js";
@@ -14,7 +14,7 @@ export function composePickerMenu(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenu>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerMenuAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuAnatomy.interactivity, options);
 
     return FASTPickerMenu.compose({
         name: `${ds.prefix}-picker-menu`,

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -1,5 +1,5 @@
 import { FASTPicker } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./picker.styles.js";
@@ -14,7 +14,7 @@ export function composePicker(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPicker>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, PickerAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerAnatomy.interactivity, options);
 
     return FASTPicker.compose({
         name: `${ds.prefix}-picker`,

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -1,5 +1,5 @@
 import { FASTProgressRing } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./progress-ring.styles.js";
@@ -14,7 +14,7 @@ export function composeProgressRing(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgressRing>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ProgressRingAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressRingAnatomy.interactivity, options);
 
     return FASTProgressRing.compose({
         name: `${ds.prefix}-progress-ring`,

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -1,5 +1,5 @@
 import { FASTProgress } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./progress.styles.js";
@@ -14,7 +14,7 @@ export function composeProgress(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgress>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ProgressAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressAnatomy.interactivity, options);
 
     return FASTProgress.compose({
         name: `${ds.prefix}-progress`,

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -1,5 +1,5 @@
 import { FASTRadioGroup } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./radio-group.styles.js";
@@ -14,7 +14,7 @@ export function composeRadioGroup(
     ds: DesignSystem,
     options?: ComposeOptions<FASTRadioGroup>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, RadioGroupAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, RadioGroupAnatomy.interactivity, options);
 
     return FASTRadioGroup.compose({
         name: `${ds.prefix}-radio-group`,

--- a/packages/adaptive-web-components/src/components/radio/radio.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.compose.ts
@@ -1,5 +1,5 @@
 import { FASTRadio } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./radio.styles.js";
@@ -23,7 +23,7 @@ export function composeRadio(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, RadioAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, RadioAnatomy.interactivity, options);
 
     return FASTRadio.compose({
         name: `${ds.prefix}-radio`,

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -1,5 +1,5 @@
 import { FASTSearch } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./search.styles.js";
@@ -14,7 +14,7 @@ export function composeSearch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSearch>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SearchAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SearchAnatomy.interactivity, options);
 
     return FASTSearch.compose({
         name: `${ds.prefix}-search`,

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -1,4 +1,4 @@
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { AdaptiveSelect } from "./select.js";
@@ -23,7 +23,7 @@ export function composeSelect(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SelectAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SelectAnatomy.interactivity, options);
 
     return AdaptiveSelect.compose({
         name: `${ds.prefix}-select`,

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -1,5 +1,5 @@
 import { FASTSkeleton } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./skeleton.styles.js";
@@ -14,7 +14,7 @@ export function composeSkeleton(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSkeleton>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SkeletonAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SkeletonAnatomy.interactivity, options);
 
     return FASTSkeleton.compose({
         name: `${ds.prefix}-skeleton`,

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -1,5 +1,5 @@
 import { FASTSliderLabel } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./slider-label.styles.js";
@@ -14,7 +14,7 @@ export function composeSliderLabel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSliderLabel>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SliderLabelAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SliderLabelAnatomy.interactivity, options);
 
     return FASTSliderLabel.compose({
         name: `${ds.prefix}-slider-label`,

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -1,5 +1,5 @@
 import { FASTSlider } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./slider.styles.js";
@@ -14,7 +14,7 @@ export function composeSlider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSlider>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SliderAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SliderAnatomy.interactivity, options);
 
     return FASTSlider.compose({
         name: `${ds.prefix}-slider`,

--- a/packages/adaptive-web-components/src/components/switch/switch.compose.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.compose.ts
@@ -1,5 +1,5 @@
 import { FASTSwitch } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./switch.styles.js";
@@ -14,7 +14,7 @@ export function composeSwitch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSwitch>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, SwitchAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SwitchAnatomy.interactivity, options);
 
     return FASTSwitch.compose({
         name: `${ds.prefix}-switch`,

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTabPanel } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tab-panel.styles.js";
@@ -14,7 +14,7 @@ export function composeTabPanel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabPanel>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TabPanelAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabPanelAnatomy.interactivity, options);
 
     return FASTTabPanel.compose({
         name: `${ds.prefix}-tab-panel`,

--- a/packages/adaptive-web-components/src/components/tab/tab.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTab } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tab.styles.js";
@@ -14,7 +14,7 @@ export function composeTab(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTab>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TabAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabAnatomy.interactivity, options);
 
     return FASTTab.compose({
         name: `${ds.prefix}-tab`,

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTabs } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tabs.styles.js";
@@ -14,7 +14,7 @@ export function composeTabs(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabs>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TabsAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabsAnatomy.interactivity, options);
 
     return FASTTabs.compose({
         name: `${ds.prefix}-tabs`,

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTextArea } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./text-area.styles.js";
@@ -14,7 +14,7 @@ export function composeTextArea(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextArea>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TextAreaAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TextAreaAnatomy.interactivity, options);
 
     return FASTTextArea.compose({
         name: `${ds.prefix}-text-area`,

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTextField } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./text-field.styles.js";
@@ -14,7 +14,7 @@ export function composeTextField(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextField>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TextFieldAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TextFieldAnatomy.interactivity, options);
 
     return FASTTextField.compose({
         name: `${ds.prefix}-text-field`,

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -1,5 +1,5 @@
 import { FASTToolbar } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./toolbar.styles.js";
@@ -14,7 +14,7 @@ export function composeToolbar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTToolbar>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, ToolbarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ToolbarAnatomy.interactivity, options);
 
     return FASTToolbar.compose({
         name: `${ds.prefix}-toolbar`,

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTooltip } from '@microsoft/fast-foundation';
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tooltip.styles.js";
@@ -14,7 +14,7 @@ export function composeTooltip(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTooltip>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TooltipAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TooltipAnatomy.interactivity, options);
 
     return FASTTooltip.compose({
         name: `${ds.prefix}-tooltip`,

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTreeItem } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tree-item.styles.js";
@@ -23,7 +23,7 @@ export function composeTreeItem(
         }
     }
 
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TreeItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TreeItemAnatomy.interactivity, options);
 
     return FASTTreeItem.compose({
         name: `${ds.prefix}-tree-item`,

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -1,5 +1,5 @@
 import { FASTTreeView } from "@microsoft/fast-foundation";
-import type { ComposableStyles, FASTElementDefinition } from '@microsoft/fast-element';
+import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { aestheticStyles, templateStyles } from "./tree-view.styles.js";
@@ -14,7 +14,7 @@ export function composeTreeView(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTreeView>
 ): FASTElementDefinition {
-    const styles: ComposableStyles[] = DesignSystem.assembleStyles(defaultStyles, TreeViewAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TreeViewAnatomy.interactivity, options);
 
     return FASTTreeView.compose({
         name: `${ds.prefix}-tree-view`,

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -1,6 +1,6 @@
 import {
     type ComposableStyles,
-    type ElementStyles,
+    ElementStyles,
     type ElementViewTemplate,
     FASTElementDefinition,
     type PartialFASTElementDefinition,
@@ -8,8 +8,8 @@ import {
 } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from "@microsoft/fast-foundation";
 import {
+    ElementStylesRenderer,
     type InteractivityDefinition,
-    renderElementStyles,
     type StyleModuleEvaluateParameters,
     type StyleModuleTarget,
     Styles,
@@ -142,7 +142,7 @@ export class DesignSystem {
      */
     public static assembleStyles(
         defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>
-    ): ComposableStyles[] {
+    ): ElementStyles {
         const componentStyles: ComposableStyles[] = options?.styles ? 
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :
             defaultStyles;
@@ -150,14 +150,12 @@ export class DesignSystem {
         if (options?.styleModules) {
             for (const [target, styles] of options.styleModules) {
                 const params: StyleModuleEvaluateParameters = Object.assign({}, interactivity, target);
-                const renderedStyles = renderElementStyles(styles, params);
-                for (const s of renderedStyles) {
-                    componentStyles.push(s);
-                }
+                const renderedStyles = new ElementStylesRenderer(styles).render(params);
+                componentStyles.push(renderedStyles);
             }
         }
 
-        return componentStyles;
+        return new ElementStyles(componentStyles);
     }
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Update css rendering to group all properties under the same selector.

Before:
![before](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/0bea441c-4ed3-4e1b-bdb9-27de5b3fb3a1)

Now:
![update](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/c3932988-bb57-472a-8473-3daff1bc3160)

## Reviewer Notes

Cleaned up a typing that affected all `compose` files. Same change everywhere.

## Test Plan

Tested in Explorer and Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.