### PR TITLE
Designer: Added feature to create interactive component states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,9 +3104,9 @@
             }
         },
         "node_modules/@figma/plugin-typings": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.58.0.tgz",
-            "integrity": "sha512-to6hFysqZYACz4VNgaBXflOVS+1pbXGNVcezDmQEMcADDkIZeAZ71Zfqf/B2YDRmU3sM1xX5Q5NkRGhjCuLOLg==",
+            "version": "1.80.0",
+            "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.80.0.tgz",
+            "integrity": "sha512-dosTVp5wj8u0pn5/pP+Ii7u/iurwbhEkT9kNbxkyrRf59cjsfbMKw5i7PyRrOUOyBmsH3edhCfh9jMff7G6tjQ==",
             "dev": true
         },
         "node_modules/@floating-ui/core": {
@@ -31149,7 +31149,7 @@
                 "@csstools/css-calc": "^1.1.1",
                 "@csstools/css-parser-algorithms": "^2.2.0",
                 "@csstools/css-tokenizer": "^2.1.1",
-                "@figma/plugin-typings": "^1.58.0",
+                "@figma/plugin-typings": "^1.80.0",
                 "concurrently": "^7.6.0",
                 "esbuild": "^0.17.10",
                 "rimraf": "^3.0.2",
@@ -31768,7 +31768,7 @@
                 "@csstools/css-calc": "^1.1.1",
                 "@csstools/css-parser-algorithms": "^2.2.0",
                 "@csstools/css-tokenizer": "^2.1.1",
-                "@figma/plugin-typings": "^1.58.0",
+                "@figma/plugin-typings": "^1.80.0",
                 "@microsoft/fast-colors": "^5.3.1",
                 "concurrently": "^7.6.0",
                 "esbuild": "^0.17.10",
@@ -34101,9 +34101,9 @@
             }
         },
         "@figma/plugin-typings": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.58.0.tgz",
-            "integrity": "sha512-to6hFysqZYACz4VNgaBXflOVS+1pbXGNVcezDmQEMcADDkIZeAZ71Zfqf/B2YDRmU3sM1xX5Q5NkRGhjCuLOLg==",
+            "version": "1.80.0",
+            "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.80.0.tgz",
+            "integrity": "sha512-dosTVp5wj8u0pn5/pP+Ii7u/iurwbhEkT9kNbxkyrRf59cjsfbMKw5i7PyRrOUOyBmsH3edhCfh9jMff7G6tjQ==",
             "dev": true
         },
         "@floating-ui/core": {

--- a/packages/adaptive-ui-figma-designer/package.json
+++ b/packages/adaptive-ui-figma-designer/package.json
@@ -47,7 +47,7 @@
     "@csstools/css-calc": "^1.1.1",
     "@csstools/css-parser-algorithms": "^2.2.0",
     "@csstools/css-tokenizer": "^2.1.1",
-    "@figma/plugin-typings": "^1.58.0",
+    "@figma/plugin-typings": "^1.80.0",
     "concurrently": "^7.6.0",
     "esbuild": "^0.17.10",
     "rimraf": "^3.0.2",

--- a/packages/adaptive-ui-figma-designer/src/core/model.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/model.ts
@@ -1,10 +1,29 @@
+import { ValuesOf } from "@microsoft/fast-foundation";
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
 import { PluginNode } from "./node.js";
+import { SerializableNodeData } from "./serialization.js";
 
+export const AdditionalDataKeys = {
 /**
- * A key for passing the fill color from the tool to the plugin. Keeping it out of main design tokens to avoid a lot more special handling.
+    * A key for passing the fill color from the tool to the plugin.
+    *
+    * @remarks
+    * Keeping it out of main design tokens to avoid a lot more special handling.
  */
-export const TOOL_PARENT_FILL_COLOR = "tool-parent-fill-color";
+    toolParentFillColor: "tool-parent-fill-color",
+
+    /**
+     * The state of interactive state configuration. Applies to component sets.
+     */
+    states: "states",
+
+    /**
+     * The interactive state of the node. Applies to all nodes.
+     */
+    state: "state",
+} as const;
+
+export type AdditionalDataKeys = ValuesOf<typeof AdditionalDataKeys>;
 
 /**
  * A design token value.
@@ -269,3 +288,15 @@ export const pluginNodesToUINodes = (
 
     return convertedNodes;
 }
+
+export interface CreateStatesMessage {
+    readonly type: 'CREATE_STATES';
+    id: string;
+}
+
+export interface NodeDataMessage {
+    readonly type: 'NODE_DATA';
+    nodes: SerializableNodeData[];
+}
+
+export type PluginMessage = CreateStatesMessage | NodeDataMessage;

--- a/packages/adaptive-ui-figma-designer/src/core/model.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/model.ts
@@ -4,12 +4,12 @@ import { PluginNode } from "./node.js";
 import { SerializableNodeData } from "./serialization.js";
 
 export const AdditionalDataKeys = {
-/**
-    * A key for passing the fill color from the tool to the plugin.
-    *
-    * @remarks
-    * Keeping it out of main design tokens to avoid a lot more special handling.
- */
+    /**
+     * A key for passing the fill color from the tool to the plugin.
+     *
+     * @remarks
+     * Keeping it out of main design tokens to avoid a lot more special handling.
+     */
     toolParentFillColor: "tool-parent-fill-color",
 
     /**

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -1,7 +1,9 @@
 import { ColorRGBA64 } from "@microsoft/fast-colors";
+import { ValuesOf } from "@microsoft/fast-foundation";
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
 import {
     AdditionalData,
+    AdditionalDataKeys,
     AppliedDesignTokens,
     AppliedStyleModules,
     AppliedStyleValues,
@@ -10,10 +12,17 @@ import {
     ReadonlyAppliedDesignTokens,
     ReadonlyAppliedStyleModules,
     ReadonlyDesignTokenValues,
-    TOOL_PARENT_FILL_COLOR,
 } from "./model.js";
 
 const DesignTokenCache: Map<string, ReadonlyDesignTokenValues> = new Map();
+
+export const StatesState = {
+    notAvailable: "notAvailable",
+    available: "available",
+    configured: "configured",
+} as const;
+
+export type StatesState = ValuesOf<typeof StatesState>;
 
 /**
  * The abstract class the plugin Controller interacts with.
@@ -148,6 +157,16 @@ export abstract class PluginNode {
     public abstract readonly fillColor: ColorRGBA64 | null;
 
     /**
+     * The state of stateful component capabilities for this node.
+     */
+    public abstract readonly states: StatesState;
+
+    /**
+     * The interactive state of the node.
+     */
+    public abstract get state(): string | null;
+
+    /**
      * Gets whether this type of node can have children or not.
      */
     public abstract get canHaveChildren(): boolean;
@@ -229,10 +248,17 @@ export abstract class PluginNode {
      * Gets additional data associated with this node.
      */
     public get additionalData(): AdditionalData {
-        if (!this._additionalData.has(TOOL_PARENT_FILL_COLOR) && this.parent?.fillColor) {
-            // console.log("PluginNode.get_additionalData - adding:", TOOL_PARENT_FILL_COLOR, this.debugInfo, this.parent?.fillColor.toStringHexARGB());
-            this._additionalData.set(TOOL_PARENT_FILL_COLOR, this.parent.fillColor.toStringHexARGB());
+        this._additionalData.set(AdditionalDataKeys.states, this.states);
+
+        if (this.state) {
+            this._additionalData.set(AdditionalDataKeys.state, this.state);
         }
+
+        if (!this._additionalData.has(AdditionalDataKeys.toolParentFillColor) && this.parent?.fillColor) {
+            // console.log("PluginNode.get_additionalData - adding:", AdditionalDataKeys.toolParentFillColor, this.debugInfo, this.parent?.fillColor.toStringHexARGB());
+            this._additionalData.set(AdditionalDataKeys.toolParentFillColor, this.parent.fillColor.toStringHexARGB());
+        }
+
         return this._additionalData;
     }
 

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -24,6 +24,8 @@ export const StatesState = {
 
 export type StatesState = ValuesOf<typeof StatesState>;
 
+export type State = "Rest" | "Hover" | "Active" | "Focus" | "Disabled";
+
 /**
  * The abstract class the plugin Controller interacts with.
  * Acts as a basic intermediary for node structure and data storage only.

--- a/packages/adaptive-ui-figma-designer/src/figma/main.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/main.ts
@@ -1,4 +1,4 @@
-import { SerializableUIState } from "../core/serialization.js";
+import { PluginMessage } from "../core/model.js";
 import { FigmaController } from "./controller.js";
 
 const controller = new FigmaController();
@@ -62,7 +62,8 @@ function debounceSelection() {
 
 figma.on("selectionchange", debounceSelection);
 
-figma.ui.onmessage = (message: SerializableUIState): void => {
+// Comes from ../ui/index.ts parent.postMessage
+figma.ui.onmessage = (message: PluginMessage): void => {
     notifyProcessing(() => {
         controller.handleMessage(message);
     });

--- a/packages/adaptive-ui-figma-designer/src/ui/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/index.ts
@@ -5,9 +5,9 @@ import { tabDefinition } from "@adaptive-web/adaptive-web-components/tab";
 import { tabPanelDefinition } from "@adaptive-web/adaptive-web-components/tab-panel";
 import { tabsDefinition } from "@adaptive-web/adaptive-web-components/tabs";
 import { DesignToken } from "@microsoft/fast-foundation";
+import { PluginMessage } from '../core/model.js';
 import { deserializeUINodes, SerializableUIState } from "../core/serialization.js";
 import { App } from "./app.js";
-import { PluginMessage } from '../core/model.js';
 
 AdaptiveDesignSystem.defineComponents({
     buttonDefinition,

--- a/packages/adaptive-ui-figma-designer/src/ui/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/index.ts
@@ -5,8 +5,9 @@ import { tabDefinition } from "@adaptive-web/adaptive-web-components/tab";
 import { tabPanelDefinition } from "@adaptive-web/adaptive-web-components/tab-panel";
 import { tabsDefinition } from "@adaptive-web/adaptive-web-components/tabs";
 import { DesignToken } from "@microsoft/fast-foundation";
-import { deserializeUINodes, SerializableUIState, serializeUINodes } from "../core/serialization.js";
+import { deserializeUINodes, SerializableUIState } from "../core/serialization.js";
 import { App } from "./app.js";
+import { PluginMessage } from '../core/model.js';
 
 AdaptiveDesignSystem.defineComponents({
     buttonDefinition,
@@ -24,16 +25,15 @@ window.onload = () => {
     const app: App = document.querySelector("designer-app") as App;
 
     // Send a message from the UI to the Controller 
-    app.addEventListener("dispatch", (e: Event): void => {
-        const message: SerializableUIState = {
-            selectedNodes: serializeUINodes((e as CustomEvent).detail)
-        }
+    app.addEventListener("dispatch", (e: CustomEvent<PluginMessage>): void => {
+        // Goes to ../figma/main.ts figma.ui.onmessage
         parent.postMessage({
-            pluginMessage: message
+            pluginMessage: e.detail
         }, "*");
     });
 
     // Update UI from Controller's message
+    // Comes from ../figma/controller.ts figma.ui.postMessage
     window.onmessage = (e: MessageEvent): void => {
         const message: SerializableUIState = e.data.pluginMessage;
         const nodes = message.selectedNodes;

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-states.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-states.ts
@@ -1,0 +1,26 @@
+import { AdditionalDataKeys, type PluginMessage } from "../core/model.js";
+import { StatesState } from "../core/node.js";
+import { UIController } from "./ui-controller.js";
+
+export class StatesController {
+    constructor(
+        private readonly controller: UIController,
+    ) {
+    }
+
+    public getState(): StatesState {
+        return this.controller.selectedNodes.length === 1 ?
+            this.controller.selectedNodes[0].additionalData.get(AdditionalDataKeys.states) as StatesState :
+            StatesState.notAvailable;
+    }
+
+    public createStates(): void {
+        const nodeID = this.controller.selectedNodes[0].id;
+
+        const message: PluginMessage = {
+            type: "CREATE_STATES",
+            id: nodeID
+        };
+        this.controller.dispatchMessage(message, "createStates");
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

In the Figma Designer, a new feature when you select a component state, to create the interactive state variants automatically (hover, active, focus, and disabled).

## Reviewer Notes

A portion of this work updates the messaging model between the plugin and the UI. Previously we only had one type of message, which was component styling state back and forth. Updated to support multiple types of messages and added a new one for the "create states" message.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

I think I can clean up the need to manage the serialization by removing the use of maps. Everything else should serialize correctly by default.