### PR TITLE
Migrated the focus styling to style modules

### DIFF
--- a/change/@adaptive-web-adaptive-ui-e22c0e69-ddd1-4daa-8582-ea65df858880.json
+++ b/change/@adaptive-web-adaptive-ui-e22c0e69-ddd1-4daa-8582-ea65df858880.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for focus styling and css outline properties",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-4f10e619-dea0-468d-9f77-c904dfcfe772.json
+++ b/change/@adaptive-web-adaptive-web-components-4f10e619-dea0-468d-9f77-c904dfcfe772.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrated the focus styling to style modules - Change `delegatesFocus` usage to override `focus` instead - Select includes additional style fixes",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
+++ b/packages/adaptive-ui-explorer/src/components/adaptive-component.ts
@@ -50,7 +50,7 @@ export class AdaptiveComponent extends FASTElement {
             this.$fastController.removeStyles(this._addedStyles);
         }
         if (next) {
-            this._addedStyles = new ElementStylesRenderer(next).render(Interactivity.disabledAttribute);
+            this._addedStyles = new ElementStylesRenderer(next).render({}, Interactivity.disabledAttribute);
             this.$fastController.addStyles(this._addedStyles);
         }
     }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -81,11 +81,9 @@ export type ColorRecipeParams = {
 
 // @public
 export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
-    // (undocumented)
     conditions: TConditions;
-    // (undocumented)
+    focus?: FocusDefinition<TParts>;
     interactivity?: InteractivityDefinition;
-    // (undocumented)
     parts: TParts;
 }
 
@@ -253,7 +251,7 @@ export function directionByIsDark(color: RelativeLuminance): PaletteDirectionVal
 // @public
 export class ElementStylesRenderer {
     constructor(styles: Styles);
-    render(params: StyleModuleEvaluateParameters): ElementStyles;
+    render(target: StyleModuleTarget, interactivity?: InteractivityDefinition): ElementStyles;
 }
 
 // @public
@@ -268,6 +266,20 @@ export const Fill: {
     backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
     foregroundNonInteractiveWithDisabled: (foreground: TypedCSSDesignToken<Swatch>, disabled: TypedCSSDesignToken<Swatch>) => StyleProperties;
 };
+
+// @public
+export const Focus: {
+    readonly hostFocused: () => FocusDefinition<any>;
+    readonly hostChildFocused: <TParts>(indicatorPart: keyof TParts & string) => FocusDefinition<TParts>;
+    readonly partFocused: <TParts_1>(part: keyof TParts_1 & string) => FocusDefinition<TParts_1>;
+    readonly partWithin: <TParts_2>(indicatorPart: keyof TParts_2 & string, focusablePart: keyof TParts_2 & string) => FocusDefinition<TParts_2>;
+};
+
+// @public
+export interface FocusDefinition<TParts> {
+    focusTarget: StyleModuleTarget;
+    resetTarget: StyleModuleTarget;
+}
 
 // @public
 export type FocusSelector = "focus" | "focus-visible" | "focus-within";
@@ -419,9 +431,13 @@ export type StyleModules = Iterable<readonly [StyleModuleTarget, Styles]>;
 
 // @public
 export interface StyleModuleTarget {
+    focusSelector?: FocusSelector;
     hostCondition?: string;
+    // @beta
+    ignoreInteractivity?: boolean;
     part?: string;
     partCondition?: string;
+    stateOnHost?: boolean;
 }
 
 // @public
@@ -467,6 +483,10 @@ export const StyleProperty: {
     readonly layoutDirection: "layoutDirection";
     readonly opacity: "opacity";
     readonly cursor: "cursor";
+    readonly outlineColor: "outlineColor";
+    readonly outlineOffset: "outlineOffset";
+    readonly outlineStyle: "outlineStyle";
+    readonly outlineWidth: "outlineWidth";
 };
 
 // @public

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1,5 +1,5 @@
 import { BorderFill, BorderStyle, BorderThickness, CornerRadius, Fill, Padding, Styles, StyleValue } from "../modules/styles.js";
-import { cornerRadiusControl, cornerRadiusLayer, strokeThickness } from "./appearance.js";
+import { cornerRadiusControl, cornerRadiusLayer, focusStrokeThickness, strokeThickness } from "./appearance.js";
 import {
     accentFillDiscernible,
     accentFillReadable,
@@ -20,6 +20,7 @@ import {
     criticalStrokeReadableRecipe,
     criticalStrokeSafety,
     fillColor,
+    focusStrokeOuter,
     highlightFillDiscernible,
     highlightFillReadable,
     highlightFillStealth,
@@ -989,4 +990,17 @@ export const disabledStyles: Styles = Styles.fromProperties(
         cursor: "not-allowed",
     },
     "styles.disabled",
+);
+
+/**
+ * @public
+ */
+export const focusIndicatorStyles: Styles = Styles.fromProperties(
+    {
+        outlineColor: focusStrokeOuter,
+        outlineOffset: "1px",
+        outlineStyle: "solid",
+        outlineWidth: focusStrokeThickness,
+    },
+    "styles.focus-indicator",
 );

--- a/packages/adaptive-ui/src/modules/css.ts
+++ b/packages/adaptive-ui/src/modules/css.ts
@@ -79,5 +79,13 @@ export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
             return "opacity";
         case StyleProperty.cursor:
             return "cursor";
+        case StyleProperty.outlineColor:
+            return "outline-color";
+        case StyleProperty.outlineOffset:
+            return "outline-offset";
+        case StyleProperty.outlineStyle:
+            return "outline-style";
+        case StyleProperty.outlineWidth:
+            return "outline-width";
     }
 };

--- a/packages/adaptive-ui/src/modules/selector.ts
+++ b/packages/adaptive-ui/src/modules/selector.ts
@@ -12,6 +12,9 @@ import type { StateSelector, StyleModuleEvaluateParameters } from "./types.js";
 export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string {
     const selectors: string[] = [];
 
+    // `disabled` is a `state`, but it's not a css pseudo selector.
+    const statePseudo = state && state !== "disabled" ? ":" + state : "";
+
     if (params.hostCondition ||
         (state && state !== "disabled" && params.interactivitySelector !== undefined) ||
         (state && state === "disabled" && params.disabledSelector !== undefined)
@@ -24,9 +27,9 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state?: Stat
                 // Add any interactive condition like `:not([disabled])`.
                 hostCondition += (params.interactivitySelector || "");
 
-                // If this is not targeting a part, apply the state at the `:host`.
-                if (!params.part) {
-                    hostCondition += ":" + state;
+                // If this is not targeting a part, or if configured, apply the state at the `:host`.
+                if (!params.part || params.stateOnHost === true) {
+                    hostCondition += statePseudo;
                 }
             } else {
                 // Add the non-interactive condition like `[disabled]`.
@@ -47,7 +50,7 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state?: Stat
             selectors.push("*");
         } else {
             // Using class selector notation for now.
-            selectors.push(`.${params.part}${params.partCondition || ""}${state && state !== "disabled" ? ":" + state : ""}`);
+            selectors.push(`.${params.part}${params.partCondition || ""}${params.stateOnHost !== true ? statePseudo : ""}`);
         }
     }
     const ret = selectors.join(" ");

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -133,11 +133,15 @@ export const accordionTemplateStyles: ElementStyles;
 // @public
 export class AdaptiveAnchor extends FASTAnchor {
     protected defaultSlottedContentChanged(): void;
+    // (undocumented)
+    focus(options?: FocusOptions): void;
 }
 
 // @public
 export class AdaptiveButton extends FASTButton {
     protected defaultSlottedContentChanged(): void;
+    // (undocumented)
+    focus(options?: FocusOptions): void;
 }
 
 // @beta
@@ -1426,7 +1430,10 @@ export const selectAestheticStyles: ElementStyles;
 export const SelectAnatomy: ComponentAnatomy<typeof SelectConditions, typeof SelectParts>;
 
 // @public (undocumented)
-export const SelectConditions: {};
+export const SelectConditions: {
+    isDropdown: string;
+    isListbox: string;
+};
 
 // @public (undocumented)
 export const SelectParts: {

--- a/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.definition.ts
@@ -14,8 +14,5 @@ export const anchorDefinition = composeAnchor(
     DefaultDesignSystem,
     {
         styleModules,
-        shadowOptions: {
-            delegatesFocus: true
-        },
     }
 );

--- a/packages/adaptive-web-components/src/components/anchor/anchor.stories.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.stories.ts
@@ -43,7 +43,7 @@ export const storyTemplate = html<StoryArgs<AdaptiveAnchor>>`
 
 export default {
     title: "Components/Anchor",
-    includeStories: ["Anchor"],
+    includeStories: ["Anchor", "AnchorWithoutHref"],
     args: {
         startSlotIcon: false,
         endSlotIcon: false,
@@ -84,3 +84,9 @@ export default {
 } as Meta<AdaptiveAnchor>;
 
 export const Anchor: Story<AdaptiveAnchor> = renderComponent(storyTemplate).bind({});
+
+export const AnchorWithoutHref: Story<AdaptiveAnchor> = Anchor.bind({});
+AnchorWithoutHref.args = {
+    storyContent: "Anchor without href attribute",
+    href: undefined,
+};

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css } from "@microsoft/fast-element";
 import type { ElementStyles } from "@microsoft/fast-element";
 
@@ -20,13 +16,8 @@ export const templateStyles: ElementStyles = css`
         justify-content: center;
         align-items: center;
         white-space: nowrap;
-        outline: none;
         font: inherit;
         text-decoration: none;
-    }
-
-    .control::-moz-focus-inner {
-        border: 0;
     }
 
     ::slotted([slot="start"]),
@@ -47,9 +38,5 @@ export const aestheticStyles: ElementStyles = css`
     .control.icon-only {
         padding: 0;
         line-height: 0;
-    }
-
-    .control:focus-visible {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { anchorTemplate, FASTAnchor } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -25,6 +25,7 @@ export const AnchorAnatomy: ComponentAnatomy<typeof AnchorConditions, typeof Anc
     interactivity: Interactivity.hrefAttribute,
     conditions: AnchorConditions,
     parts: AnchorParts,
+    focus: Focus.partFocused("control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/anchor/anchor.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.ts
@@ -18,4 +18,8 @@ export class AdaptiveAnchor extends FASTAnchor {
             this.control.classList.remove("icon-only");
         }
     }
+
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
 }

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -2,6 +2,7 @@ import { FASTBreadcrumbItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveBreadcrumbItem } from "./breadcrumb-item.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb-item.styles.js";
 import { BreadcrumbItemAnatomy, BreadcrumbItemStatics, template } from "./breadcrumb-item.template.js";
 
@@ -25,7 +26,7 @@ export function composeBreadcrumbItem(
 
     const styles = DesignSystem.assembleStyles(defaultStyles, BreadcrumbItemAnatomy, options);
 
-    return FASTBreadcrumbItem.compose({
+    return AdaptiveBreadcrumbItem.compose({
         name: `${ds.prefix}-breadcrumb-item`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.definition.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.definition.ts
@@ -19,8 +19,5 @@ export const breadcrumbItemDefinition = composeBreadcrumbItem(
             [BreadcrumbItemStatics.separator]: chevronRightIcon
         },
         styleModules,
-        shadowOptions: {
-            delegatesFocus: true
-        }
     }
 );

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -1,9 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { neutralForegroundRest } from "@adaptive-web/adaptive-ui/migration";
-import {
-    focusStrokeThickness,
-    strokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -22,7 +18,6 @@ export const templateStyles: ElementStyles = css`
     .control {
         display: flex;
         align-items: center;
-        outline: none;
         white-space: nowrap;
     }
 
@@ -47,28 +42,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .control {
-        text-decoration: none;
         fill: currentcolor;
-    }
-
-    .control .content {
-        position: relative;
-    }
-
-    :host([href]) .control .content::before {
-        content: "";
-        display: block;
-        height: ${strokeThickness};
-        left: 0;
-        position: absolute;
-        right: 0;
-        top: calc(1em + 4px);
-        width: 100%;
-        background: currentcolor;
-    }
-
-    .control:focus-visible .content::before {
-        height: ${focusStrokeThickness};
     }
 
     :host(:not([href])),

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { breadcrumbItemTemplate, FASTBreadcrumbItem } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -40,6 +40,7 @@ export const BreadcrumbItemAnatomy: ComponentAnatomy<typeof BreadcrumbItemCondit
     interactivity: Interactivity.hrefAttribute,
     conditions: BreadcrumbItemConditions,
     parts: BreadcrumbItemParts,
+    focus: Focus.partFocused("control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -1,0 +1,12 @@
+import { FASTBreadcrumbItem } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of BreadcrumbItem. Extends {@link @microsoft/fast-foundation#FASTBreadcrumbItem}.
+ *
+ * @public
+ */
+export class AdaptiveBreadcrumbItem extends FASTBreadcrumbItem {
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -1,8 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -20,15 +16,10 @@ export const templateStyles: ElementStyles = css`
         align-items: center;
         white-space: nowrap;
         /* reset */
-        outline: none;
         font: inherit;
         border: none;
         margin: 0;
         padding: 0;
-    }
-
-    .control::-moz-focus-inner {
-        border: 0;
     }
 
     ::slotted([slot="start"]),
@@ -53,9 +44,5 @@ export const aestheticStyles: ElementStyles = css`
     .control.icon-only {
         padding: 0;
         line-height: 0;
-    }
-
-    .control:focus-visible {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/button/button.template.ts
+++ b/packages/adaptive-web-components/src/components/button/button.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { buttonTemplate, FASTButton } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -25,6 +25,7 @@ export const ButtonAnatomy: ComponentAnatomy<typeof ButtonConditions, typeof But
     interactivity: Interactivity.disabledAttribute,
     conditions: ButtonConditions,
     parts: ButtonParts,
+    focus: Focus.partFocused("control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/button/button.ts
+++ b/packages/adaptive-web-components/src/components/button/button.ts
@@ -18,4 +18,8 @@ export class AdaptiveButton extends FASTButton {
             this.control.classList.remove("icon-only");
         }
     }
+
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
 }

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -1,7 +1,5 @@
 import {
     designUnit,
-    focusStrokeOuter,
-    focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -15,10 +13,6 @@ export const templateStyles: ElementStyles = css`
         display: inline-flex;
         align-items: center;
         user-select: none;
-    }
-
-    :host(:focus-visible) {
-        outline: none;
     }
 
     .control {
@@ -56,18 +50,10 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        /* outline: none; */
-    }
-
     .control {
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) .control {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     .label {

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { checkboxTemplate, FASTCheckbox } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -42,6 +42,7 @@ export const CheckboxAnatomy: ComponentAnatomy<typeof CheckboxConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: CheckboxConditions,
     parts: CheckboxParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -2,6 +2,7 @@ import { FASTCombobox } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveCombobox } from "./combobox.js";
 import { aestheticStyles, templateStyles } from "./combobox.styles.js";
 import { ComboboxAnatomy, ComboboxStatics, template } from "./combobox.template.js";
 
@@ -25,7 +26,7 @@ export function composeCombobox(
 
     const styles = DesignSystem.assembleStyles(defaultStyles, ComboboxAnatomy, options);
 
-    return FASTCombobox.compose({
+    return AdaptiveCombobox.compose({
         name: `${ds.prefix}-combobox`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/combobox/combobox.definition.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.definition.ts
@@ -19,8 +19,5 @@ export const comboboxDefinition = composeCombobox(
             [ComboboxStatics.indicator]: chevronDownIcon
         },
         styleModules,
-        shadowOptions: {
-            delegatesFocus: true
-        }
     }
 );

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -1,7 +1,5 @@
 import {
     elevationFlyout,
-    focusStrokeOuter,
-    focusStrokeThickness,
     layerFillFixedPlus1,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
@@ -39,10 +37,6 @@ export const templateStyles: ElementStyles = css`
         padding: unset;
     }
 
-    .selected-value:focus-visible {
-        outline: none;
-    }
-
     :host(:active) .selected-value {
         user-select: none;
     }
@@ -78,15 +72,6 @@ export const aestheticStyles: ElementStyles = css`
         min-width: 250px;
         fill: currentcolor;
     }
-
-    :host(:focus-within) .control {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    }
-
-    /* ideally the option can take care of itself
-    :host(:focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    } */
 
     .control {
         min-height: 100%;

--- a/packages/adaptive-web-components/src/components/combobox/combobox.template.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { comboboxTemplate, FASTCombobox } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -41,6 +41,7 @@ export const ComboboxAnatomy: ComponentAnatomy<typeof ComboboxConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: ComboboxConditions,
     parts: ComboboxParts,
+    focus: Focus.partWithin("control", "selected-value" as any),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/combobox/combobox.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.ts
@@ -1,0 +1,33 @@
+import { FASTCombobox } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of Combobox. Extends {@link @microsoft/fast-foundation#FASTCombobox}.
+ *
+ * @public
+ */
+export class AdaptiveCombobox extends FASTCombobox {
+    public connectedCallback() {
+        super.connectedCallback();
+
+        this.onfocus = this.focusinHandler;
+    }
+
+    /**
+     * Handles `focusin` actions for the component. When the component receives focus,
+     * the input control is focused as it is on click.
+     *
+     * @internal
+     */
+    public focusinHandler(e: FocusEvent): void {
+        if (!this.shouldSkipFocus && e.target === e.currentTarget) {
+            this.setSelectedOptions();
+            this.focusAndScrollOptionIntoView();
+        }
+
+        this.shouldSkipFocus = false;
+    }
+
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -1,8 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -27,9 +23,5 @@ export const aestheticStyles: ElementStyles = css`
     :host([cell-type="columnheader"]),
     :host([cell-type="rowheader"]) {
         font-weight: 600;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { dataGridCellTemplate, DataGridCellTypes, FASTDataGridCell } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -25,6 +25,7 @@ export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions
     interactivity: Interactivity.never,
     conditions: DataGridCellConditions,
     parts: DataGridCellParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -27,7 +27,6 @@ export const templateStyles: ElementStyles = css`
         display: flex;
         align-items: center;
         list-style-type: none;
-        outline: none;
         cursor: pointer;
     }
 

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { disclosureTemplate, FASTDisclosure } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -24,6 +24,7 @@ export const DisclosureAnatomy: ComponentAnatomy<typeof DisclosureConditions, ty
     interactivity: Interactivity.never,
     conditions: DisclosureConditions,
     parts: DisclosureParts,
+    focus: Focus.partFocused("invoker"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -15,10 +11,6 @@ export const templateStyles: ElementStyles = css`
         justify-content: center;
         align-items: center;
         cursor: pointer;
-    }
-
-    :host::-moz-focus-inner {
-        border: 0;
     }
 
     .next,
@@ -42,10 +34,6 @@ export const aestheticStyles: ElementStyles = css`
         border-radius: 50% !important;
         padding: 0 !important;
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTFlipper, flipperTemplate } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -42,6 +42,7 @@ export const FlipperAnatomy: ComponentAnatomy<typeof FlipperConditions, typeof F
     interactivity: Interactivity.disabledAttribute,
     conditions: FlipperConditions,
     parts: FlipperParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -38,10 +34,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     ::slotted([slot="start"]),

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -1,12 +1,11 @@
 import {
-    BorderFill,
     StyleModules,
     Styles
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
     itemContainerDensityStyles,
-    neutralStrokeSubtleRest
+    neutralOutlineDiscernibleControlStyles,
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
@@ -22,10 +21,8 @@ export const styleModules: StyleModules = [
             [
                 controlShapeStyles,
                 itemContainerDensityStyles,
+                neutralOutlineDiscernibleControlStyles,
             ],
-            {
-                ...BorderFill.all(neutralStrokeSubtleRest),
-            },
         )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -25,7 +25,9 @@ export const aestheticStyles: ElementStyles = css`
         background: ${layerFillFixedPlus1};
     }
 
-    :host(:not([disabled]):focus-within) {
+    :host(:not([aria-multiselectable]):not([disabled]):focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])),
+    :host([aria-multiselectable="true"]:not([disabled]):focus-visible) ::slotted([aria-checked="true"][role="option"]:not([disabled])) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
+        outline-offset: 1px;
     }
 `;

--- a/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTListboxElement, listboxTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -22,6 +22,7 @@ export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof L
     interactivity: Interactivity.disabledAttribute,
     conditions: ListboxConditions,
     parts: ListboxParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -1,6 +1,4 @@
 import {
-    focusStrokeOuter,
-    focusStrokeThickness,
     neutralFillStealthActive,
     neutralStrokeReadableRest,
 } from "@adaptive-web/adaptive-ui/reference";
@@ -132,10 +130,6 @@ export const aestheticStyles: ElementStyles = css`
 
     :host([aria-expanded="true"]) {
         background: ${neutralFillStealthActive};
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     ::slotted([slot="end"]:not(svg)) {

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
@@ -8,7 +8,7 @@ import {
      staticallyCompose,
 } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -49,6 +49,7 @@ export const MenuItemAnatomy: ComponentAnatomy<typeof MenuItemConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: MenuItemConditions,
     parts: MenuItemParts,
+    focus: Focus.hostFocused(),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/components/menu/menu.stories.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.stories.ts
@@ -168,6 +168,12 @@ MenuWithEverything.args = {
                 },
             ],
         },
+        {
+            storyContent: html`
+                Menu Item 3 (disabled)
+            `,
+            disabled: true,
+        },
         { template: dividerStoryTemplate },
         {
             storyContent: html`

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -2,6 +2,7 @@ import { FASTNumberField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveNumberField } from "./number-field.js";
 import { aestheticStyles, templateStyles } from "./number-field.styles.js";
 import { NumberFieldAnatomy, NumberFieldStatics, template } from "./number-field.template.js";
 
@@ -32,7 +33,7 @@ export function composeNumberField(
 
     const styles = DesignSystem.assembleStyles(defaultStyles, NumberFieldAnatomy, options);
 
-    return FASTNumberField.compose({
+    return AdaptiveNumberField.compose({
         name: `${ds.prefix}-number-field`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/number-field/number-field.definition.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.definition.ts
@@ -21,8 +21,5 @@ export const numberFieldDefinition = composeNumberField(
             [NumberFieldStatics.stepUp]: chevronUpIcon
         },
         styleModules,
-        shadowOptions: {
-            delegatesFocus: true
-        }
     }
 );

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -41,10 +37,6 @@ export const templateStyles: ElementStyles = css`
         border: none;
     }
 
-    .control:focus-visible {
-        outline: none;
-    }
-
     .controls {
         opacity: 0;
     }
@@ -77,10 +69,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .root {
         fill: currentcolor;
-    }
-
-    :host(:enabled:focus-within) .root {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     .control {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.template.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTNumberField, numberFieldTemplate } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -44,6 +44,7 @@ export const NumberFieldAnatomy: ComponentAnatomy<typeof NumberFieldConditions, 
     interactivity: Interactivity.disabledAttribute,
     conditions: NumberFieldConditions,
     parts: NumberFieldParts,
+    focus: Focus.partWithin("root", "control"), // How to make this `NumberFieldParts.root` instead of a string?
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/number-field/number-field.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.ts
@@ -1,0 +1,12 @@
+import { FASTNumberField } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of Number Field. Extends {@link @microsoft/fast-foundation#FASTNumberField}.
+ *
+ * @public
+ */
+export class AdaptiveNumberField extends FASTNumberField {
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -27,9 +23,5 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTPickerListItem, pickerListItemTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -22,6 +22,7 @@ export const PickerListItemAnatomy: ComponentAnatomy<typeof PickerListItemCondit
     interactivity: Interactivity.always,
     conditions: PickerListItemConditions,
     parts: PickerListItemParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -3,8 +3,6 @@ import {
 } from "@adaptive-web/adaptive-ui/migration";
 import {
     accentFillReadableRest,
-    focusStrokeOuter,
-    focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -31,10 +29,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     :host([aria-selected="true"]) {

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -1,7 +1,5 @@
 import {
     designUnit,
-    focusStrokeOuter,
-    focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -15,10 +13,6 @@ export const templateStyles: ElementStyles = css`
         display: inline-flex;
         align-items: center;
         user-select: none;
-    }
-
-    :host(:focus-visible) {
-        outline: none;
     }
 
     .control {
@@ -57,19 +51,11 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        /* outline: none; */
-    }
-
     .control {
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
         border-radius: 50% !important;
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) .control {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     .label {

--- a/packages/adaptive-web-components/src/components/radio/radio.template.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTRadio, radioTemplate } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -40,6 +40,7 @@ export const RadioAnatomy: ComponentAnatomy<typeof RadioConditions, typeof Radio
     interactivity: Interactivity.disabledAttribute,
     conditions: RadioConditions,
     parts: RadioParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -2,6 +2,7 @@ import { FASTSearch } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveSearch } from "./search.js";
 import { aestheticStyles, templateStyles } from "./search.styles.js";
 import { SearchAnatomy, template } from "./search.template.js";
 
@@ -16,7 +17,7 @@ export function composeSearch(
 ): FASTElementDefinition {
     const styles = DesignSystem.assembleStyles(defaultStyles, SearchAnatomy, options);
 
-    return FASTSearch.compose({
+    return AdaptiveSearch.compose({
         name: `${ds.prefix}-search`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/search/search.definition.ts
+++ b/packages/adaptive-web-components/src/components/search/search.definition.ts
@@ -11,11 +11,8 @@ import { styleModules } from "./search.styles.modules.js";
  * @public
  */
 export const searchDefinition = composeSearch(
-	DefaultDesignSystem,
-	{
-		styleModules,
-		shadowOptions: {
-			delegatesFocus: true
-		}
-	}
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
 );

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -1,7 +1,5 @@
 import {
     designUnit,
-    focusStrokeOuter,
-    focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { density, heightNumber } from "../../styles/index.js";
@@ -92,14 +90,6 @@ export const aestheticStyles: ElementStyles = css`
     .root {
         /*position: relative;*/
         fill: currentcolor;
-    }
-
-    :host(:not([disabled]):focus-within) .root {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    }
-
-    .control:focus-visible {
-        outline: none;
     }
 
     .clear-button {

--- a/packages/adaptive-web-components/src/components/search/search.template.ts
+++ b/packages/adaptive-web-components/src/components/search/search.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTSearch, searchTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -26,6 +26,7 @@ export const SearchAnatomy: ComponentAnatomy<typeof SearchConditions, typeof Sea
     interactivity: Interactivity.disabledAttribute,
     conditions: SearchConditions,
     parts: SearchParts,
+    focus: Focus.partWithin("root", "control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/search/search.ts
+++ b/packages/adaptive-web-components/src/components/search/search.ts
@@ -1,0 +1,12 @@
+import { FASTSearch } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of Search. Extends {@link @microsoft/fast-foundation#FASTSearch}.
+ *
+ * @public
+ */
+export class AdaptiveSearch extends FASTSearch {
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
@@ -3,9 +3,11 @@ import {
     Styles
 } from "@adaptive-web/adaptive-ui";
 import {
+    controlShapeStyles,
     inputStyles,
     itemContainerDensityStyles,
-    layerShapeStyles
+    layerShapeStyles,
+    neutralOutlineDiscernibleControlStyles
 } from "@adaptive-web/adaptive-ui/reference";
 import { SelectAnatomy } from "./select.template.js";
 
@@ -29,6 +31,18 @@ export const styleModules: StyleModules = [
             [
                 layerShapeStyles,
                 itemContainerDensityStyles,
+            ],
+        )
+    ],
+    [
+        {
+            hostCondition: SelectAnatomy.conditions.isListbox,
+            part: SelectAnatomy.parts.listbox
+        },
+        Styles.compose(
+            [
+                controlShapeStyles,
+                neutralOutlineDiscernibleControlStyles,
             ],
         )
     ],

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -55,8 +55,11 @@ export const templateStyles: ElementStyles = css`
         z-index: 1;
         display: flex;
         flex-direction: column;
-        position: fixed;
         overflow-y: auto;
+    }
+
+    :host([aria-haspopup]) .listbox {
+        position: fixed;
     }
 
     .listbox[hidden] {
@@ -81,14 +84,11 @@ export const aestheticStyles: ElementStyles = css`
         fill: currentcolor;
     }
 
-    :host(:focus-visible) {
+    :host(:not([aria-multiselectable]):not([disabled]):focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])),
+    :host([aria-multiselectable="true"]:not([disabled]):focus-visible) ::slotted([aria-checked="true"][role="option"]:not([disabled])) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
+        outline-offset: 1px;
     }
-
-    /* ideally the option can take care of itself
-    :host(:focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    } */
 
     .listbox {
         max-height: calc((var(--size, 0) * ${heightNumber}) * 1px + (${designUnit} + ${strokeThickness} * 2));

--- a/packages/adaptive-web-components/src/components/select/select.template.ts
+++ b/packages/adaptive-web-components/src/components/select/select.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTSelect, selectTemplate } from "@microsoft/fast-foundation";
 import type { ValuesOf } from '@microsoft/fast-foundation';
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -22,6 +22,8 @@ export type SelectStatics = ValuesOf<typeof SelectStatics>;
  * @public
  */
 export const SelectConditions = {
+    isDropdown: "[aria-haspopup]",
+    isListbox: ":not([aria-haspopup])",
 };
 
 /**
@@ -41,6 +43,7 @@ export const SelectAnatomy: ComponentAnatomy<typeof SelectConditions, typeof Sel
     interactivity: Interactivity.disabledAttribute,
     conditions: SelectConditions,
     parts: SelectParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -4,8 +4,6 @@ import {
 } from "@adaptive-web/adaptive-ui/migration";
 import {
     designUnit,
-    focusStrokeOuter,
-    focusStrokeThickness,
     neutralStrokeDiscernibleRest,
     neutralStrokeSubtleActive,
     neutralStrokeSubtleHover,
@@ -22,7 +20,6 @@ export const templateStyles: ElementStyles = css`
         display: inline-grid;
         align-items: center;
         user-select: none;
-        outline: none;
         cursor: pointer;
     }
 
@@ -146,11 +143,6 @@ export const aestheticStyles: ElementStyles = css`
     .thumb:active {
         border-color: ${neutralStrokeSubtleActive};
         background: ${neutralForegroundRest};
-    }
-
-    :host(:focus-visible) .thumb {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-        outline-offset: 2px;
     }
 
     .track-start {

--- a/packages/adaptive-web-components/src/components/slider/slider.template.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.template.ts
@@ -1,7 +1,7 @@
 import { ElementViewTemplate, html, ref } from "@microsoft/fast-element";
 // import { sliderTemplate } from "@microsoft/fast-foundation";
 import { FASTSlider, staticallyCompose } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -30,6 +30,7 @@ export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof Sli
     interactivity: Interactivity.never,
     conditions: SliderConditions,
     parts: SliderParts,
+    focus: Focus.hostFocused(),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -1,8 +1,5 @@
 import {
     designUnit,
-    fillColor,
-    focusStrokeOuter,
-    focusStrokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -16,7 +13,6 @@ export const templateStyles: ElementStyles = css`
         display: inline-flex;
         align-items: center;
         user-select: none;
-        outline: none;
     }
 
     .label {
@@ -55,10 +51,6 @@ export const aestheticStyles: ElementStyles = css`
         padding: 4px;
     }
 
-    :host(:focus-visible) .switch {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    }
-
     .thumb {
         position: absolute;
         height: calc((${heightNumber}) * 1px - (${designUnit} * 5.5));
@@ -68,10 +60,5 @@ export const aestheticStyles: ElementStyles = css`
         fill: currentcolor;
         border-radius: 50%;
         transition: all 0.2s ease-in-out;
-    }
-
-    :host([aria-checked="true"]:enabled:focus-visible) .switch {
-        box-shadow: 0 0 0 2px ${fillColor}, 0 0 0 4px ${focusStrokeOuter};
-        border-color: transparent;
     }
 `;

--- a/packages/adaptive-web-components/src/components/switch/switch.template.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTSwitch, switchTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -26,6 +26,7 @@ export const SwitchAnatomy: ComponentAnatomy<typeof SwitchConditions, typeof Swi
     interactivity: Interactivity.disabledAttribute,
     conditions: SwitchConditions,
     parts: SwitchParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -29,9 +25,5 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/tab/tab.template.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTab, tabTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -22,6 +22,7 @@ export const TabAnatomy: ComponentAnatomy<typeof TabConditions, typeof TabParts>
     interactivity: Interactivity.disabledAttribute,
     conditions: TabConditions,
     parts: TabParts,
+    focus: Focus.hostFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -2,6 +2,7 @@ import { FASTTextArea } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveTextArea } from "./text-area.js";
 import { aestheticStyles, templateStyles } from "./text-area.styles.js";
 import { template, TextAreaAnatomy } from "./text-area.template.js";
 
@@ -16,7 +17,7 @@ export function composeTextArea(
 ): FASTElementDefinition {
     const styles = DesignSystem.assembleStyles(defaultStyles, TextAreaAnatomy, options);
 
-    return FASTTextArea.compose({
+    return AdaptiveTextArea.compose({
         name: `${ds.prefix}-text-area`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/text-area/text-area.definition.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.definition.ts
@@ -11,11 +11,8 @@ import { styleModules } from "./text-area.styles.modules.js";
  * @public
  */
 export const textAreaDefinition = composeTextArea(
-	DefaultDesignSystem,
-	{
-		styleModules,
-		shadowOptions: {
-			delegatesFocus: true
-		}
-	}
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
 );

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
 
@@ -59,9 +55,5 @@ export const aestheticStyles: ElementStyles = css`
         /* position: relative; */
         height: calc(${heightNumber} * 2px);
         width: 100%;
-    }
-
-    :host(:not([disabled]):focus-within) .control {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 `;

--- a/packages/adaptive-web-components/src/components/text-area/text-area.template.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTextArea, textAreaTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -24,6 +24,7 @@ export const TextAreaAnatomy: ComponentAnatomy<typeof TextAreaConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: TextAreaConditions,
     parts: TextAreaParts,
+    focus: Focus.partFocused("control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/text-area/text-area.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.ts
@@ -1,0 +1,12 @@
+import { FASTTextArea } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of Text Area. Extends {@link @microsoft/fast-foundation#FASTTextArea}.
+ *
+ * @public
+ */
+export class AdaptiveTextArea extends FASTTextArea {
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -2,6 +2,7 @@ import { FASTTextField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
 import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { AdaptiveTextField } from "./text-field.js";
 import { aestheticStyles, templateStyles } from "./text-field.styles.js";
 import { template, TextFieldAnatomy } from "./text-field.template.js";
 
@@ -16,7 +17,7 @@ export function composeTextField(
 ): FASTElementDefinition {
     const styles = DesignSystem.assembleStyles(defaultStyles, TextFieldAnatomy, options);
 
-    return FASTTextField.compose({
+    return AdaptiveTextField.compose({
         name: `${ds.prefix}-text-field`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/text-field/text-field.definition.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.definition.ts
@@ -11,11 +11,8 @@ import { styleModules } from "./text-field.styles.modules.js";
  * @public
  */
 export const textFieldDefinition = composeTextField(
-	DefaultDesignSystem,
-	{
-		styleModules,
-		shadowOptions: {
-			delegatesFocus: true
-		}
-	}
+    DefaultDesignSystem,
+    {
+        styleModules,
+    }
 );

--- a/packages/adaptive-web-components/src/components/text-field/text-field.stories.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.stories.ts
@@ -18,7 +18,6 @@ const storyTemplate = html<StoryArgs<FASTTextField>>`
         resize="${(x) => x.resize}"
         size="${(x) => x.size}"
         ?spellcheck="${(x) => x.spellcheck}"
-        tabindex="${(x) => (x.disabled ? null : "0")}"
         type="${(x) => x.type}"
         value="${(x) => x.value}"
         :ariaAtomic="${(x) => x.ariaAtomic}"

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -1,7 +1,3 @@
-import {
-    focusStrokeOuter,
-    focusStrokeThickness,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -65,15 +61,7 @@ export const aestheticStyles: ElementStyles = css`
         fill: currentcolor;
     }
 
-    :host(:not([disabled]):focus-within) .root {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-    }
-
     .control {
         height: 100%;
-    }
-
-    .control:focus-visible {
-        outline: none;
     }
 `;

--- a/packages/adaptive-web-components/src/components/text-field/text-field.template.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.template.ts
@@ -1,6 +1,6 @@
 import { ElementViewTemplate } from "@microsoft/fast-element";
 import { FASTTextField, textFieldTemplate } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -25,6 +25,7 @@ export const TextFieldAnatomy: ComponentAnatomy<typeof TextFieldConditions, type
     interactivity: Interactivity.disabledAttribute,
     conditions: TextFieldConditions,
     parts: TextFieldParts,
+    focus: Focus.partWithin("root", "control"),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/text-field/text-field.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.ts
@@ -1,0 +1,12 @@
+import { FASTTextField } from "@microsoft/fast-foundation";
+
+/**
+ * The Adaptive version of Text field. Extends {@link @microsoft/fast-foundation#FASTTextField}.
+ *
+ * @public
+ */
+export class AdaptiveTextField extends FASTTextField {
+    public focus(options?: FocusOptions): void {
+        this.control.focus(options);
+    }
+}

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.stories.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.stories.ts
@@ -21,6 +21,8 @@ export default {
         endSlotIcon: false,
         storyContent: html`
             <button slot="start">Start Slot Button</button>
+            <adaptive-button>Adaptive Button</adaptive-button>
+            <adaptive-anchor href="javascript:void;">Adaptive Anchor</adaptive-anchor>
             <button>Button</button>
             <select>
                 <option>Option 1</option>

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -1,5 +1,4 @@
 import { neutralForegroundRest } from "@adaptive-web/adaptive-ui/migration";
-import { focusStrokeOuter, focusStrokeThickness } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -44,10 +43,6 @@ export const aestheticStyles: ElementStyles = css`
         gap: 8px;
         color: ${neutralForegroundRest};
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
 
     .positioning-region {

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -2,7 +2,6 @@ import { Swatch } from"@adaptive-web/adaptive-ui";
 import { accentForegroundRest } from "@adaptive-web/adaptive-ui/migration";
 import {
     cornerRadiusControl,
-    focusStrokeOuter,
     focusStrokeThickness,
     neutralFillStealthRecipe,
     neutralFillSubtleRecipe,
@@ -35,7 +34,7 @@ export const templateStyles: ElementStyles = css`
     :host {
         position: relative;
         display: block;
-        contain: content;
+        contain: layout style;
         cursor: pointer;
     }
 
@@ -91,10 +90,6 @@ export const templateStyles: ElementStyles = css`
     ::slotted(adaptive-tree-item) {
         --tree-item-nested-width: var(--tree-item-nested-width-slotted, 0px);
     }
-
-    :host(:focus-visible) {
-        outline: none;
-    }
 `;
 
 /**
@@ -108,11 +103,6 @@ export const aestheticStyles: ElementStyles = css`
 
     .control {
         fill: currentcolor;
-    }
-
-    :host(:focus-visible) .control {
-        outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
-        outline-offset: calc(${focusStrokeThickness} * -1px);
     }
 
     .expand-collapse-button {

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
@@ -1,7 +1,7 @@
 import { children, elements, ElementViewTemplate, html, ref, slotted, when } from "@microsoft/fast-element";
 import { endSlotTemplate, startSlotTemplate, staticallyCompose, TreeItemOptions } from "@microsoft/fast-foundation";
 import type { FASTTreeItem, ValuesOf } from "@microsoft/fast-foundation";
-import { ComponentAnatomy, Interactivity } from "@adaptive-web/adaptive-ui";
+import { ComponentAnatomy, Focus, Interactivity } from "@adaptive-web/adaptive-ui";
 import { DesignSystem } from "../../design-system.js";
 
 /**
@@ -42,6 +42,7 @@ export const TreeItemAnatomy: ComponentAnatomy<typeof TreeItemConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: TreeItemConditions,
     parts: TreeItemParts,
+    focus: Focus.hostChildFocused("control"),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.ts
@@ -8,7 +8,6 @@ export const templateStyles: ElementStyles = css`
     :host {
         display: flex;
         flex-direction: column;
-        align-items: stretch;
         min-width: fit-content;
     }
 `;

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -10,7 +10,6 @@ import type { StaticallyComposableHTML } from "@microsoft/fast-foundation";
 import {
     type ComponentAnatomy,
     ElementStylesRenderer,
-    type StyleModuleEvaluateParameters,
     type StyleModuleTarget,
     Styles,
 } from "@adaptive-web/adaptive-ui";
@@ -148,18 +147,14 @@ export class DesignSystem {
             (Array.isArray(options.styles) ? options.styles : new Array(options.styles)) :
             defaultStyles;
 
-        for (const [target, styles] of globalStyleModules(anatomy)) {
-            const params: StyleModuleEvaluateParameters = Object.assign({}, anatomy?.interactivity, target);
-            const renderedStyles = new ElementStylesRenderer(styles).render(params);
-            componentStyles.push(renderedStyles);
-        }
+        const allStyleModules = [
+            ...globalStyleModules(anatomy),
+            ...(options && options.styleModules ? options.styleModules : [])
+        ];
 
-        if (options?.styleModules) {
-            for (const [target, styles] of options.styleModules) {
-                const params: StyleModuleEvaluateParameters = Object.assign({}, anatomy?.interactivity, target);
-                const renderedStyles = new ElementStylesRenderer(styles).render(params);
-                componentStyles.push(renderedStyles);
-            }
+        for (const [target, styles] of allStyleModules) {
+            const renderedStyles = new ElementStylesRenderer(styles).render(target, anatomy?.interactivity);
+            componentStyles.push(renderedStyles);
         }
 
         return new ElementStyles(componentStyles);

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -1,5 +1,58 @@
-import { ComponentAnatomy, StyleModules, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
-import { disabledStyles } from "@adaptive-web/adaptive-ui/reference";
+import { CSSDesignToken } from "@microsoft/fast-foundation";
+import {
+    ComponentAnatomy,
+    InteractiveSet,
+    StyleModules,
+    StyleModuleTarget,
+    StyleProperties,
+    Styles,
+    StyleValue
+} from "@adaptive-web/adaptive-ui";
+import { disabledStyles, focusIndicatorStyles } from "@adaptive-web/adaptive-ui/reference";
+
+/**
+ * Converts `Styles` to focus-only state. This allows styles to be constructed as usual, using interactive sets
+ * or simple values, but convert the styles specifically to focus state to the necessary structure.
+ *
+ * @param styles - The input `Styles` to convert to focus-only styles.
+ * @returns Converted `Styles`.
+ */
+const convertToFocusState = (styles: Styles) => {
+    const props: StyleProperties = {};
+    styles.effectiveProperties.forEach((value, target) => {
+        let focusValue: StyleValue | null;
+        if (typeof value === "string" || value instanceof CSSDesignToken) {
+            focusValue = value;
+        } else if (value && typeof (value as any).createCSS === "function") {
+            focusValue = value;
+        } else {
+            focusValue = (value as InteractiveSet<any>).focus;
+        }
+
+        if (focusValue) {
+            props[target] = {
+                rest: undefined,
+                hover: undefined,
+                active: undefined,
+                focus: focusValue,
+                disabled: undefined,
+            };
+        }
+    });
+    return Styles.fromProperties(props);
+};
+
+/**
+ * Focus-only state of the customized focus indicator styles.
+ */
+const focusStateStyles = convertToFocusState(focusIndicatorStyles);
+
+/**
+ * Styles to remove browser default styling.
+ */
+const focusResetStyles = convertToFocusState(Styles.fromProperties({
+    outlineStyle: "none",
+}));
 
 /**
  * Global visual styles.
@@ -18,6 +71,26 @@ export const globalStyleModules = (anatomy?: ComponentAnatomy<any, any>): StyleM
                     part: "*",
                 },
                 disabledStyles,
+            ]
+        );
+    }
+
+    // If this component can get focus, apply the focus indicator styles.
+    if (anatomy?.focus) {
+        if (anatomy.focus?.resetTarget) {
+            styles.push(
+                [
+                    anatomy.focus?.resetTarget,
+                    focusResetStyles,
+                ],
+            );
+        }
+
+        // Set intentional focus styles
+        styles.push(
+            [
+                anatomy.focus.focusTarget,
+                focusStateStyles,
             ]
         );
     }


### PR DESCRIPTION
# Pull Request

## Description

Migrated _most_ of the focus states from custom css to `Styles`. A couple of components and use cases still use some custom css. See "Next Steps" below.

Change `delegatesFocus` usage to override `focus` instead. The trouble with `delegatesFocus` is that a click _anywhere_ within the custom element footprint triggers focus. This is not desirable in some cases, like an input with a label, which has an "L" shape instead of a full block. A click in the empty space next to the label should not focus that element, just as it would not if that structure had been created using native elements.

Select includes additional style fixes.

### Issues

Closes #82

## Reviewer Notes

This ended up being a larger change than I initially expected. There are a few combinations representing focus state, and not all cases were correctly represented with the custom css previously. This is particularly true around list items, which took a majority of this effort.

Most of the changes are the same for each component: Removing styles that set the `outline` and setting the declarative focus method in the component anatomy.

A small portion of this work is infrastructure updates to enable more styling capability. The Design System portion and global style modules will likely migrate to the Adaptive UI package, as we've discussed, with the `compose` updates currently in progress.

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Accordion item indicates focus using a `::before` pseudo element. The selector generator does not currently support this, but I want to evaluate how to best support this for other styling needs as well.

List items still use custom css to indicate focus as well. I believe a selector generator update can resolve this as well. Focus management in these components is difficult as well, and I believe the underlying component needs to provide more information for robust styling capabilities. Picker falls into this category.