### PR TITLE
Updated the style assembly function to get the full anatomy definition

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-52f429c6-0fd9-4c89-8129-e130742b20a3.json
+++ b/change/@adaptive-web-adaptive-web-components-52f429c6-0fd9-4c89-8129-e130742b20a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated the style assembly function to get the full anatomy definition",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -60,7 +60,6 @@ import { FASTTooltip } from '@microsoft/fast-foundation';
 import { FASTTreeItem } from '@microsoft/fast-foundation';
 import { FASTTreeView } from '@microsoft/fast-foundation';
 import { HorizontalScrollView } from '@microsoft/fast-foundation';
-import { InteractivityDefinition } from '@adaptive-web/adaptive-ui';
 import { ShadowRootOptions } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '@microsoft/fast-foundation';
 import { StyleModules } from '@adaptive-web/adaptive-ui';
@@ -831,7 +830,7 @@ export const dataGridTemplateStyles: ElementStyles;
 export class DesignSystem {
     // Warning: (ae-forgotten-export) The symbol "ElementStaticMap" needs to be exported by the entry point index.d.ts
     constructor(_prefix: string, _registry?: CustomElementRegistry, _statics?: ElementStaticMap);
-    static assembleStyles(defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>): ElementStyles;
+    static assembleStyles(defaultStyles: ComposableStyles[], anatomy?: ComponentAnatomy<any, any>, options?: ComposeOptions<any>): ElementStyles;
     // Warning: (ae-forgotten-export) The symbol "PartialDesignSystem" needs to be exported by the entry point index.d.ts
     configure(options: PartialDesignSystem): this;
     defineComponents(components: Record<string, ((ds: DesignSystem) => FASTElementDefinition) | FASTElementDefinition>): void;
@@ -963,7 +962,7 @@ export const flipperTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTFlip
 export const flipperTemplateStyles: ElementStyles;
 
 // @public
-export function globalStyleModules(interactivity?: InteractivityDefinition): StyleModules;
+export const globalStyleModules: (anatomy?: ComponentAnatomy<any, any>) => StyleModules;
 
 // @public
 export const horizontalScrollAestheticStyles: ElementStyles;

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
@@ -30,7 +30,7 @@ export function composeAccordionItem(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionItemAnatomy, options);
 
     return FASTAccordionItem.compose({
         name: `${ds.prefix}-accordion-item`,

--- a/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
@@ -14,7 +14,7 @@ export function composeAccordion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAccordion>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AccordionAnatomy, options);
 
     return FASTAccordion.compose({
         name: `${ds.prefix}-accordion`,

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -14,7 +14,7 @@ export function composeAnchor(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveAnchor>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, AnchorAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AnchorAnatomy, options);
 
     return AdaptiveAnchor.compose({
         name: `${ds.prefix}-anchor`,

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -14,7 +14,7 @@ export function composeAnchoredRegion(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAnchoredRegion>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, AnchoredRegionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AnchoredRegionAnatomy, options);
 
     return FASTAnchoredRegion.compose({
         name: `${ds.prefix}-anchored-region`,

--- a/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
@@ -14,7 +14,7 @@ export function composeAvatar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTAvatar>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, AvatarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, AvatarAnatomy, options);
 
     return FASTAvatar.compose({
         name: `${ds.prefix}-avatar`,

--- a/packages/adaptive-web-components/src/components/badge/badge.compose.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.compose.ts
@@ -14,7 +14,7 @@ export function composeBadge(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBadge>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, BadgeAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BadgeAnatomy, options);
 
     return FASTBadge.compose({
         name: `${ds.prefix}-badge`,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -23,7 +23,7 @@ export function composeBreadcrumbItem(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbItemAnatomy, options);
 
     return FASTBreadcrumbItem.compose({
         name: `${ds.prefix}-breadcrumb-item`,

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -14,7 +14,7 @@ export function composeBreadcrumb(
     ds: DesignSystem,
     options?: ComposeOptions<FASTBreadcrumb>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbAnatomy, options);
 
     return FASTBreadcrumb.compose({
         name: `${ds.prefix}-breadcrumb`,

--- a/packages/adaptive-web-components/src/components/button/button.compose.ts
+++ b/packages/adaptive-web-components/src/components/button/button.compose.ts
@@ -14,7 +14,7 @@ export function composeButton(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveButton>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ButtonAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ButtonAnatomy, options);
 
     return AdaptiveButton.compose({
         name: `${ds.prefix}-button`,

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -14,7 +14,7 @@ export function composeCalendar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCalendar>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, CalendarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CalendarAnatomy, options);
 
     return FASTCalendar.compose({
         name: `${ds.prefix}-calendar`,

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -14,7 +14,7 @@ export function composeCard(
     ds: DesignSystem,
     options?: ComposeOptions<FASTCard>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, CardAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CardAnatomy, options);
 
     return FASTCard.compose({
         name: `${ds.prefix}-card`,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -30,7 +30,7 @@ export function composeCheckbox(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, CheckboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, CheckboxAnatomy, options);
 
     return FASTCheckbox.compose({
         name: `${ds.prefix}-checkbox`,

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -23,7 +23,7 @@ export function composeCombobox(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, ComboboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ComboboxAnatomy, options);
 
     return FASTCombobox.compose({
         name: `${ds.prefix}-combobox`,

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -14,7 +14,7 @@ export function composeDataGridCell(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridCell>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridCellAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridCellAnatomy, options);
 
     return FASTDataGridCell.compose({
         name: `${ds.prefix}-data-grid-cell`,

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -14,7 +14,7 @@ export function composeDataGridRow(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGridRow>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy, options);
 
     return FASTDataGridRow.compose({
         name: `${ds.prefix}-data-grid-row`,

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -14,7 +14,7 @@ export function composeDataGrid(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDataGrid>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DataGridAnatomy, options);
 
     return FASTDataGrid.compose({
         name: `${ds.prefix}-data-grid`,

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -14,7 +14,7 @@ export function composeDialog(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDialog>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DialogAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DialogAnatomy, options);
 
     return FASTDialog.compose({
         name: `${ds.prefix}-dialog`,

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -14,7 +14,7 @@ export function composeDisclosure(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDisclosure>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DisclosureAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DisclosureAnatomy, options);
 
     return FASTDisclosure.compose({
         name: `${ds.prefix}-disclosure`,

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -14,7 +14,7 @@ export function composeDivider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTDivider>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, DividerAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, DividerAnatomy, options);
 
     return FASTDivider.compose({
         name: `${ds.prefix}-divider`,

--- a/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
@@ -30,7 +30,7 @@ export function composeFlipper(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, FlipperAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, FlipperAnatomy, options);
 
     return FASTFlipper.compose({
         name: `${ds.prefix}-flipper`,

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -14,7 +14,7 @@ export function composeHorizontalScroll(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveHorizontalScroll>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, HorizontalScrollAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, HorizontalScrollAnatomy, options);
 
     return AdaptiveHorizontalScroll.compose({
         name: `${ds.prefix}-horizontal-scroll`,

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
@@ -14,7 +14,7 @@ export function composeListboxOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxOption>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxOptionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxOptionAnatomy, options);
 
     return FASTListboxOption.compose({
         name: `${ds.prefix}-option`,

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -14,7 +14,7 @@ export function composeListbox(
     ds: DesignSystem,
     options?: ComposeOptions<FASTListboxElement>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ListboxAnatomy, options);
 
     return FASTListboxElement.compose({
         name: `${ds.prefix}-listbox`,

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
@@ -37,7 +37,7 @@ export function composeMenuItem(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, MenuItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, MenuItemAnatomy, options);
 
     return AdaptiveMenuItem.compose({
         name: `${ds.prefix}-menu-item`,

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -14,7 +14,7 @@ export function composeMenu(
     ds: DesignSystem,
     options?: ComposeOptions<AdaptiveMenu>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, MenuAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, MenuAnatomy, options);
 
     return AdaptiveMenu.compose({
         name: `${ds.prefix}-menu`,

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -30,7 +30,7 @@ export function composeNumberField(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, NumberFieldAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, NumberFieldAnatomy, options);
 
     return FASTNumberField.compose({
         name: `${ds.prefix}-number-field`,

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
@@ -14,7 +14,7 @@ export function composePickerListItem(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerListItem>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListItemAnatomy, options);
 
     return FASTPickerListItem.compose({
         name: `${ds.prefix}-picker-list-item`,

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -14,7 +14,7 @@ export function composePickerList(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerList>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerListAnatomy, options);
 
     return FASTPickerList.compose({
         name: `${ds.prefix}-picker-list`,

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
@@ -14,7 +14,7 @@ export function composePickerMenuOption(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenuOption>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuOptionAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuOptionAnatomy, options);
 
     return FASTPickerMenuOption.compose({
         name: `${ds.prefix}-picker-menu-option`,

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -14,7 +14,7 @@ export function composePickerMenu(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPickerMenu>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerMenuAnatomy, options);
 
     return FASTPickerMenu.compose({
         name: `${ds.prefix}-picker-menu`,

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -14,7 +14,7 @@ export function composePicker(
     ds: DesignSystem,
     options?: ComposeOptions<FASTPicker>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, PickerAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, PickerAnatomy, options);
 
     return FASTPicker.compose({
         name: `${ds.prefix}-picker`,

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -14,7 +14,7 @@ export function composeProgressRing(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgressRing>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressRingAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressRingAnatomy, options);
 
     return FASTProgressRing.compose({
         name: `${ds.prefix}-progress-ring`,

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -14,7 +14,7 @@ export function composeProgress(
     ds: DesignSystem,
     options?: ComposeOptions<FASTProgress>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ProgressAnatomy, options);
 
     return FASTProgress.compose({
         name: `${ds.prefix}-progress`,

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -14,7 +14,7 @@ export function composeRadioGroup(
     ds: DesignSystem,
     options?: ComposeOptions<FASTRadioGroup>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, RadioGroupAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, RadioGroupAnatomy, options);
 
     return FASTRadioGroup.compose({
         name: `${ds.prefix}-radio-group`,

--- a/packages/adaptive-web-components/src/components/radio/radio.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.compose.ts
@@ -23,7 +23,7 @@ export function composeRadio(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, RadioAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, RadioAnatomy, options);
 
     return FASTRadio.compose({
         name: `${ds.prefix}-radio`,

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -14,7 +14,7 @@ export function composeSearch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSearch>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, SearchAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SearchAnatomy, options);
 
     return FASTSearch.compose({
         name: `${ds.prefix}-search`,

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -23,7 +23,7 @@ export function composeSelect(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, SelectAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SelectAnatomy, options);
 
     return AdaptiveSelect.compose({
         name: `${ds.prefix}-select`,

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -14,7 +14,7 @@ export function composeSkeleton(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSkeleton>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, SkeletonAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SkeletonAnatomy, options);
 
     return FASTSkeleton.compose({
         name: `${ds.prefix}-skeleton`,

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -14,7 +14,7 @@ export function composeSliderLabel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSliderLabel>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, SliderLabelAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SliderLabelAnatomy, options);
 
     return FASTSliderLabel.compose({
         name: `${ds.prefix}-slider-label`,

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -14,7 +14,7 @@ export function composeSlider(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSlider>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, SliderAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SliderAnatomy, options);
 
     return FASTSlider.compose({
         name: `${ds.prefix}-slider`,

--- a/packages/adaptive-web-components/src/components/switch/switch.compose.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.compose.ts
@@ -14,7 +14,7 @@ export function composeSwitch(
     ds: DesignSystem,
     options?: ComposeOptions<FASTSwitch>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, SwitchAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, SwitchAnatomy, options);
 
     return FASTSwitch.compose({
         name: `${ds.prefix}-switch`,

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -14,7 +14,7 @@ export function composeTabPanel(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabPanel>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TabPanelAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabPanelAnatomy, options);
 
     return FASTTabPanel.compose({
         name: `${ds.prefix}-tab-panel`,

--- a/packages/adaptive-web-components/src/components/tab/tab.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.compose.ts
@@ -14,7 +14,7 @@ export function composeTab(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTab>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TabAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabAnatomy, options);
 
     return FASTTab.compose({
         name: `${ds.prefix}-tab`,

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -14,7 +14,7 @@ export function composeTabs(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTabs>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TabsAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TabsAnatomy, options);
 
     return FASTTabs.compose({
         name: `${ds.prefix}-tabs`,

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -14,7 +14,7 @@ export function composeTextArea(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextArea>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TextAreaAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TextAreaAnatomy, options);
 
     return FASTTextArea.compose({
         name: `${ds.prefix}-text-area`,

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -14,7 +14,7 @@ export function composeTextField(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTextField>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TextFieldAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TextFieldAnatomy, options);
 
     return FASTTextField.compose({
         name: `${ds.prefix}-text-field`,

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -14,7 +14,7 @@ export function composeToolbar(
     ds: DesignSystem,
     options?: ComposeOptions<FASTToolbar>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, ToolbarAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, ToolbarAnatomy, options);
 
     return FASTToolbar.compose({
         name: `${ds.prefix}-toolbar`,

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -14,7 +14,7 @@ export function composeTooltip(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTooltip>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TooltipAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TooltipAnatomy, options);
 
     return FASTTooltip.compose({
         name: `${ds.prefix}-tooltip`,

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -23,7 +23,7 @@ export function composeTreeItem(
         }
     }
 
-    const styles = DesignSystem.assembleStyles(defaultStyles, TreeItemAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TreeItemAnatomy, options);
 
     return FASTTreeItem.compose({
         name: `${ds.prefix}-tree-item`,

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -14,7 +14,7 @@ export function composeTreeView(
     ds: DesignSystem,
     options?: ComposeOptions<FASTTreeView>
 ): FASTElementDefinition {
-    const styles = DesignSystem.assembleStyles(defaultStyles, TreeViewAnatomy.interactivity, options);
+    const styles = DesignSystem.assembleStyles(defaultStyles, TreeViewAnatomy, options);
 
     return FASTTreeView.compose({
         name: `${ds.prefix}-tree-view`,

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -8,8 +8,8 @@ import {
 } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from "@microsoft/fast-foundation";
 import {
+    type ComponentAnatomy,
     ElementStylesRenderer,
-    type InteractivityDefinition,
     type StyleModuleEvaluateParameters,
     type StyleModuleTarget,
     Styles,
@@ -142,21 +142,21 @@ export class DesignSystem {
      * @beta
      */
     public static assembleStyles(
-        defaultStyles: ComposableStyles[], interactivity?: InteractivityDefinition, options?: ComposeOptions<any>
+        defaultStyles: ComposableStyles[], anatomy?: ComponentAnatomy<any, any>, options?: ComposeOptions<any>
     ): ElementStyles {
         const componentStyles: ComposableStyles[] = options?.styles ? 
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :
             defaultStyles;
 
-        for (const [target, styles] of globalStyleModules(interactivity)) {
-            const params: StyleModuleEvaluateParameters = Object.assign({}, interactivity, target);
+        for (const [target, styles] of globalStyleModules(anatomy)) {
+            const params: StyleModuleEvaluateParameters = Object.assign({}, anatomy?.interactivity, target);
             const renderedStyles = new ElementStylesRenderer(styles).render(params);
             componentStyles.push(renderedStyles);
         }
 
         if (options?.styleModules) {
             for (const [target, styles] of options.styleModules) {
-                const params: StyleModuleEvaluateParameters = Object.assign({}, interactivity, target);
+                const params: StyleModuleEvaluateParameters = Object.assign({}, anatomy?.interactivity, target);
                 const renderedStyles = new ElementStylesRenderer(styles).render(params);
                 componentStyles.push(renderedStyles);
             }

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -1,4 +1,4 @@
-import { InteractivityDefinition, StyleModules, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, StyleModules, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
 import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
@@ -6,15 +6,15 @@ import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
  * 
  * @public
  */
-export function globalStyleModules(interactivity?: InteractivityDefinition): StyleModules {
+export const globalStyleModules = (anatomy?: ComponentAnatomy<any, any>): StyleModules => {
     const styles = new Array<[StyleModuleTarget, Styles]>();
 
     // If this component can be disabled, apply the style to all children.
-    if (interactivity?.disabledSelector !== undefined) {
+    if (anatomy?.interactivity?.disabledSelector !== undefined) {
         styles.push(
             [
                 {
-                    hostCondition: interactivity.disabledSelector,
+                    hostCondition: anatomy.interactivity.disabledSelector,
                     part: "*",
                 },
                 disabledStyles,
@@ -23,4 +23,4 @@ export function globalStyleModules(interactivity?: InteractivityDefinition): Sty
     }
 
     return styles;
-}
+};


### PR DESCRIPTION
# Pull Request

## Description

The style modules are assembled by the design system helper. Right now they only get the "interactivity" definition which describes when a component is interactive (hover and active states) and informs the color system (or any other interested system).

As part of extending the style assembly to other systems, it's necessary to provide more information about the anatomy of the component.

### Issues

Related to #82

## Reviewer Notes

Same change in all the `compose` files. This will probably evolve further under the update to the compose helper, but this unblocks other styling work now.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Add the focus state support and finish the refactor of the compose helper.