### PR TITLE
Designer: Added remove support for styles and tokens

### DIFF
--- a/packages/adaptive-ui-figma-designer/src/core/controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/controller.ts
@@ -2,6 +2,11 @@ import { pluginNodesToUINodes, PluginUINodeData } from "./model.js";
 import { PluginNode } from "./node.js";
 
 /**
+ * A constant used to remove a previously applied style or token.
+ */
+export const STYLE_REMOVE = "__REMOVE__";
+
+/**
  * The state object that is passed back and forth between the plugin UI and Controller portions.
  */
 export interface PluginUIState {

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -216,6 +216,8 @@ const densityTokens: DesignTokenStore<string> = [
     densityControl.verticalGap,
     densityItemContainer.horizontalGap,
     densityItemContainer.verticalGap,
+    densityLayer.horizontalGap,
+    densityLayer.verticalGap,
 ];
 
 const cornerRadiusTokens: DesignTokenStore<string> = [

--- a/packages/adaptive-ui-figma-designer/src/ui/app.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/app.ts
@@ -116,7 +116,7 @@ const appliedTokensTemplate = (
                                 slot="actions"
                                 appearance="stealth"
                                 aria-label="Remove design token"
-                                @click=${(x, c) => c.parent.controller.styles.removeAppliedDesignToken(x.target, x.tokenID)}
+                                @click=${(x, c) => c.parent.controller.styles.removeAppliedDesignToken(x.targets, x.tokenID)}
                             >
                                 ${staticallyCompose(SubtractIcon)}
                             </adaptive-button>
@@ -563,19 +563,19 @@ export class App extends FASTElement {
     }
 
     private refreshObservables() {
-        this.backgroundTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.backgroundFill);
-        this.foregroundTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.foregroundFill);
-        this.borderFillTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.borderFillTop);
-        this.borderThicknessTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.borderThicknessTop);
-        this.densityTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.gap);
-        this.cornerRadiusTokens = this.controller.styles.getAppliedDesignTokens(StyleProperty.cornerRadiusTopLeft);
-        this.textTokens = [
-            ...this.controller.styles.getAppliedDesignTokens(StyleProperty.fontFamily),
-            ...this.controller.styles.getAppliedDesignTokens(StyleProperty.fontStyle),
-            ...this.controller.styles.getAppliedDesignTokens(StyleProperty.fontWeight),
-            ...this.controller.styles.getAppliedDesignTokens(StyleProperty.fontSize),
-            ...this.controller.styles.getAppliedDesignTokens(StyleProperty.lineHeight),
-        ];
+        this.backgroundTokens = this.controller.styles.getAppliedDesignTokens([StyleProperty.backgroundFill]);
+        this.foregroundTokens = this.controller.styles.getAppliedDesignTokens([StyleProperty.foregroundFill]);
+        this.borderFillTokens = this.controller.styles.getAppliedDesignTokens(stylePropertyBorderFillAll);
+        this.borderThicknessTokens = this.controller.styles.getAppliedDesignTokens(stylePropertyBorderThicknessAll);
+        this.densityTokens = this.controller.styles.getAppliedDesignTokens([StyleProperty.gap]);
+        this.cornerRadiusTokens = this.controller.styles.getAppliedDesignTokens(stylePropertyCornerRadiusAll);
+        this.textTokens = this.controller.styles.getAppliedDesignTokens([
+            StyleProperty.fontFamily,
+            StyleProperty.fontStyle,
+            StyleProperty.fontWeight,
+            StyleProperty.fontSize,
+            StyleProperty.lineHeight
+        ]);
 
         this.appliedStyleModules = this.controller.styles.getAppliedStyleModules();
     }

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-styles.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-styles.ts
@@ -1,8 +1,9 @@
 import { StyleProperty, Styles } from "@adaptive-web/adaptive-ui";
 import { nameToTitle } from "../core/registry/recipes.js";
 import { DesignTokenDefinition } from "../core/registry/design-token-registry.js";
+import { STYLE_REMOVE } from "../core/controller.js";
 import { AppliedDesignToken } from "../core/model.js";
-import { STYLE_REMOVE, UIController } from "./ui-controller.js";
+import { UIController } from "./ui-controller.js";
 
 /**
  * A display definition for a single style module.


### PR DESCRIPTION
# Pull Request

## Description

Added support for removing styling when an applied style or token is removed from a node.

Previously when you applied a style or token, the visual change would be applied to the node in Figma, but when you removed the style or token the visual implications of it would remain. This created more of a "detach" than "remove" function, and we generally don't want visual artifacts not attached to styling behaviors hanging around.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.