### PR TITLE
Added support for setting `fill` when `color` is set

### DIFF
--- a/change/@adaptive-web-adaptive-ui-be94cfb8-7fcd-465e-a89d-1fb7a1c82d9d.json
+++ b/change/@adaptive-web-adaptive-ui-be94cfb8-7fcd-465e-a89d-1fb7a1c82d9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for setting `fill` when `color` is set",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-53b24c53-96a4-443f-b5f0-1b5f51768892.json
+++ b/change/@adaptive-web-adaptive-web-components-53b24c53-96a4-443f-b5f0-1b5f51768892.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for setting `fill` when `color` is set",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -99,8 +99,4 @@ export const aestheticStyles: ElementStyles = css`
     :host(:not([disabled])) .button:focus-visible::before {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }
-
-    .icon {
-        fill: currentcolor;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -31,10 +31,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .control {
-        fill: currentcolor;
-    }
-
     .control.icon-only {
         padding: 0;
         line-height: 0;

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.ts
@@ -48,7 +48,6 @@ export const aestheticStyles: ElementStyles = css`
     .backplate {
         border-radius: 100%;
         min-width: 100%;
-        fill: currentcolor;
     }
 
     ::slotted([slot="badge"]) {

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.ts
@@ -23,6 +23,5 @@ export const aestheticStyles: ElementStyles = css`
         padding:
             calc(((${designUnit} * 0.5) - ${strokeThickness}) * 1)
             calc((${designUnit} - ${strokeThickness}) * 1);
-        fill: currentcolor;
     }
 `;

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -41,17 +41,9 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .control {
-        fill: currentcolor;
-    }
-
     :host(:not([href])),
     :host([aria-current]) .control {
         color: ${neutralForegroundRest} !important;
-        fill: currentcolor;
-    }
-
-    .separator {
         fill: currentcolor;
     }
 `;

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -37,10 +37,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .control {
-        fill: currentcolor;
-    }
-
     .control.icon-only {
         padding: 0;
         line-height: 0;

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -42,7 +42,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         --calendar-cell-size: calc((${baseHeightMultiplier} + 2 + ${density}) * ${designUnit});
         --calendar-gap: 2px;
-        fill: currentcolor;
     }
 
     .title {

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -53,7 +53,6 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
-        fill: currentcolor;
     }
 
     .label {

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -70,7 +70,6 @@ export const templateStyles: ElementStyles = css`
 export const aestheticStyles: ElementStyles = css`
     :host {
         min-width: 250px;
-        fill: currentcolor;
     }
 
     .control {

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -16,7 +16,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        fill: currentcolor;
         white-space: nowrap;
     }
 

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -33,7 +33,6 @@ export const aestheticStyles: ElementStyles = css`
         height: calc(${heightNumber} * 1px);
         border-radius: 50% !important;
         padding: 0 !important;
-        fill: currentcolor;
     }
 
     :host([disabled]) {

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -32,10 +32,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
-
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
         display: flex;

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.ts
@@ -125,7 +125,6 @@ export const aestheticStyles: ElementStyles = css`
     :host {
         --col-width: minmax(20px, auto);
         overflow: visible;
-        fill: currentcolor;
     }
 
     :host([aria-expanded="true"]) {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -67,10 +67,6 @@ export const aestheticStyles: ElementStyles = css`
         margin-bottom: 4px;
     }
 
-    .root {
-        fill: currentcolor;
-    }
-
     .control {
         height: calc(100% - 4px);
     }

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.ts
@@ -21,7 +21,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -32,7 +32,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        fill: currentcolor;
         gap: ${densityControl.horizontalGap};
     }
 

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -27,10 +27,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
-
     :host([aria-selected="true"]) {
         background: ${accentFillReadableRest};
         color: ${foregroundOnAccentRest};

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -55,7 +55,6 @@ export const aestheticStyles: ElementStyles = css`
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
         border-radius: 50% !important;
-        fill: currentcolor;
     }
 
     .label {

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -79,17 +79,12 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
-
     .label {
         margin-bottom: 4px;
     }
 
     .root {
         /*position: relative;*/
-        fill: currentcolor;
     }
 
     .clear-button {
@@ -97,6 +92,5 @@ export const aestheticStyles: ElementStyles = css`
         height: calc(100% - 2px);
         min-width: calc(${heightNumber} * 1px);
         padding: 0 calc(10px + (${designUnit} * (2 * ${density})));
-        fill: currentcolor;
     }
 `;

--- a/packages/adaptive-web-components/src/components/select/select.styles.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.ts
@@ -80,10 +80,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
-
     :host(:not([aria-multiselectable]):not([disabled]):focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])),
     :host([aria-multiselectable="true"]:not([disabled]):focus-visible) ::slotted([aria-checked="true"][role="option"]:not([disabled])) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.ts
@@ -23,7 +23,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -48,17 +48,12 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        fill: currentcolor;
-    }
-
     .label {
         margin-bottom: 4px;
     }
 
     .root {
         /*position: relative;*/
-        fill: currentcolor;
     }
 
     .control {

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -101,10 +101,6 @@ export const aestheticStyles: ElementStyles = css`
         --expand-collapse-button-size: calc((12 + 6 + 6) * 1px);
     }
 
-    .control {
-        fill: currentcolor;
-    }
-
     .expand-collapse-button {
         width: var(--expand-collapse-button-size);
         height: var(--expand-collapse-button-size);


### PR DESCRIPTION
# Pull Request

## Description

Removing use of `fill` in the custom css styles for the components. This now sets the `fill` property whenever the foreground `color` is set.

### Issues

Related to #79

## Reviewer Notes

Style files remove most uses of `currentcolor`. The remaining ones are for colors not set from Styles, should be resolved with the next style pass.

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

As commented, this is a stopgap solution and would be better implemented with the plugin architecture of the style generation.