### PR TITLE
Updated color recipes to allow null interactive states

### DIFF
--- a/change/@adaptive-web-adaptive-ui-dcb49912-a53a-4289-bbd2-b5117bafc451.json
+++ b/change/@adaptive-web-adaptive-ui-dcb49912-a53a-4289-bbd2-b5117bafc451.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated color recipes to allow null interactive states",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-1f3a9607-2e82-49c5-b7ba-ba9de8f9d63d.json
+++ b/change/@adaptive-web-adaptive-web-components-1f3a9607-2e82-49c5-b7ba-ba9de8f9d63d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated color recipes to allow null interactive states",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -34,7 +34,7 @@ export const _black: SwatchRGB;
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
 
 // @public
-export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, disabledReference: Swatch, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
+export function blackOrWhiteByContrastSet(set: InteractiveSwatchSet, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
 
 // @public (undocumented)
 export const BorderFill: {
@@ -76,7 +76,7 @@ export type ColorRecipePaletteParams = ColorRecipeParams & {
 
 // @public
 export type ColorRecipeParams = {
-    reference?: Swatch;
+    reference: Swatch | null;
 };
 
 // @public
@@ -183,6 +183,9 @@ export function createTokenNonCss<T>(name: string, type: DesignTokenType, intend
 export function createTokenNumber(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<number>;
 
 // @public
+export function createTokenRecipe<TParam, TResult>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: RecipeEvaluate<TParam, TResult>): TypedDesignToken<Recipe<TParam, TResult>>;
+
+// @public
 export function createTokenSwatch(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch>;
 
 // @public
@@ -236,6 +239,7 @@ export const DesignTokenType: {
     readonly typography: "typography";
     readonly fontStyle: "fontStyle";
     readonly fontVariations: "fontVariations";
+    readonly palette: "palette";
     readonly recipe: "recipe";
     readonly string: "string";
 };
@@ -299,7 +303,7 @@ export interface InteractiveSet<T> {
 }
 
 // @public
-export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {
+export interface InteractiveSwatchSet extends InteractiveSet<Swatch | null> {
 }
 
 // @public
@@ -500,7 +504,7 @@ export class Styles {
 }
 
 // @public
-export type StyleValue = CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string;
+export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string;
 
 // @public
 export interface Swatch extends RelativeLuminance {
@@ -509,7 +513,7 @@ export interface Swatch extends RelativeLuminance {
 }
 
 // @public
-export function swatchAsOverlay(swatch: Swatch, reference: Swatch, asOverlay: boolean): Swatch;
+export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null;
 
 // @public
 export class SwatchRGB implements Swatch {

--- a/packages/adaptive-ui/src/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/adaptive-design-tokens.ts
@@ -26,6 +26,7 @@ export const DesignTokenType = {
     // Added in Adaptive UI
     fontStyle: "fontStyle",
     fontVariations: "fontVariations",
+    palette: "palette",
     recipe: "recipe",
     string: "string",
 } as const;

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -12,7 +12,7 @@ export type ColorRecipeParams = {
     /**
      * The reference color, implementation defaults to `fillColor`, but allows for overriding for nested color recipes.
      */
-    reference?: Swatch,
+    reference: Swatch | null,
 };
 
 /**
@@ -87,7 +87,7 @@ export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<I
  *
  * @public
  */
-export interface InteractiveSwatchSet extends InteractiveSet<Swatch> {}
+export interface InteractiveSwatchSet extends InteractiveSet<Swatch | null> {}
 
 /**
  * A recipe that evaluates based on an interactive set of color values.

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
@@ -22,27 +22,23 @@ import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
  * @public
  */
 export function blackOrWhiteByContrastSet(
-    restReference: Swatch,
-    hoverReference: Swatch,
-    activeReference: Swatch,
-    focusReference: Swatch,
-    disabledReference: Swatch,
+    set: InteractiveSwatchSet,
     minContrast: number,
     defaultBlack: boolean
 ): InteractiveSwatchSet {
-    const defaultRule: (reference: Swatch) => Swatch = (reference) =>
-        blackOrWhiteByContrast(reference, minContrast, defaultBlack);
+    const defaultRule: (reference: Swatch | null) => Swatch | null = (reference) =>
+        reference ? blackOrWhiteByContrast(reference, minContrast, defaultBlack) : null;
 
-    const restForeground = defaultRule(restReference);
-    const hoverForeground = defaultRule(hoverReference);
+    const restForeground = defaultRule(set.rest);
+    const hoverForeground = defaultRule(set.hover);
     // Active does not have contrast requirements, so if rest and hover use the same color, use that for active
     // even if it would not have passed the contrast check.
     const activeForeground =
-        restForeground.relativeLuminance === hoverForeground.relativeLuminance
+        restForeground && hoverForeground && restForeground.relativeLuminance === hoverForeground.relativeLuminance
             ? restForeground
-            : defaultRule(activeReference);
-    const focusForeground = defaultRule(focusReference);
-    const disabled = defaultRule(disabledReference) as SwatchRGB;
+            : defaultRule(set.active);
+    const focusForeground = defaultRule(set.focus);
+    const disabled = defaultRule(set.disabled) as SwatchRGB;
     // TODO: Reasonable disabled opacity, but not configurable.
     // Considering replacing these recipes anyway.
     const disabledForeground = new SwatchRGB(disabled.r, disabled.g, disabled.b, 0.3);

--- a/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
@@ -18,8 +18,8 @@ describe("idealColorDeltaSwatchSet", (): void => {
         const lightModeColors = idealColorDeltaSwatchSet(accentPalette, _white, 4.5, accentPalette.source, 0, 6, -4, 0, 1);
         const darkModeColors = idealColorDeltaSwatchSet(accentPalette, _black, 4.5, accentPalette.source, 0, 6, -4, 0, 1);
 
-        expect(lightModeColors.hover.contrast(_white)).to.be.greaterThan(lightModeColors.rest.contrast(_white));
-        expect(darkModeColors.hover.contrast(_black)).to.be.greaterThan(darkModeColors.rest.contrast(_black));
+        expect(lightModeColors.hover!.contrast(_white)).to.be.greaterThan(lightModeColors.rest!.contrast(_white));
+        expect(darkModeColors.hover!.contrast(_black)).to.be.greaterThan(darkModeColors.rest!.contrast(_black));
     });
 
     it("should have accessible rest and hover colors against the background color", (): void => {

--- a/packages/adaptive-ui/src/color/utilities/opacity.ts
+++ b/packages/adaptive-ui/src/color/utilities/opacity.ts
@@ -11,7 +11,7 @@ import { Swatch, SwatchRGB } from "../swatch.js";
  *
  * @public
  */
-export function swatchAsOverlay(swatch: Swatch, reference: Swatch, asOverlay: boolean): Swatch {
+export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null {
     return swatch instanceof SwatchRGB && asOverlay
         ? SwatchRGB.asOverlay(swatch as SwatchRGB, reference as SwatchRGB)
         : swatch;

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -148,11 +148,7 @@ export const blackOrWhiteDiscernibleRecipe = createTokenColorRecipeBySet<Interac
     StyleProperty.foregroundFill,
     (resolve: DesignTokenResolver, reference: InteractiveSwatchSet) =>
         blackOrWhiteByContrastSet(
-            reference.rest,
-            reference.hover,
-            reference.active,
-            reference.focus,
-            reference.disabled,
+            reference,
             resolve(minContrastDiscernible),
             false,
         )
@@ -172,11 +168,7 @@ export const blackOrWhiteReadableRecipe = createTokenColorRecipeBySet<Interactiv
     StyleProperty.foregroundFill,
     (resolve: DesignTokenResolver, reference: InteractiveSwatchSet) =>
         blackOrWhiteByContrastSet(
-            reference.rest,
-            reference.hover,
-            reference.active,
-            reference.focus,
-            reference.disabled,
+            reference,
             resolve(minContrastReadable),
             false,
         )

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -33,14 +33,11 @@ import {
     neutralFillStealth,
     neutralFillSubtle,
     neutralStrokeDiscernible,
-    neutralStrokeDiscernibleRest,
-    neutralStrokeReadableRest,
+    neutralStrokeReadable,
     neutralStrokeSafety,
     neutralStrokeStrong,
     neutralStrokeStrongRecipe,
-    neutralStrokeStrongRest,
     neutralStrokeSubtle,
-    neutralStrokeSubtleRest,
 } from "./color.js";
 import { densityControl, densityItemContainer, densityLayer } from "./density.js";
 import {
@@ -636,7 +633,7 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
         ...densityBorderStyles(neutralStrokeDiscernible),
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrongRest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
         backgroundFill: fillColor,
     },
     "color.neutral-outline-discernible-control",
@@ -654,7 +651,7 @@ export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeReadableRest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeReadable.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-foreground-readable-control",
 );
@@ -671,7 +668,7 @@ export const neutralForegroundReadableElementStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrongRest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-foreground-strong-element",
 );
@@ -688,7 +685,7 @@ export const neutralForegroundStrongElementStyles: Styles = Styles.fromPropertie
  */
 export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeSubtleRest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeSubtle.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-subtle-element",
 );
@@ -705,7 +702,7 @@ export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
  */
 export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeDiscernibleRest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeDiscernible.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-discernible-element",
 );

--- a/packages/adaptive-ui/src/design-tokens/palette.ts
+++ b/packages/adaptive-ui/src/design-tokens/palette.ts
@@ -1,13 +1,13 @@
 import type { DesignTokenResolver } from "@microsoft/fast-foundation";
 import { DesignTokenType } from "../adaptive-design-tokens.js";
 import { Palette, PaletteOkhsl } from "../color/index.js";
-import { createNonCss, createTokenNonCss } from "../token-helpers.js";
+import { createTokenNonCss } from "../token-helpers.js";
 
 /** @public */
 export const neutralBaseColor = createTokenNonCss<string>("neutral-base-color", DesignTokenType.color).withDefault("#808080");
 
 /** @public */
-export const neutralPalette = createNonCss<Palette>("neutral-palette").withDefault(
+export const neutralPalette = createTokenNonCss<Palette>("neutral-palette", DesignTokenType.palette).withDefault(
     (resolve: DesignTokenResolver) =>
         PaletteOkhsl.from(resolve(neutralBaseColor))
 );
@@ -16,7 +16,7 @@ export const neutralPalette = createNonCss<Palette>("neutral-palette").withDefau
 export const accentBaseColor = createTokenNonCss<string>("accent-base-color", DesignTokenType.color).withDefault("#F26C0D");
 
 /** @public */
-export const accentPalette = createNonCss<Palette>("accent-palette").withDefault(
+export const accentPalette = createTokenNonCss<Palette>("accent-palette", DesignTokenType.palette).withDefault(
     (resolve: DesignTokenResolver) =>
         PaletteOkhsl.from(resolve(accentBaseColor))
 );
@@ -25,7 +25,7 @@ export const accentPalette = createNonCss<Palette>("accent-palette").withDefault
 export const highlightBaseColor = createTokenNonCss<string>("highlight-base-color", DesignTokenType.color).withDefault("#0DA1F2");
 
 /** @public */
-export const highlightPalette = createNonCss<Palette>("highlight-palette").withDefault(
+export const highlightPalette = createTokenNonCss<Palette>("highlight-palette", DesignTokenType.palette).withDefault(
     (resolve: DesignTokenResolver) =>
         PaletteOkhsl.from(resolve(highlightBaseColor))
 );
@@ -34,7 +34,7 @@ export const highlightPalette = createNonCss<Palette>("highlight-palette").withD
 export const criticalBaseColor = createTokenNonCss<string>("critical-base-color", DesignTokenType.color).withDefault("#D92635");
 
 /** @public */
-export const criticalPalette = createNonCss<Palette>("critical-palette").withDefault(
+export const criticalPalette = createTokenNonCss<Palette>("critical-palette", DesignTokenType.palette).withDefault(
     (resolve: DesignTokenResolver) =>
         PaletteOkhsl.from(resolve(criticalBaseColor))
 );
@@ -48,4 +48,4 @@ export const criticalPalette = createNonCss<Palette>("critical-palette").withDef
  *
  * @public
  */
-export const disabledPalette = createNonCss<Palette>("disabled-palette").withDefault(neutralPalette);
+export const disabledPalette = createTokenNonCss<Palette>("disabled-palette", DesignTokenType.palette).withDefault(neutralPalette);

--- a/packages/adaptive-ui/src/migration/color.ts
+++ b/packages/adaptive-ui/src/migration/color.ts
@@ -113,11 +113,13 @@ export const foregroundOnAccentFillReadableRecipe = createTokenColorRecipe(
     StyleProperty.foregroundFill,
     (resolve: DesignTokenResolver): InteractiveSwatchSet =>
         blackOrWhiteByContrastSet(
-            resolve(accentFillReadableRest),
-            resolve(accentFillReadableHover),
-            resolve(accentFillReadableActive),
-            resolve(accentFillReadableFocus),
-            resolve(accentFillReadable.disabled),
+            {
+                rest: resolve(accentFillReadable.rest),
+                hover: resolve(accentFillReadable.hover),
+                active: resolve(accentFillReadable.active),
+                focus: resolve(accentFillReadable.focus),
+                disabled: resolve(accentFillReadable.disabled),
+            },
             resolve(minContrastReadable),
             false
         )
@@ -575,7 +577,7 @@ export const neutralStrokeDividerRecipe = createTokenColorRecipe(
             ),
             params?.reference || resolve(fillColor),
             resolve(neutralAsOverlay)
-        )
+        )!
 );
 
 /** @public @deprecated Use "Subtle" instead */

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -1,8 +1,8 @@
 import { css, HostBehavior } from "@microsoft/fast-element";
 import { type CSSDirective, ElementStyles } from "@microsoft/fast-element";
 import { CSSDesignToken } from "@microsoft/fast-foundation";
-import type { StyleProperty } from "../modules/types.js";
-import type { InteractiveTokenGroup } from "../types.js";
+import { type StyleProperty } from "../modules/types.js";
+import type { InteractiveSet } from "../types.js";
 import { makeSelector } from "./selector.js";
 import type { FocusSelector, StyleModuleEvaluateParameters } from "./types.js";
 import { stylePropertyToCssProperty } from "./css.js";
@@ -49,14 +49,15 @@ export class ElementStylesRenderer {
 
     private static propertyInteractive(
         property: string,
-        values: InteractiveTokenGroup<any>,
+        values: InteractiveSet<any>,
         focusSelector: FocusSelector = "focus-visible",
     ): StyleModuleEvaluate {
         return (params: StyleModuleEvaluateParameters): Map<string, CSSDirective> => {
-            const selectors = new Map([
-                [makeSelector(params), css.partial`${property}: ${values.rest};`]
-            ]);
+            const selectors = new Map();
 
+            if (values.rest) {
+                selectors.set(makeSelector(params), css.partial`${property}: ${values.rest};`);
+            }
             if (params.interactivitySelector !== undefined && values.hover) {
                 selectors.set(makeSelector(params, "hover"), css.partial`${property}: ${values.hover};`);
             }
@@ -83,7 +84,7 @@ export class ElementStylesRenderer {
             } else if (value && typeof (value as any).createCSS === "function") {
                 return ElementStylesRenderer.propertySingle(property, value as CSSDirective);
             } else {
-                return ElementStylesRenderer.propertyInteractive(property, value as InteractiveTokenGroup<any>);
+                return ElementStylesRenderer.propertyInteractive(property, value as InteractiveSet<any>);
             }
         });
         return modules;

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -3,7 +3,7 @@ import type { CSSDesignToken } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
 import { TypedCSSDesignToken, TypedDesignToken } from "../adaptive-design-tokens.js";
-import { InteractiveTokenGroup } from "../types.js";
+import { InteractiveSet, InteractiveTokenGroup } from "../types.js";
 import { createForegroundSet, createForegroundSetBySet } from "../token-helpers-color.js";
 import { StyleProperty } from "./types.js";
 
@@ -12,7 +12,7 @@ import { StyleProperty } from "./types.js";
  *
  * @public
  */
-export type StyleValue = CSSDesignToken<any> | InteractiveTokenGroup<any> | CSSDirective | string;
+export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string;
 
 /**
  * An object of style definitions, where the key is the {@link (StyleProperty:type)} and the value is the token or final value.
@@ -67,7 +67,7 @@ export const Fill = {
                 active: foreground,
                 focus: foreground,
                 disabled,
-            },
+            } as InteractiveTokenGroup<Swatch>,
         }
     }
 }

--- a/packages/adaptive-ui/src/token-helpers-color.ts
+++ b/packages/adaptive-ui/src/token-helpers-color.ts
@@ -138,7 +138,7 @@ function createTokenColorSetState(
 ): TypedCSSDesignToken<Swatch> {
     return createTokenSwatch(`${valueToken.name.replace("-value", "")}-${state}`, valueToken.intendedFor).withDefault(
         (resolve: DesignTokenResolver) =>
-            resolve(valueToken)[state]
+            resolve(valueToken)[state] as any
     );
 }
 
@@ -199,8 +199,7 @@ export function createForegroundSet(
     background: InteractiveTokenGroup<Swatch>,
 ): InteractiveTokenGroup<Swatch> {
     const foregroundBaseName = `${foregroundRecipe.name.replace("-recipe", "")}`;
-    const backgroundBaseName = background.rest.name.replace("-rest", "");
-    const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
+    const setName = `${foregroundBaseName}-on-${background.name}`;
 
     function createState(
         foregroundState: keyof InteractiveSet<any>,
@@ -210,7 +209,7 @@ export function createForegroundSet(
             (resolve: DesignTokenResolver) =>
                 resolve(foregroundRecipe).evaluate(resolve, {
                     reference: resolve(background[state])
-                })[foregroundState]
+                })[foregroundState] as any
         );
     }
 
@@ -239,8 +238,7 @@ export function createForegroundSetBySet(
     background: InteractiveTokenGroup<Swatch>,
 ): InteractiveTokenGroup<Swatch> {
     const foregroundBaseName = foregroundRecipe.name.replace("-recipe", "");
-    const backgroundBaseName = background.rest.name.replace("-rest", "");
-    const setName = `${foregroundBaseName}-on-${backgroundBaseName}`;
+    const setName = `${foregroundBaseName}-on-${background.name}`;
 
     const set = createTokenNonCss<InteractiveSwatchSet>(`${setName}-value`, DesignTokenType.color).withDefault(
         (resolve: DesignTokenResolver) =>
@@ -261,7 +259,7 @@ export function createForegroundSetBySet(
     ): TypedCSSDesignToken<Swatch> {
         return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
-                resolve(set)[state]
+                resolve(set)[state] as any
         );
     }
 

--- a/packages/adaptive-ui/src/token-helpers.ts
+++ b/packages/adaptive-ui/src/token-helpers.ts
@@ -2,6 +2,7 @@ import { DesignToken } from "@microsoft/fast-foundation";
 import { DesignTokenType, TypedCSSDesignToken, TypedDesignToken } from "./adaptive-design-tokens.js";
 import { Swatch } from "./color/swatch.js";
 import { StyleProperty } from "./modules/types.js";
+import { Recipe, RecipeEvaluate } from "./recipes.js";
 
 /** @internal @deprecated Use one of the typed `createTokenX` functions instead */
 export const { create } = DesignToken;
@@ -33,6 +34,25 @@ export function createTokenColor(name: string, intendedFor?: StyleProperty | Sty
  */
 export function createTokenNonCss<T>(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): TypedDesignToken<T> {
     return TypedDesignToken.createTyped<T>(name, type, intendedFor);
+}
+
+/**
+ * Creates a DesignToken that can be used for a recipe.
+ *
+ * @param baseName - The base token name in `css-identifier` casing.
+ * @param intendedFor - The style properties where this token is intended to be used.
+ * @param evaluate - The function to call when the derived token needs to be evaluated.
+ *
+ * @public
+ */
+export function createTokenRecipe<TParam, TResult>(
+    baseName: string,
+    intendedFor: StyleProperty | StyleProperty[],
+    evaluate: RecipeEvaluate<TParam, TResult>,
+): TypedDesignToken<Recipe<TParam, TResult>> {
+    return createTokenNonCss<Recipe<TParam, TResult>>(`${baseName}-recipe`, DesignTokenType.recipe, intendedFor).withDefault({
+        evaluate
+    });
 }
 
 /**

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -15,7 +15,7 @@ import { heightNumber } from "../../styles/index.js";
 const expandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collapse-hover").withDefault(
     (resolve: DesignTokenResolver) => {
         const recipe = resolve(neutralFillStealthRecipe);
-        return recipe.evaluate(resolve, { reference: recipe.evaluate(resolve).hover }).hover;
+        return recipe.evaluate(resolve, { reference: recipe.evaluate(resolve).hover }).hover as any;
     }
 );
 
@@ -23,7 +23,7 @@ const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand
     (resolve: DesignTokenResolver) => {
         const baseRecipe = resolve(neutralFillSubtleRecipe);
         const buttonRecipe = resolve(neutralFillStealthRecipe);
-        return buttonRecipe.evaluate(resolve, { reference: baseRecipe.evaluate(resolve).rest }).hover;
+        return buttonRecipe.evaluate(resolve, { reference: baseRecipe.evaluate(resolve).rest }).hover as any;
     }
 );
 


### PR DESCRIPTION
# Pull Request

## Description

While migrating focus state to Styles (#82), I found that requiring all states on an interactive set is too constrained for some purposes, including focus-only treatment. I started to run into this when adding disabled state as well (#91).

The value of a `DesignToken` can be null, though this isn't reflected in typing of the API. This update makes this capability clear in the typing of Adaptive UI.

There are different requirements depending on whether the interactive set is of tokens or values. Tokens can not be null in order to be referenced in `css` blocks. Token _values_ may actually be null, and a recipe may choose to return a null value.

### Issues

Related issues linked above.

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

I believe the typing of the color recipes can be cleaned up a bit more. I will look into this after the focus indicator work.