### PR TITLE
Added support for disabled state colors 

### DIFF
--- a/change/@adaptive-web-adaptive-ui-b1f99344-ba31-417c-a4d1-4670dded59c7.json
+++ b/change/@adaptive-web-adaptive-ui-b1f99344-ba31-417c-a4d1-4670dded59c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for `disabled` state colors - Added deltas to base semantic recipes - Added a disabled palette to enable neutral disabled states - Added support for global styles - Added disabled cursor to global styles",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-ef56e4a6-4179-40e6-92e5-39cced762d94.json
+++ b/change/@adaptive-web-adaptive-web-components-ef56e4a6-4179-40e6-92e5-39cced762d94.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for `disabled` state colors and cursor",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -40,7 +40,7 @@ AdaptiveDesignSystem.defineComponents({
 const accentOutlineReadableControlStyles: Styles = Styles.fromProperties({
     backgroundFill: neutralFillSubtle,
     ...BorderFill.all(accentStrokeReadable),
-    foregroundFill: createForegroundSet(accentStrokeReadableRecipe, "rest", neutralFillSubtle),
+    foregroundFill: createForegroundSet(accentStrokeReadableRecipe, neutralFillSubtle),
 });
 
 const myDS = new DesignSystem("my");

--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -49,6 +49,7 @@ const colorBlockTemplate = html<App>`
                 component="${(x, c) => c.parent.componentType}"
                 color="${(x) => x.color}"
                 layer-name="${(x) => x.title}"
+                :disabledState=${(x, c) => c.parent.disabledState}
             ></app-color-block>
         `
     )}
@@ -235,6 +236,9 @@ export class App extends FASTElement implements AppAttributes {
 
     @observable
     public backgrounds: SwatchInfo[];
+
+    @observable
+    public disabledState: boolean = false;
 
     public connectedCallback() {
         super.connectedCallback();

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -1,6 +1,7 @@
-import { ElementStylesRenderer } from "@adaptive-web/adaptive-ui";
+import { ElementStylesRenderer, Interactivity } from "@adaptive-web/adaptive-ui";
 import type { Styles } from "@adaptive-web/adaptive-ui";
 import {
+    attr,
     css,
     customElement,
     ElementStyles,
@@ -28,18 +29,10 @@ const styles = css`
         box-sizing: border-box;
         font-size: 14px;
         justify-items: start;
-        border-width: 1px;
-        border-style: solid;
         border-radius: 4px;
         cursor: pointer;
     }
-
 `;
-
-const params = {
-    interactivitySelector: "",
-    nonInteractivitySelector: "",
-};
 
 @customElement({
     name: "app-adaptive-component",
@@ -47,6 +40,9 @@ const params = {
     styles
 })
 export class AdaptiveComponent extends FASTElement {
+    @attr({ mode: "boolean" })
+    public disabled: boolean = false;
+
     @observable
     public styles?: Styles;
     protected stylesChanged(prev: Styles, next: Styles) {
@@ -54,7 +50,7 @@ export class AdaptiveComponent extends FASTElement {
             this.$fastController.removeStyles(this._addedStyles);
         }
         if (next) {
-            this._addedStyles = new ElementStylesRenderer(next).render(params);
+            this._addedStyles = new ElementStylesRenderer(next).render(Interactivity.disabledAttribute);
             this.$fastController.addStyles(this._addedStyles);
         }
     }

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -31,6 +31,7 @@ import {
     customElement,
     FASTElement,
     html,
+    observable,
     Updates,
     ViewTemplate,
     when,
@@ -41,91 +42,91 @@ import "./style-example.js";
 import "./swatch.js";
 
 const backplateComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => accentFillReadableControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentFillReadableControlStyles}">
         Accent readable
     </app-style-example>
 
-    <app-style-example :styles="${x => accentFillStealthControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentFillStealthControlStyles}">
         Accent stealth
     </app-style-example>
 
-    <app-style-example :styles="${x => accentFillSubtleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentFillSubtleControlStyles}">
         Accent subtle
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillReadableControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillReadableControlStyles}">
         Neutral readable
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillStealthControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillStealthControlStyles}">
         Neutral stealth
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillSubtleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillSubtleControlStyles}">
         Neutral subtle
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightFillReadableControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillReadableControlStyles}">
         Highlight readable
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightFillStealthControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillStealthControlStyles}">
         Highlight stealth
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightFillSubtleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillSubtleControlStyles}">
         Highlight subtle
     </app-style-example>
 `;
 
 const textComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => accentForegroundReadableControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentForegroundReadableControlStyles}">
         Accent control
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralForegroundStrongElementStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralForegroundStrongElementStyles}">
         Neutral element
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralForegroundReadableElementStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralForegroundReadableElementStyles}">
         Hint / placeholder element
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightForegroundReadableControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightForegroundReadableControlStyles}">
         Highlight control
     </app-style-example>
 `;
 
 const formComponents = html<ColorBlock>`
-    <app-style-example :styles="${x => accentOutlineDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentOutlineDiscernibleControlStyles}">
         Accent outline
     </app-style-example>
 
-    <app-style-example :styles="${x => accentFillDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentFillDiscernibleControlStyles}">
         Accent discernible
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralOutlineDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralOutlineDiscernibleControlStyles}">
         Neutral outline
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralFillDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillDiscernibleControlStyles}">
         Neutral discernible
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralDividerSubtleElementStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralDividerSubtleElementStyles}">
         Divider subtle
     </app-style-example>
 
-    <app-style-example :styles="${x => neutralDividerDiscernibleElementStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralDividerDiscernibleElementStyles}">
         Divider discernible
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightOutlineDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightOutlineDiscernibleControlStyles}">
         Highlight outline
     </app-style-example>
 
-    <app-style-example :styles="${x => highlightFillDiscernibleControlStyles}">
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillDiscernibleControlStyles}">
         Highlight discernible
     </app-style-example>
 `;
@@ -203,6 +204,9 @@ export class ColorBlock extends FASTElement {
 
     @attr({ attribute: "layer-name" })
     public layerName: string;
+
+    @observable
+    public disabledState: boolean = false;
 
     public componentTypeTemplate(): ViewTemplate<ColorBlock, any> {
         switch (this.component) {

--- a/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.template.ts
+++ b/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.template.ts
@@ -45,7 +45,7 @@ export function controlPaneTemplate<T extends ControlPane>(): ElementViewTemplat
         <label>
             <input
                 type="checkbox"
-                checked="${(x) => x.showOnlyLayerBackgrounds}"
+                ?checked="${(x) => x.showOnlyLayerBackgrounds}"
                 @change="${(x, c) => {
                     x.updateFormValue("showOnlyLayerBackgrounds", c.eventTarget<HTMLInputElement>().checked);
                 }}"
@@ -92,5 +92,15 @@ export function controlPaneTemplate<T extends ControlPane>(): ElementViewTemplat
                 `
             )}
         </div>
+        <label>
+            <input
+                type="checkbox"
+                ?checked="${(x) => x.disabledState}"
+                @change="${(x, c) => {
+                    x.updateFormValue("disabledState", c.eventTarget<HTMLInputElement>().checked);
+                }}"
+            />
+            <span>Disabled state</span>
+        </label>
     `;
 }

--- a/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.ts
+++ b/packages/adaptive-ui-explorer/src/components/control-pane/control-pane.ts
@@ -20,6 +20,9 @@ export class ControlPane extends FASTElement {
     @observable
     public wcagContrastLevel: WcagContrastLevel = "aa";
 
+    @observable
+    public disabledState: boolean = false;
+
     public updateFormValue(field: string, value: any) {
         this.$emit("formvaluechange", { field: field, value: value });
     }

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -8,7 +8,7 @@ import "./swatch.js";
 const template = html<StyleExample>`
     <template>
         <div class="example">
-            <app-adaptive-component :styles="${x => x.styles}">
+            <app-adaptive-component ?disabled=${x => x.disabledState} :styles=${x => x.styles}>
                 <slot></slot>
             </app-adaptive-component>
         </div>
@@ -54,6 +54,9 @@ interface StyleValue {
     styles,
 })
 export class StyleExample extends FASTElement {
+    @observable
+    public disabledState: boolean = false;
+
     @observable
     public styles?: Styles;
     

--- a/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/custom-recipes.ts
@@ -64,6 +64,7 @@ export const blackOrWhiteDiscernibleRest = createTokenSwatch("black-or-white-dis
             hover: fill,
             active: fill,
             focus: fill,
+            disabled: fill,
         }
         return resolve(blackOrWhiteDiscernibleRecipe).evaluate(resolve, set).rest
     }
@@ -77,6 +78,7 @@ export const blackOrWhiteReadableRest = createTokenSwatch("black-or-white-readab
             hover: fill,
             active: fill,
             focus: fill,
+            disabled: fill,
         }
         return resolve(blackOrWhiteReadableRecipe).evaluate(resolve, set).rest
     }

--- a/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
@@ -1,7 +1,7 @@
 import { attr, css, customElement, ElementStyles, FASTElement, html, observable } from "@microsoft/fast-element";
 import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
 import { parseColor } from "@microsoft/fast-colors";
-import { ElementStylesRenderer, Styles } from "@adaptive-web/adaptive-ui";
+import { ElementStylesRenderer, Interactivity, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
 import BlobIcon from "../../assets/blob.svg";
 
@@ -117,8 +117,7 @@ export enum TokenGlyphType {
 }
 
 const params = {
-    interactivitySelector: "",
-    nonInteractivitySelector: "",
+    ...Interactivity.always,
     part: "swatch",
 };
 

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -34,7 +34,7 @@ export const _black: SwatchRGB;
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
 
 // @public
-export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
+export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, disabledReference: Swatch, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
 
 // @public (undocumented)
 export const BorderFill: {
@@ -102,7 +102,7 @@ export type ComponentParts = Record<string, string>;
 export function contrast(a: RelativeLuminance, b: RelativeLuminance): number;
 
 // @public
-export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
+export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
 
 // @public
 export function contrastSwatch(palette: Palette, reference: Swatch, minContrast: number, direction?: PaletteDirection): Swatch;
@@ -118,7 +118,7 @@ export const CornerRadius: {
 export const create: typeof DesignToken.create;
 
 // @public
-export function createForegroundSet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>, foregroundState: keyof InteractiveSet<any>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
+export function createForegroundSet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
 
 // @public
 export function createForegroundSetBySet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
@@ -189,7 +189,7 @@ export function createTokenSwatch(name: string, intendedFor?: StyleProperty | St
 export function deltaSwatch(palette: Palette, reference: Swatch, delta: number, direction?: PaletteDirection): Swatch;
 
 // @public
-export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
+export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta?: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
 
 // @public
 export const densityAdjustmentUnits: TypedDesignToken<number>;
@@ -262,13 +262,14 @@ export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;
 export const Fill: {
     backgroundAndForeground: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>) => StyleProperties;
     backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
+    foregroundNonInteractiveWithDisabled: (foreground: TypedCSSDesignToken<Swatch>, disabled: TypedCSSDesignToken<Swatch>) => StyleProperties;
 };
 
 // @public
 export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 
 // @public
-export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, direction?: PaletteDirection): InteractiveSwatchSet;
+export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveSwatchSet;
 
 // @public
 export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
@@ -291,6 +292,7 @@ export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<I
 // @public
 export interface InteractiveSet<T> {
     active: T;
+    disabled: T;
     focus: T;
     hover: T;
     rest: T;
@@ -317,8 +319,8 @@ export const Interactivity: {
 
 // @public
 export interface InteractivityDefinition {
+    disabledSelector?: string;
     interactivitySelector?: string;
-    nonInteractivitySelector?: string;
 }
 
 // @public
@@ -403,7 +405,7 @@ export interface RelativeLuminance {
 export function resolvePaletteDirection(direction: PaletteDirection): PaletteDirectionValue;
 
 // @public
-export type StateSelector = "hover" | "active" | FocusSelector;
+export type StateSelector = "hover" | "active" | FocusSelector | "disabled";
 
 // @public
 export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
@@ -460,6 +462,7 @@ export const StyleProperty: {
     readonly width: "width";
     readonly layoutDirection: "layoutDirection";
     readonly opacity: "opacity";
+    readonly cursor: "cursor";
 };
 
 // @public

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
@@ -1,5 +1,5 @@
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { Swatch, SwatchRGB } from "../swatch.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 /**
@@ -26,6 +26,7 @@ export function blackOrWhiteByContrastSet(
     hoverReference: Swatch,
     activeReference: Swatch,
     focusReference: Swatch,
+    disabledReference: Swatch,
     minContrast: number,
     defaultBlack: boolean
 ): InteractiveSwatchSet {
@@ -41,11 +42,16 @@ export function blackOrWhiteByContrastSet(
             ? restForeground
             : defaultRule(activeReference);
     const focusForeground = defaultRule(focusReference);
+    const disabled = defaultRule(disabledReference) as SwatchRGB;
+    // TODO: Reasonable disabled opacity, but not configurable.
+    // Considering replacing these recipes anyway.
+    const disabledForeground = new SwatchRGB(disabled.r, disabled.g, disabled.b, 0.3);
 
     return {
         rest: restForeground,
         hover: hoverForeground,
         active: activeForeground,
         focus: focusForeground,
+        disabled: disabledForeground,
     };
 }

--- a/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
@@ -20,6 +20,8 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param hoverDelta - The hover state offset from the base color
  * @param activeDelta - The active state offset from the base color
  * @param focusDelta - The focus state offset from the base color
+ * @param disabledDelta - The disabled state offset from the base color
+ * @param disabledPalette - The Palette for the disabled Swatch
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @param zeroAsTransparent - Treat a zero offset as transparent, defaults to true
  * @returns The interactive set of Swatches
@@ -34,6 +36,8 @@ export function contrastAndDeltaSwatchSet(
     hoverDelta: number,
     activeDelta: number,
     focusDelta: number,
+    disabledDelta: number,
+    disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference),
     zeroAsTransparent: boolean = false,
 ): InteractiveSwatchSet {
@@ -58,7 +62,7 @@ export function contrastAndDeltaSwatchSet(
         hoverIndex = accessibleIndex1;
     }
 
-    function getSwatch(index: number): Swatch {
+    function getSwatch(palette: Palette, index: number): Swatch {
         const swatch = palette.get(index) as SwatchRGB;
         if (zeroAsTransparent === true && index === referenceIndex) {
             return swatch.toTransparent();
@@ -68,9 +72,10 @@ export function contrastAndDeltaSwatchSet(
     }
 
     return {
-        rest: getSwatch(restIndex),
-        hover: getSwatch(hoverIndex),
-        active: getSwatch(restIndex + dir * activeDelta),
-        focus: getSwatch(restIndex + dir * focusDelta),
+        rest: getSwatch(palette, restIndex),
+        hover: getSwatch(palette, hoverIndex),
+        active: getSwatch(palette, restIndex + dir * activeDelta),
+        focus: getSwatch(palette, restIndex + dir * focusDelta),
+        disabled: getSwatch(disabledPalette, referenceIndex + dir * disabledDelta),
     };
 }

--- a/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
@@ -12,6 +12,8 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param hoverDelta - The hover state offset from `reference`
  * @param activeDelta - The active state offset from `reference`
  * @param focusDelta - The focus state offset from `reference`
+ * @param disabledDelta - The disabled state offset from the base color
+ * @param disabledPalette - The Palette for the disabled Swatch
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @param zeroAsTransparent - Treat a zero offset as transparent, defaults to true
  * @returns The interactive set of Swatches
@@ -25,13 +27,15 @@ export function deltaSwatchSet(
     hoverDelta: number,
     activeDelta: number,
     focusDelta: number,
+    disabledDelta: number = restDelta,
+    disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference),
     zeroAsTransparent: boolean = false,
 ): InteractiveSwatchSet {
     const referenceIndex = palette.closestIndexOf(reference);
     const dir = resolvePaletteDirection(direction);
 
-    function getSwatch(delta: number): Swatch {
+    function getSwatch(palette: Palette, delta: number): Swatch {
         const swatch = palette.get(referenceIndex + dir * delta) as SwatchRGB;
         if (zeroAsTransparent === true && delta === 0) {
             return swatch.toTransparent();
@@ -41,9 +45,10 @@ export function deltaSwatchSet(
     }
 
     return {
-        rest: getSwatch(restDelta),
-        hover: getSwatch(hoverDelta),
-        active: getSwatch(activeDelta),
-        focus: getSwatch(focusDelta),
+        rest: getSwatch(palette, restDelta),
+        hover: getSwatch(palette, hoverDelta),
+        active: getSwatch(palette, activeDelta),
+        focus: getSwatch(palette, focusDelta),
+        disabled: getSwatch(disabledPalette, disabledDelta),
     };
 }

--- a/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
@@ -15,8 +15,8 @@ describe("idealColorDeltaSwatchSet", (): void => {
     const accentPalette = PaletteRGB.from(accentBase);
 
     it("should increase contrast on hover state and decrease contrast on active state in either mode", (): void => {
-        const lightModeColors = idealColorDeltaSwatchSet(accentPalette, _white, 4.5, accentPalette.source, 0, 6, -4, 0);
-        const darkModeColors = idealColorDeltaSwatchSet(accentPalette, _black, 4.5, accentPalette.source, 0, 6, -4, 0);
+        const lightModeColors = idealColorDeltaSwatchSet(accentPalette, _white, 4.5, accentPalette.source, 0, 6, -4, 0, 1);
+        const darkModeColors = idealColorDeltaSwatchSet(accentPalette, _black, 4.5, accentPalette.source, 0, 6, -4, 0, 1);
 
         expect(lightModeColors.hover.contrast(_white)).to.be.greaterThan(lightModeColors.rest.contrast(_white));
         expect(darkModeColors.hover.contrast(_black)).to.be.greaterThan(darkModeColors.rest.contrast(_black));
@@ -43,7 +43,8 @@ describe("idealColorDeltaSwatchSet", (): void => {
                     0,
                     6,
                     -4,
-                    0
+                    0,
+                    1
                 );
                 const largeColors = idealColorDeltaSwatchSet(
                     accentPalette,
@@ -53,7 +54,8 @@ describe("idealColorDeltaSwatchSet", (): void => {
                     0,
                     6,
                     -4,
-                    0
+                    0,
+                    1
                 );
                 expect(
                     swatch.contrast(smallColors.rest)

--- a/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.ts
@@ -25,6 +25,8 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param hoverDelta - The hover state offset from the base color
  * @param activeDelta - The active state offset from the base color
  * @param focusDelta - The focus state offset from the base color
+ * @param disabledDelta - The disabled state offset from the base color
+ * @param disabledPalette - The Palette for the disabled Swatch
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @returns The interactive set of Swatches
  *
@@ -39,6 +41,8 @@ export function idealColorDeltaSwatchSet(
     hoverDelta: number,
     activeDelta: number,
     focusDelta: number,
+    disabledDelta: number,
+    disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference)
 ): InteractiveSwatchSet {
     const dir = resolvePaletteDirection(direction);
@@ -72,5 +76,6 @@ export function idealColorDeltaSwatchSet(
         hover: palette.get(hoverIndex),
         active: palette.get(restIndex + dir * activeDelta),
         focus: palette.get(restIndex + dir * focusDelta),
+        disabled: disabledPalette.get(restIndex + dir * disabledDelta),
     };
 }

--- a/packages/adaptive-ui/src/color/utilities/conditional.ts
+++ b/packages/adaptive-ui/src/color/utilities/conditional.ts
@@ -22,5 +22,6 @@ export function conditionalSwatchSet(
         hover: transparent,
         active: transparent,
         focus: transparent,
+        disabled: transparent,
     };
 }

--- a/packages/adaptive-ui/src/color/utilities/opacity.ts
+++ b/packages/adaptive-ui/src/color/utilities/opacity.ts
@@ -38,6 +38,7 @@ export function interactiveSwatchSetAsOverlay(
             hover: swatchAsOverlay(set.hover, reference, asOverlay),
             active: swatchAsOverlay(set.active, reference, asOverlay),
             focus: swatchAsOverlay(set.focus, reference, asOverlay),
+            disabled: swatchAsOverlay(set.disabled, reference, asOverlay),
         };
     }
     return set;

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -22,7 +22,7 @@ import {
 } from "../token-helpers-color.js";
 import { createNonCss, createTokenNonCss, createTokenSwatch } from "../token-helpers.js";
 import { DesignTokenType, TypedDesignToken } from "../adaptive-design-tokens.js";
-import { accentPalette, criticalPalette, highlightPalette, neutralPalette } from "./palette.js";
+import { accentPalette, criticalPalette, disabledPalette, highlightPalette, neutralPalette } from "./palette.js";
 
 /**
  * Creates a DesignToken that can be used for the _accent_ palette configuration of a shared color recipe.
@@ -152,8 +152,9 @@ export const blackOrWhiteDiscernibleRecipe = createTokenColorRecipeBySet<Interac
             reference.hover,
             reference.active,
             reference.focus,
+            reference.disabled,
             resolve(minContrastDiscernible),
-            false
+            false,
         )
 );
 
@@ -175,8 +176,9 @@ export const blackOrWhiteReadableRecipe = createTokenColorRecipeBySet<Interactiv
             reference.hover,
             reference.active,
             reference.focus,
+            reference.disabled,
             resolve(minContrastReadable),
-            false
+            false,
         )
 );
 
@@ -197,6 +199,9 @@ export const fillStealthActiveDelta = createTokenDelta(fillStealthName, "active"
 export const fillStealthFocusDelta = createTokenDelta(fillStealthName, "focus", 0);
 
 /** @public */
+export const fillStealthDisabledDelta = createTokenDelta(fillStealthName, "disabled", 0);
+
+/** @public */
 export const fillStealthRecipe = createTokenColorRecipeForPalette(
     fillStealthName,
     StyleProperty.backgroundFill,
@@ -208,8 +213,10 @@ export const fillStealthRecipe = createTokenColorRecipeForPalette(
             resolve(fillStealthHoverDelta),
             resolve(fillStealthActiveDelta),
             resolve(fillStealthFocusDelta),
+            resolve(fillStealthDisabledDelta),
+            resolve(disabledPalette),
             undefined,
-            true
+            true,
         )
 );
 
@@ -228,6 +235,9 @@ export const fillSubtleActiveDelta = createTokenDelta(fillSubtleName, "active", 
 export const fillSubtleFocusDelta = createTokenDelta(fillSubtleName, "focus", 2);
 
 /** @public */
+export const fillSubtleDisabledDelta = createTokenDelta(fillSubtleName, "disabled", 2);
+
+/** @public */
 export const fillSubtleRecipe = createTokenColorRecipeForPalette(
     fillSubtleName,
     StyleProperty.backgroundFill,
@@ -238,7 +248,9 @@ export const fillSubtleRecipe = createTokenColorRecipeForPalette(
             resolve(fillSubtleRestDelta),
             resolve(fillSubtleHoverDelta),
             resolve(fillSubtleActiveDelta),
-            resolve(fillSubtleFocusDelta)
+            resolve(fillSubtleFocusDelta),
+            resolve(fillSubtleDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -257,6 +269,9 @@ export const fillDiscernibleActiveDelta = createTokenDelta(fillDiscernibleName, 
 export const fillDiscernibleFocusDelta = createTokenDelta(fillDiscernibleName, "focus", 0);
 
 /** @public */
+export const fillDiscernibleDisabledDelta = createTokenDelta(fillDiscernibleName, "disabled", 2);
+
+/** @public */
 export const fillDiscernibleRecipe = createTokenColorRecipeForPalette(
     fillDiscernibleName,
     StyleProperty.backgroundFill,
@@ -268,7 +283,9 @@ export const fillDiscernibleRecipe = createTokenColorRecipeForPalette(
             resolve(fillDiscernibleRestDelta),
             resolve(fillDiscernibleHoverDelta),
             resolve(fillDiscernibleActiveDelta),
-            resolve(fillDiscernibleFocusDelta)
+            resolve(fillDiscernibleFocusDelta),
+            resolve(fillDiscernibleDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -287,6 +304,9 @@ export const fillReadableActiveDelta = createTokenDelta(fillReadableName, "activ
 export const fillReadableFocusDelta = createTokenDelta(fillReadableName, "focus", 0);
 
 /** @public */
+export const fillReadableDisabledDelta = createTokenDelta(fillReadableName, "disabled", 2);
+
+/** @public */
 export const fillReadableRecipe = createTokenColorRecipeForPalette(
     fillReadableName,
     StyleProperty.backgroundFill,
@@ -298,7 +318,9 @@ export const fillReadableRecipe = createTokenColorRecipeForPalette(
             resolve(fillReadableRestDelta),
             resolve(fillReadableHoverDelta),
             resolve(fillReadableActiveDelta),
-            resolve(fillReadableFocusDelta)
+            resolve(fillReadableFocusDelta),
+            resolve(fillReadableDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -317,6 +339,9 @@ export const strokeSafetyActiveDelta = createTokenDelta(strokeSafetyName, "activ
 export const strokeSafetyFocusDelta = createTokenDelta(strokeSafetyName, "focus", 0);
 
 /** @public */
+export const strokeSafetyDisabledDelta = createTokenDelta(strokeSafetyName, "disabled", 0);
+
+/** @public */
 export const strokeSafetyRecipe = createTokenColorRecipeForPalette(
     strokeSafetyName,
     stylePropertyBorderFillAll,
@@ -329,7 +354,9 @@ export const strokeSafetyRecipe = createTokenColorRecipeForPalette(
                 resolve(strokeSafetyRestDelta),
                 resolve(strokeSafetyHoverDelta),
                 resolve(strokeSafetyActiveDelta),
-                resolve(strokeSafetyFocusDelta)
+                resolve(strokeSafetyFocusDelta),
+                resolve(strokeSafetyDisabledDelta),
+                resolve(disabledPalette),
             ),
             resolve(minContrastSafety) > 0
         )
@@ -350,6 +377,9 @@ export const strokeStealthActiveDelta = createTokenDelta(strokeStealthName, "act
 export const strokeStealthFocusDelta = createTokenDelta(strokeStealthName, "focus", 0);
 
 /** @public */
+export const strokeStealthDisabledDelta = createTokenDelta(strokeStealthName, "disabled", 0);
+
+/** @public */
 export const strokeStealthRecipe = createTokenColorRecipeForPalette(
     strokeStealthName,
     stylePropertyBorderFillAll,
@@ -362,6 +392,8 @@ export const strokeStealthRecipe = createTokenColorRecipeForPalette(
             resolve(strokeStealthHoverDelta),
             resolve(strokeStealthActiveDelta),
             resolve(strokeStealthFocusDelta),
+            resolve(strokeStealthDisabledDelta),
+            resolve(disabledPalette),
             undefined,
             true
         )
@@ -382,6 +414,9 @@ export const strokeSubtleActiveDelta = createTokenDelta(strokeSubtleName, "activ
 export const strokeSubtleFocusDelta = createTokenDelta(strokeSubtleName, "focus", 0);
 
 /** @public */
+export const strokeSubtleDisabledDelta = createTokenDelta(strokeSubtleName, "disabled", 8);
+
+/** @public */
 export const strokeSubtleRecipe = createTokenColorRecipeForPalette(
     strokeSubtleName,
     stylePropertyBorderFillAll,
@@ -393,7 +428,9 @@ export const strokeSubtleRecipe = createTokenColorRecipeForPalette(
             resolve(strokeSubtleRestDelta),
             resolve(strokeSubtleHoverDelta),
             resolve(strokeSubtleActiveDelta),
-            resolve(strokeSubtleFocusDelta)
+            resolve(strokeSubtleFocusDelta),
+            resolve(strokeSubtleDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -412,6 +449,9 @@ export const strokeDiscernibleActiveDelta = createTokenDelta(strokeDiscernibleNa
 export const strokeDiscernibleFocusDelta = createTokenDelta(strokeDiscernibleName, "focus", 0);
 
 /** @public */
+export const strokeDiscernibleDisabledDelta = createTokenDelta(strokeDiscernibleName, "disabled", 8);
+
+/** @public */
 export const strokeDiscernibleRecipe = createTokenColorRecipeForPalette(
     strokeDiscernibleName,
     stylePropertyBorderFillAll,
@@ -423,7 +463,9 @@ export const strokeDiscernibleRecipe = createTokenColorRecipeForPalette(
             resolve(strokeDiscernibleRestDelta),
             resolve(strokeDiscernibleHoverDelta),
             resolve(strokeDiscernibleActiveDelta),
-            resolve(strokeDiscernibleFocusDelta)
+            resolve(strokeDiscernibleFocusDelta),
+            resolve(strokeDiscernibleDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -442,6 +484,9 @@ export const strokeReadableActiveDelta = createTokenDelta(strokeReadableName, "a
 export const strokeReadableFocusDelta = createTokenDelta(strokeReadableName, "focus", 0);
 
 /** @public */
+export const strokeReadableDisabledDelta = createTokenDelta(strokeReadableName, "disabled", 8);
+
+/** @public */
 export const strokeReadableRecipe = createTokenColorRecipeForPalette(
     strokeReadableName,
     [...stylePropertyBorderFillAll, StyleProperty.foregroundFill],
@@ -453,7 +498,9 @@ export const strokeReadableRecipe = createTokenColorRecipeForPalette(
             resolve(strokeReadableRestDelta),
             resolve(strokeReadableHoverDelta),
             resolve(strokeReadableActiveDelta),
-            resolve(strokeReadableFocusDelta)
+            resolve(strokeReadableFocusDelta),
+            resolve(strokeReadableDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 
@@ -475,6 +522,9 @@ export const strokeStrongActiveDelta = createTokenDelta(strokeStrongName, "activ
 export const strokeStrongFocusDelta = createTokenDelta(strokeStrongName, "focus", 0);
 
 /** @public */
+export const strokeStrongDisabledDelta = createTokenDelta(strokeStrongName, "disabled", 8);
+
+/** @public */
 export const strokeStrongRecipe = createTokenColorRecipeForPalette(
     strokeStrongName,
     [...stylePropertyBorderFillAll, StyleProperty.foregroundFill],
@@ -486,7 +536,9 @@ export const strokeStrongRecipe = createTokenColorRecipeForPalette(
             resolve(strokeStrongRestDelta),
             resolve(strokeStrongHoverDelta),
             resolve(strokeStrongActiveDelta),
-            resolve(strokeStrongFocusDelta)
+            resolve(strokeStrongFocusDelta),
+            resolve(strokeStrongDisabledDelta),
+            resolve(disabledPalette),
         )
 );
 

--- a/packages/adaptive-ui/src/design-tokens/layer.ts
+++ b/packages/adaptive-ui/src/design-tokens/layer.ts
@@ -94,6 +94,13 @@ export const layerFillActiveDelta = createTokenNonCss<number>("layer-fill-active
 export const layerFillFocusDelta = createTokenNonCss<number>("layer-fill-focus-delta", DesignTokenType.number).withDefault(-3);
 
 /**
+ * The offset from the container for "Interactive" disabled state, {@link layerFillInteractiveDisabled}.
+ *
+ * @public
+ */
+export const layerFillDisabledDelta = createTokenNonCss<number>("layer-fill-disabled-delta", DesignTokenType.number).withDefault(-1);
+
+/**
  * The "Fixed" layers represent background fills commonly used to define app structure.
  *
  * @remarks
@@ -249,7 +256,9 @@ export const layerFillInteractiveRecipe = createNonCss<InteractiveColorRecipe>("
             resolve(layerFillHoverDelta),
             resolve(layerFillActiveDelta),
             resolve(layerFillFocusDelta),
-            PaletteDirectionValue.darker
+            resolve(layerFillDisabledDelta),
+            undefined,
+            PaletteDirectionValue.darker,
         ),
 });
 
@@ -305,6 +314,19 @@ export const layerFillInteractiveFocus = createTokenSwatch("layer-fill-interacti
         resolve(layerFillInteractiveRecipe).evaluate(resolve).focus
 );
 
+/**
+ * The fill of an interactive layer while disabled.
+ *
+ * @remarks
+ * See {@link layerFillDisabledDelta}.
+ *
+ * @public
+ */
+export const layerFillInteractiveDisabled = createTokenSwatch("layer-fill-interactive-disabled", StyleProperty.backgroundFill).withDefault(
+    (resolve: DesignTokenResolver) =>
+        resolve(layerFillInteractiveRecipe).evaluate(resolve).disabled
+);
+
 /** @public */
 export const layerFillInteractive: InteractiveTokenGroup<Swatch> = {
     name: "layer-fill-interactive",
@@ -312,4 +334,5 @@ export const layerFillInteractive: InteractiveTokenGroup<Swatch> = {
     hover: layerFillInteractiveHover,
     active: layerFillInteractiveActive,
     focus: layerFillInteractiveFocus,
+    disabled: layerFillInteractiveDisabled,
 };

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -36,6 +36,7 @@ import {
     neutralStrokeDiscernibleRest,
     neutralStrokeReadableRest,
     neutralStrokeSafety,
+    neutralStrokeStrong,
     neutralStrokeStrongRecipe,
     neutralStrokeStrongRest,
     neutralStrokeSubtle,
@@ -635,7 +636,7 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
         ...densityBorderStyles(neutralStrokeDiscernible),
-        foregroundFill: neutralStrokeStrongRest,
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrongRest, neutralStrokeStrong.disabled),
         backgroundFill: fillColor,
     },
     "color.neutral-outline-discernible-control",
@@ -653,7 +654,7 @@ export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties(
     {
-        foregroundFill: neutralStrokeReadableRest,
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeReadableRest, neutralStrokeStrong.disabled),
     },
     "color.neutral-foreground-readable-control",
 );
@@ -670,7 +671,7 @@ export const neutralForegroundReadableElementStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties(
     {
-        foregroundFill: neutralStrokeStrongRest,
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrongRest, neutralStrokeStrong.disabled),
     },
     "color.neutral-foreground-strong-element",
 );
@@ -687,7 +688,7 @@ export const neutralForegroundStrongElementStyles: Styles = Styles.fromPropertie
  */
 export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
     {
-        foregroundFill: neutralStrokeSubtleRest,
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeSubtleRest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-subtle-element",
 );
@@ -704,7 +705,7 @@ export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
  */
 export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromProperties(
     {
-        foregroundFill: neutralStrokeDiscernibleRest,
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeDiscernibleRest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-discernible-element",
 );
@@ -869,15 +870,31 @@ export const actionStyles: Styles = Styles.compose(
     "styles.action-control",
 );
 
+const inputCommonStyles = [
+    controlShapeStyles,
+    typeRampBaseStyles,
+    Styles.compose([
+        neutralOutlineDiscernibleControlStyles
+    ], {
+        backgroundFill: {
+            name: "color.input-common-background",
+            rest: fillColor,
+            hover: fillColor,
+            active: fillColor,
+            focus: fillColor,
+            disabled: neutralFillSubtle.disabled,
+        }
+    })
+    ,
+];
+
 /**
  * @public
  */
 export const inputStyles: Styles = Styles.compose(
     [
-        controlShapeStyles,
+        ...inputCommonStyles,
         controlDensityStyles,
-        typeRampBaseStyles,
-        neutralOutlineDiscernibleControlStyles,
     ],
     undefined,
     "styles.input-control",
@@ -888,10 +905,8 @@ export const inputStyles: Styles = Styles.compose(
  */
 export const inputAutofillStyles: Styles = Styles.compose(
     [
-        controlShapeStyles,
+        ...inputCommonStyles,
         autofillOuterDensityStyles,
-        typeRampBaseStyles,
-        neutralOutlineDiscernibleControlStyles,
     ],
     undefined,
     "styles.input-autofill-control",
@@ -963,4 +978,18 @@ export const labelTextStyles: Styles = Styles.compose(
         fontWeight: labelFontWeight,
     },
     "styles.text-label",
+);
+
+/**
+ * Style module for the disabled state.
+ *
+ * By default, sets the cursor to "not-allowed".
+ *
+ * @public
+ */
+export const disabledStyles: Styles = Styles.fromProperties(
+    {
+        cursor: "not-allowed",
+    },
+    "styles.disabled",
 );

--- a/packages/adaptive-ui/src/design-tokens/palette.ts
+++ b/packages/adaptive-ui/src/design-tokens/palette.ts
@@ -38,3 +38,14 @@ export const criticalPalette = createNonCss<Palette>("critical-palette").withDef
     (resolve: DesignTokenResolver) =>
         PaletteOkhsl.from(resolve(criticalBaseColor))
 );
+
+/**
+ * The {@link Palette} to use for disabled state.
+ *
+ * @remarks
+ * By default this maps to the {@link neutralPalette}.
+ * Use a custom palette like `disabledPalette.withDefault(PaletteOkhsl.from("#[HEX_COLOR]"))`.
+ *
+ * @public
+ */
+export const disabledPalette = createNonCss<Palette>("disabled-palette").withDefault(neutralPalette);

--- a/packages/adaptive-ui/src/design-tokens/type.ts
+++ b/packages/adaptive-ui/src/design-tokens/type.ts
@@ -9,7 +9,7 @@ import {
 } from "../token-helpers.js";
 
 /**
- * Standard font wights.
+ * Standard font weights.
  *
  * @public
  */

--- a/packages/adaptive-ui/src/migration/color.ts
+++ b/packages/adaptive-ui/src/migration/color.ts
@@ -14,6 +14,7 @@ import {
     createTokenMinContrast
 } from "../token-helpers-color.js";
 import {
+    accentFillReadable,
     accentFillReadableActive,
     accentFillReadableFocus,
     accentFillReadableHover,
@@ -116,6 +117,7 @@ export const foregroundOnAccentFillReadableRecipe = createTokenColorRecipe(
             resolve(accentFillReadableHover),
             resolve(accentFillReadableActive),
             resolve(accentFillReadableFocus),
+            resolve(accentFillReadable.disabled),
             resolve(minContrastReadable),
             false
         )
@@ -425,7 +427,8 @@ export const neutralFillInputRecipe = createTokenColorRecipe(
                 resolve(neutralFillInputRestDelta),
                 resolve(neutralFillInputHoverDelta),
                 resolve(neutralFillInputActiveDelta),
-                resolve(neutralFillInputFocusDelta)
+                resolve(neutralFillInputFocusDelta),
+                1,
             ),
             params?.reference || resolve(fillColor),
             resolve(neutralAsOverlay)
@@ -475,7 +478,8 @@ export const neutralFillSecondaryRecipe = createTokenColorRecipe(
                 resolve(neutralFillSecondaryRestDelta),
                 resolve(neutralFillSecondaryHoverDelta),
                 resolve(neutralFillSecondaryActiveDelta),
-                resolve(neutralFillSecondaryFocusDelta)
+                resolve(neutralFillSecondaryFocusDelta),
+                1,
             ),
             params?.reference || resolve(fillColor),
             resolve(neutralAsOverlay)
@@ -605,7 +609,8 @@ export const neutralStrokeInputRecipe = createTokenColorRecipe(
                 resolve(neutralStrokeInputRestDelta),
                 resolve(neutralStrokeInputHoverDelta),
                 resolve(neutralStrokeInputActiveDelta),
-                resolve(neutralStrokeInputFocusDelta)
+                resolve(neutralStrokeInputFocusDelta),
+                1,
             ),
             params?.reference || resolve(fillColor),
             resolve(neutralAsOverlay)

--- a/packages/adaptive-ui/src/modules/css.ts
+++ b/packages/adaptive-ui/src/modules/css.ts
@@ -77,5 +77,7 @@ export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
             return "flex-direction";
         case StyleProperty.opacity:
             return "opacity";
+        case StyleProperty.cursor:
+            return "cursor";
     }
 };

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -67,6 +67,10 @@ export class ElementStylesRenderer {
                 selectors.set(makeSelector(params, focusSelector), css.partial`${property}: ${values.focus};`);
             }
 
+            if (params.disabledSelector !== undefined && values.disabled) {
+                selectors.set(makeSelector(params, "disabled"), css.partial`${property}: ${values.disabled};`);
+            }
+
             return selectors;
         }
     }

--- a/packages/adaptive-ui/src/modules/selector.ts
+++ b/packages/adaptive-ui/src/modules/selector.ts
@@ -12,17 +12,25 @@ import type { StateSelector, StyleModuleEvaluateParameters } from "./types.js";
 export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string {
     const selectors: string[] = [];
 
-    if (params.hostCondition || (state && params.interactivitySelector !== undefined)) {
-        // Use any base host condition like `[appearance='accent']`.
+    if (params.hostCondition ||
+        (state && state !== "disabled" && params.interactivitySelector !== undefined) ||
+        (state && state === "disabled" && params.disabledSelector !== undefined)
+    ) {
+        // Start with any base host condition like `[appearance='accent']`.
         let hostCondition = params.hostCondition || "";
 
         if (state) {
-            // Add any interactive condition like `:not([disabled])`.
-            hostCondition += (params.interactivitySelector || "");
+            if (state !== "disabled") {
+                // Add any interactive condition like `:not([disabled])`.
+                hostCondition += (params.interactivitySelector || "");
 
-            // If this is not targeting a part, apply the state at the `:host`.
-            if (!params.part) {
-                hostCondition += ":" + state;
+                // If this is not targeting a part, apply the state at the `:host`.
+                if (!params.part) {
+                    hostCondition += ":" + state;
+                }
+            } else {
+                // Add the non-interactive condition like `[disabled]`.
+                hostCondition += (params.disabledSelector || "");
             }
         }
 
@@ -30,12 +38,17 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state?: Stat
             selectors.push(`:host(${hostCondition})`);
         }
     } else if (!params.part) {
+        // There wasn't a host condition, and there isn't a part, so basic host selector.
         selectors.push(":host");
     }
 
     if (params.part) {
-        // Using class selector notation for now.
-        selectors.push(`.${params.part}${params.partCondition || ""}${state ? ":" + state : ""}`);
+        if (params.part === "*") {
+            selectors.push("*");
+        } else {
+            // Using class selector notation for now.
+            selectors.push(`.${params.part}${params.partCondition || ""}${state && state !== "disabled" ? ":" + state : ""}`);
+        }
     }
     const ret = selectors.join(" ");
     // console.log("makeSelector", ret);

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -2,7 +2,7 @@ import type { CSSDirective } from "@microsoft/fast-element";
 import type { CSSDesignToken } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
-import { TypedDesignToken } from "../adaptive-design-tokens.js";
+import { TypedCSSDesignToken, TypedDesignToken } from "../adaptive-design-tokens.js";
 import { InteractiveTokenGroup } from "../types.js";
 import { createForegroundSet, createForegroundSetBySet } from "../token-helpers-color.js";
 import { StyleProperty } from "./types.js";
@@ -41,7 +41,7 @@ export const Fill = {
     ): StyleProperties {
         return {
             backgroundFill: background,
-            foregroundFill: createForegroundSet(foregroundRecipe, "rest",  background),
+            foregroundFill: createForegroundSet(foregroundRecipe, background),
         };
     },
 
@@ -51,9 +51,25 @@ export const Fill = {
     ): StyleProperties {
         return {
             backgroundFill: background,
-            foregroundFill: createForegroundSetBySet(foregroundRecipe,  background),
+            foregroundFill: createForegroundSetBySet(foregroundRecipe, background),
         };
     },
+
+    foregroundNonInteractiveWithDisabled: function(
+        foreground: TypedCSSDesignToken<Swatch>,
+        disabled: TypedCSSDesignToken<Swatch>,
+    ): StyleProperties {
+        return {
+            foregroundFill: {
+                name: `${foreground.name}-with-disabled-value`,
+                rest: foreground,
+                hover: foreground,
+                active: foreground,
+                focus: foreground,
+                disabled,
+            },
+        }
+    }
 }
 
 /**
@@ -124,6 +140,7 @@ export const Padding = {
             paddingLeft: value,
         };
     },
+
     verticalHorizontal: function(valueVertical: StyleValue, valueHorizontal: StyleValue): StyleProperties {
         return {
             paddingTop: valueVertical,

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -13,7 +13,7 @@ export type FocusSelector = "focus" | "focus-visible" | "focus-within";
  *
  * @public
  */
-export type StateSelector = "hover" | "active" | FocusSelector;
+export type StateSelector = "hover" | "active" | FocusSelector | "disabled";
 
 /**
  * Type of the `conditions` for component {@link ComponentAnatomy}.
@@ -74,9 +74,9 @@ export interface InteractivityDefinition {
     interactivitySelector?: string;
 
     /**
-     * The selector indicating the component or element is not interactive, like `[disabled]`.
+     * The selector indicating the component or element is disabled, like `[disabled]`.
      */
-    nonInteractivitySelector?: string;
+    disabledSelector?: string;
 }
 
 /**
@@ -87,19 +87,19 @@ export interface InteractivityDefinition {
 export const Interactivity = {
     disabledAttribute: { 
         interactivitySelector: ":not([disabled])",
-        nonInteractivitySelector: "[disabled]",
+        disabledSelector: "[disabled]",
     } as InteractivityDefinition,
     hrefAttribute:  { 
         interactivitySelector: "[href]",
-        nonInteractivitySelector: ":not([href])",
+        disabledSelector: undefined,
     } as InteractivityDefinition,
     always: { 
         interactivitySelector: "",
-        nonInteractivitySelector: "",
+        disabledSelector: "",
     } as InteractivityDefinition,
     never: { 
         interactivitySelector: undefined,
-        nonInteractivitySelector: undefined,
+        disabledSelector: undefined,
     } as InteractivityDefinition,
 } as const;
 
@@ -150,6 +150,7 @@ export const StyleProperty = {
     width: "width",
     layoutDirection: "layoutDirection",
     opacity: "opacity",
+    cursor: "cursor",
 } as const;
 
 /**

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -85,18 +85,41 @@ export interface InteractivityDefinition {
  * @public
  */
 export const Interactivity = {
+    /**
+     * Has interactive or disabled states based on the `disabled` attribute.
+     *
+     * For instance, a form control.
+     */
     disabledAttribute: { 
         interactivitySelector: ":not([disabled])",
         disabledSelector: "[disabled]",
     } as InteractivityDefinition,
+
+    /**
+     * Has interactive states based on the `href` attribute, but never a disabled state.
+     *
+     * For instance, an `<a>` should style as plain text when it doesn't have an `href` attribute.
+     */
     hrefAttribute:  { 
         interactivitySelector: "[href]",
         disabledSelector: undefined,
     } as InteractivityDefinition,
+
+    /**
+     * Is always interactive and never has a disabled state.
+     *
+     * For instance, cards or list items that are not able to be disabled.
+     */
     always: { 
         interactivitySelector: "",
-        disabledSelector: "",
+        disabledSelector: undefined,
     } as InteractivityDefinition,
+
+    /**
+     * Is never interactive or disabled, that is, a plain static element.
+     *
+     * For instance, body text, headings, illustrations, etc.
+     */
     never: { 
         interactivitySelector: undefined,
         disabledSelector: undefined,

--- a/packages/adaptive-ui/src/token-helpers-color.ts
+++ b/packages/adaptive-ui/src/token-helpers-color.ts
@@ -53,7 +53,7 @@ export function createTokenMinContrast(
 }
 
 /**
- * Creates a DesignToken that can be used for a color recipe.
+ * Creates a DesignToken that can be used for a color recipe, optionally referencing a context color.
  *
  * @param baseName - The base token name in `css-identifier` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
@@ -72,7 +72,7 @@ export function createTokenColorRecipe<T = Swatch>(
 }
 
 /**
- * Creates a DesignToken that can be used for a color recipe, based on another interactive color set.
+ * Creates a DesignToken that can be used for a color recipe, referencing an interactive color set for context.
  *
  * @param baseName - The base token name in `css-identifier` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
@@ -165,6 +165,7 @@ export function createTokenColorSet(
         hover: createTokenColorSetState(valueToken, "hover"),
         active: createTokenColorSetState(valueToken, "active"),
         focus: createTokenColorSetState(valueToken, "focus"),
+        disabled: createTokenColorSetState(valueToken, "disabled"),
     };
 }
 
@@ -185,24 +186,24 @@ export function createTokenColorRecipeValue(
 }
 
 /**
- * Creates a TokenGroup of a single state from a set of foreground tokens to be applied over the interactive background tokens.
+ * Creates an {@link InteractiveTokenGroup} from the `rest` state of the foreground set
+ * to be applied over the interactive background tokens.
  *
  * @param foregroundRecipe - The recipe for the foreground.
- * @param foregroundState - The state from the foreground recipe, typically "rest".
  * @param background - The interactive token group for the background.
  *
  * @public
  */
 export function createForegroundSet(
     foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>,
-    foregroundState: keyof InteractiveSet<any>,
     background: InteractiveTokenGroup<Swatch>,
 ): InteractiveTokenGroup<Swatch> {
-    const foregroundBaseName = `${foregroundRecipe.name.replace("-recipe", "")}-${foregroundState}`;
+    const foregroundBaseName = `${foregroundRecipe.name.replace("-recipe", "")}`;
     const backgroundBaseName = background.rest.name.replace("-rest", "");
     const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
 
     function createState(
+        foregroundState: keyof InteractiveSet<any>,
         state: keyof InteractiveSet<any>,
     ): TypedCSSDesignToken<Swatch> {
         return createTokenSwatch(`${setName}-${state}`).withDefault(
@@ -217,10 +218,11 @@ export function createForegroundSet(
         name: setName,
         type: DesignTokenType.color,
         intendedFor: foregroundRecipe.intendedFor,
-        rest: createState("rest"),
-        hover: createState("hover"),
-        active: createState("active"),
-        focus: createState("focus")
+        rest: createState("rest", "rest"),
+        hover: createState("rest", "hover"),
+        active: createState("rest", "active"),
+        focus: createState("rest", "focus"),
+        disabled: createState("disabled", "disabled"),
     };
 }
 
@@ -248,6 +250,7 @@ export function createForegroundSetBySet(
                     hover: resolve(background.hover),
                     active: resolve(background.active),
                     focus: resolve(background.focus),
+                    disabled: resolve(background.disabled),
                 }
                 return resolve(foregroundRecipe).evaluate(resolve, backgroundSet);
             }
@@ -269,6 +272,7 @@ export function createForegroundSetBySet(
         rest: createState("rest"),
         hover: createState("hover"),
         active: createState("active"),
-        focus: createState("focus")
+        focus: createState("focus"),
+        disabled: createState("disabled"),
     };
 }

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -48,6 +48,11 @@ export interface InteractiveSet<T> {
      * The value to apply to the focus state.
      */
     focus: T;
+
+    /**
+     * The value to apply to the disabled state.
+     */
+    disabled: T;
 }
 
 /**

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -963,6 +963,9 @@ export const flipperTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTFlip
 export const flipperTemplateStyles: ElementStyles;
 
 // @public
+export function globalStyleModules(interactivity?: InteractivityDefinition): StyleModules;
+
+// @public
 export const horizontalScrollAestheticStyles: ElementStyles;
 
 // @public (undocumented)

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -103,8 +103,4 @@ export const aestheticStyles: ElementStyles = css`
     .icon {
         fill: currentcolor;
     }
-
-    :host([disabled]) {
-        opacity: 0.3;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -6,8 +6,7 @@ import {
     accentForegroundReadableControlStyles,
     controlDensityStyles,
     controlShapeStyles,
-    plainTextStyles,
-    typeRampBaseStyles
+    plainTextStyles
 } from "@adaptive-web/adaptive-ui/reference";
 import { BreadcrumbItemAnatomy } from "./breadcrumb-item.template.js";
 
@@ -20,7 +19,7 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampBaseStyles
+        plainTextStyles,
     ],
     [
         {
@@ -30,14 +29,14 @@ export const styleModules: StyleModules = [
             [
                 controlShapeStyles,
                 controlDensityStyles,
-                accentForegroundReadableControlStyles,
             ],
         )
     ],
     [
         {
-            part: BreadcrumbItemAnatomy.parts.separator,
+            hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            part: BreadcrumbItemAnatomy.parts.control,
         },
-        plainTextStyles
+        accentForegroundReadableControlStyles,
     ],
 ];

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -22,12 +22,14 @@ export const templateStyles: ElementStyles = css`
     .control {
         display: flex;
         align-items: center;
-        cursor: pointer;
         outline: none;
         white-space: nowrap;
     }
 
-    :host(:not([href])),
+    :host([href]) .control {
+        cursor: pointer;
+    }
+
     :host([aria-current]) .control {
         cursor: default;
     }
@@ -53,7 +55,7 @@ export const aestheticStyles: ElementStyles = css`
         position: relative;
     }
 
-    .control .content::before {
+    :host([href]) .control .content::before {
         content: "";
         display: block;
         height: ${strokeThickness};

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -19,9 +19,9 @@ export const templateStyles: ElementStyles = css`
         justify-content: center;
         align-items: center;
         white-space: nowrap;
+        /* reset */
         outline: none;
         font: inherit;
-        /* reset */
         border: none;
         margin: 0;
         padding: 0;
@@ -39,10 +39,6 @@ export const templateStyles: ElementStyles = css`
     :host(:not([disabled])) .control {
         cursor: pointer;
     }
-
-    :host([disabled]) .control {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -51,7 +47,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .control {
-        white-space: nowrap;
         fill: currentcolor;
     }
 

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -49,11 +49,6 @@ export const templateStyles: ElementStyles = css`
         display: none;
         visibility: hidden;
     }
-
-    :host([disabled]) .label,
-    :host([disabled]) .control {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -77,9 +72,5 @@ export const aestheticStyles: ElementStyles = css`
 
     .label {
         padding-inline-start: calc((${designUnit} * 2) + 2px);
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -61,7 +61,6 @@ export const templateStyles: ElementStyles = css`
 
     :host([disabled]) .control,
     :host([disabled]) .selected-value {
-        cursor: not-allowed;
         user-select: none;
     }
 
@@ -102,9 +101,5 @@ export const aestheticStyles: ElementStyles = css`
     .listbox {
         background: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -18,6 +18,7 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
+    /* Keep for now, show on full component not just children */
     :host([disabled]) {
         cursor: not-allowed;
     }
@@ -41,10 +42,6 @@ export const aestheticStyles: ElementStyles = css`
 
     :host(:focus-visible) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 
     ::slotted([slot="start"]),

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -113,6 +113,7 @@ export const templateStyles: ElementStyles = css`
         z-index: 1;
     }
 
+    /* Keep for now, show on full component not just children */
     :host([disabled]) {
         cursor: not-allowed;
     }
@@ -139,9 +140,5 @@ export const aestheticStyles: ElementStyles = css`
 
     ::slotted([slot="end"]:not(svg)) {
         color: ${neutralStrokeReadableRest};
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -15,7 +15,7 @@ export const templateStyles: ElementStyles = css`
     }
 
     .label {
-        display: block;
+        display: inline-block;
         cursor: pointer;
     }
 
@@ -64,11 +64,6 @@ export const templateStyles: ElementStyles = css`
     ::slotted([slot="end"]) {
         display: flex;
     }
-
-    :host([disabled]) .label,
-    :host([disabled]) .control {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -95,9 +90,5 @@ export const aestheticStyles: ElementStyles = css`
     .step-up,
     .step-down {
         padding: 1px 10px;
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -50,11 +50,6 @@ export const templateStyles: ElementStyles = css`
         display: none;
         visibility: hidden;
     }
-
-    :host([disabled]) .label,
-    :host([disabled]) .control {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -79,9 +74,5 @@ export const aestheticStyles: ElementStyles = css`
 
     .label {
         padding-inline-start: calc((${designUnit} * 2) + 2px);
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -66,19 +66,13 @@ export const templateStyles: ElementStyles = css`
     }
 
     .label {
-        display: block;
+        display: inline-block;
         cursor: pointer;
     }
 
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
         display: flex;
-    }
-
-    :host([disabled]) .label,
-    :host([disabled]) .root,
-    :host([disabled]) .control {
-        cursor: not-allowed;
     }
 `;
 

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -68,7 +68,6 @@ export const templateStyles: ElementStyles = css`
     }
 
     :host([disabled]) .control {
-        cursor: not-allowed;
         user-select: none;
     }
 `;
@@ -98,9 +97,5 @@ export const aestheticStyles: ElementStyles = css`
 
     :host([aria-haspopup]) .listbox {
         box-shadow: ${elevationFlyout};
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -69,8 +69,4 @@ export const aestheticStyles: ElementStyles = css`
     .mark {
         background: ${neutralStrokeSubtleRest};
     }
-
-    :host([disabled]) {
-        opacity: 0.3;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -38,6 +38,7 @@ export const templateStyles: ElementStyles = css`
         touch-action: pan-x;
     }
 
+    /* Keep for now, show on full component not just children */
     :host([disabled]) {
         cursor: not-allowed;
     }
@@ -158,9 +159,5 @@ export const aestheticStyles: ElementStyles = css`
 
     .track {
         background: ${neutralStrokeDiscernibleRest};
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -19,11 +19,6 @@ export const templateStyles: ElementStyles = css`
         outline: none;
     }
 
-    :host([disabled]) .label,
-    :host([disabled]) .switch {
-        cursor: not-allowed;
-    }
-
     .label {
         cursor: pointer;
     }
@@ -78,9 +73,5 @@ export const aestheticStyles: ElementStyles = css`
     :host([aria-checked="true"]:enabled:focus-visible) .switch {
         box-shadow: 0 0 0 2px ${fillColor}, 0 0 0 4px ${focusStrokeOuter};
         border-color: transparent;
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -34,8 +34,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:focus-visible) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
-
-    :host([disabled]) {
-        opacity: 0.3;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -24,7 +24,7 @@ export const templateStyles: ElementStyles = css`
     }
 
     .label {
-        display: block;
+        display: inline-block;
         cursor: pointer;
     }
 
@@ -43,11 +43,6 @@ export const templateStyles: ElementStyles = css`
 
     :host([resize="vertical"]) .control {
         resize: vertical;
-    }
-
-    :host([disabled]) .label,
-    :host([disabled]) .control {
-        cursor: not-allowed;
     }
 `;
 

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -37,19 +37,13 @@ export const templateStyles: ElementStyles = css`
     }
 
     .label {
-        display: block;
+        display: inline-block;
         cursor: pointer;
     }
 
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
         display: flex;
-    }
-
-    :host([disabled]) .label,
-    :host([disabled]) .root,
-    :host([disabled]) .control {
-        cursor: not-allowed;
     }
 `;
 

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -95,10 +95,6 @@ export const templateStyles: ElementStyles = css`
     :host(:focus-visible) {
         outline: none;
     }
-
-    :host([disabled]) .control {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -147,9 +143,5 @@ export const aestheticStyles: ElementStyles = css`
         height: calc((${heightNumber} / 2) * 1px);
         border-radius: calc(${cornerRadiusControl} * 1px);
         background: ${accentForegroundRest};
-    }
-
-    :host([disabled]) .control {
-        opacity: 0.3;
     }
 `;

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -148,7 +148,7 @@ export class DesignSystem {
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :
             defaultStyles;
 
-        for (const [target, styles] of globalStyleModules) {
+        for (const [target, styles] of globalStyleModules(interactivity)) {
             const params: StyleModuleEvaluateParameters = Object.assign({}, interactivity, target);
             const renderedStyles = new ElementStylesRenderer(styles).render(params);
             componentStyles.push(renderedStyles);

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -26,6 +26,7 @@ import type {
     SelectStatics,
     TreeItemStatics
 } from "./components/index.js";
+import { globalStyleModules } from './global.styles.modules.js';
 
 type ComponentStatics =
     AccordionItemStatics
@@ -146,6 +147,12 @@ export class DesignSystem {
         const componentStyles: ComposableStyles[] = options?.styles ? 
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :
             defaultStyles;
+
+        for (const [target, styles] of globalStyleModules) {
+            const params: StyleModuleEvaluateParameters = Object.assign({}, interactivity, target);
+            const renderedStyles = new ElementStylesRenderer(styles).render(params);
+            componentStyles.push(renderedStyles);
+        }
 
         if (options?.styleModules) {
             for (const [target, styles] of options.styleModules) {

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -1,0 +1,17 @@
+import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
+
+/**
+ * Global visual styles.
+ * 
+ * @public
+ */
+export const globalStyleModules: StyleModules = [
+    [
+        {
+            hostCondition: "[disabled]",
+            part: "*",
+        },
+        disabledStyles,
+    ],
+];

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { InteractivityDefinition, StyleModules, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
 import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
@@ -6,12 +6,21 @@ import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
  * 
  * @public
  */
-export const globalStyleModules: StyleModules = [
-    [
-        {
-            hostCondition: "[disabled]",
-            part: "*",
-        },
-        disabledStyles,
-    ],
-];
+export function globalStyleModules(interactivity?: InteractivityDefinition): StyleModules {
+    const styles = new Array<[StyleModuleTarget, Styles]>();
+
+    // If this component can be disabled, apply the style to all children.
+    if (interactivity?.disabledSelector !== undefined) {
+        styles.push(
+            [
+                {
+                    hostCondition: interactivity.disabledSelector,
+                    part: "*",
+                },
+                disabledStyles,
+            ]
+        );
+    }
+
+    return styles;
+}

--- a/packages/adaptive-web-components/src/index.ts
+++ b/packages/adaptive-web-components/src/index.ts
@@ -2,4 +2,5 @@ export {
 	DesignSystem,
 	DefaultDesignSystem as AdaptiveDesignSystem,
 } from "./design-system.js";
+export * from "./global.styles.modules.js";
 export * from "./components/index.js";


### PR DESCRIPTION
# Pull Request

## Description

![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/860315eb-81a0-48d9-95c7-2432ad630926)

Added `disabled` state to the interactive color model.
Removed the fixed 30% opacity temporary styling.
Added a Palette for disabled state, defaulting to neutral, which removes the color from accent or highlight components, an additional signal of the disabled state.
Migrated most of the `not-allowed` cursor support to a global style module. There's something I'd still like to cleanup here regarding components where the _whole_ component should appear disabled vs. only the child elements. This depends on how the empty space works in the components - A list or menu item (full component) compared to an input field with label (more of an "L" shape).

### Issues
Closes #91
Related to #79 

## Reviewer Notes

This feels like a pretty solid update to me, but there are a couple of things I'd still like to cleanup.
- One is the cursor issue mentioned above.
- Another is the `black-or-white` recipe, which could migrate to another recipe since black and white are at the extents of all palettes. I want to think about this more, so for now I shimmed a reasonable default solution.

## Test Plan

Tested in Explorer and Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

I found that Slider is not going disabled, but that's happening aside from these changes. Will address separately (#150).