### PR TITLE
Components: Migrate default icons to local svgs

### DIFF
--- a/change/@adaptive-web-adaptive-ui-4a2ed00b-771c-4531-9808-f03159b28bf9.json
+++ b/change/@adaptive-web-adaptive-ui-4a2ed00b-771c-4531-9808-f03159b28bf9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Components: Migrate default icons to local svgs",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-6dc6a84e-64fc-4e8d-ae1a-3460ce54cce8.json
+++ b/change/@adaptive-web-adaptive-web-components-6dc6a84e-64fc-4e8d-ae1a-3460ce54cce8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Components: Migrate default icons to local svgs",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3122,11 +3122,6 @@
                 "@floating-ui/core": "^1.0.5"
             }
         },
-        "node_modules/@fluentui/svg-icons": {
-            "version": "1.1.192",
-            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.192.tgz",
-            "integrity": "sha512-Sps/7lFm1rGluuJ/7oczyWQfoM0tGzJalKzgi3+zU0JQmjQyl8Jj7o3P55xGCvU7iMiuux/3YpebjzVaPdt+8w=="
-        },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -31479,7 +31474,6 @@
             "license": "MIT",
             "dependencies": {
                 "@adaptive-web/adaptive-ui": "0.2.1",
-                "@fluentui/svg-icons": "^1.1.192",
                 "@microsoft/fast-element": "2.0.0-beta.26",
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
                 "@microsoft/fast-web-utilities": "6.0.0",
@@ -31980,7 +31974,6 @@
                 "@babel/core": "^7.20.12",
                 "@custom-elements-manifest/analyzer": "^0.6.8",
                 "@custom-elements-manifest/to-markdown": "^0.1.0",
-                "@fluentui/svg-icons": "^1.1.192",
                 "@microsoft/api-extractor": "^7.34.4",
                 "@microsoft/fast-element": "2.0.0-beta.26",
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
@@ -34118,11 +34111,6 @@
             "requires": {
                 "@floating-ui/core": "^1.0.5"
             }
-        },
-        "@fluentui/svg-icons": {
-            "version": "1.1.192",
-            "resolved": "https://registry.npmjs.org/@fluentui/svg-icons/-/svg-icons-1.1.192.tgz",
-            "integrity": "sha512-Sps/7lFm1rGluuJ/7oczyWQfoM0tGzJalKzgi3+zU0JQmjQyl8Jj7o3P55xGCvU7iMiuux/3YpebjzVaPdt+8w=="
         },
         "@gar/promisify": {
             "version": "1.1.3",

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -88,9 +88,6 @@ export interface ComponentAnatomy<TConditions extends ComponentConditions, TPart
 }
 
 // @public
-export const componentBaseStyles = "\n    :host([hidden]) {\n        display: none !important;\n    }\n\n    :host {\n        box-sizing: border-box;\n    }\n\n    *, *:before, *:after {\n        box-sizing: inherit;\n    }\n";
-
-// @public
 export type ComponentConditions = Record<string, string>;
 
 // @public

--- a/packages/adaptive-ui/src/index.ts
+++ b/packages/adaptive-ui/src/index.ts
@@ -4,7 +4,6 @@ export * from "./elevation/index.js";
 export * from "./modules/index.js";
 export * from "./adaptive-design-tokens.js";
 export * from "./recipes.js";
-export * from "./styles.js";
 export * from "./token-helpers-color.js";
 export * from "./token-helpers.js";
 export * from "./types.js";

--- a/packages/adaptive-web-components/package.json
+++ b/packages/adaptive-web-components/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@adaptive-web/adaptive-ui": "0.2.1",
-    "@fluentui/svg-icons": "^1.1.192",
     "@microsoft/fast-element": "2.0.0-beta.26",
     "@microsoft/fast-foundation": "3.0.0-alpha.31",
     "@microsoft/fast-web-utilities": "6.0.0",

--- a/packages/adaptive-web-components/src/assets.ts
+++ b/packages/adaptive-web-components/src/assets.ts
@@ -1,0 +1,20 @@
+const svgIcon = (path: string, className: "stroked" | "filled" = "stroked"): string => {
+    const pathStyle = className === "filled" ? 'stroke="none"': 'fill="none"';
+    return `<svg class="${className}" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <path d="${path}" ${pathStyle}/>
+</svg>`;
+}
+
+export const checkboxIcon = svgIcon("M3 9L5.5 11.5L13.5 4");
+
+export const checkboxIndeterminateIcon = svgIcon("M2.5 8H13.5");
+
+export const radioIcon = svgIcon("M12.5 8a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z", "filled");
+
+export const chevronDownIcon = svgIcon("M3.5 6L8 10.5L12.5 6");
+
+export const chevronLeftIcon = svgIcon("M10 12.5L5.5 8L10 3.5");
+
+export const chevronRightIcon = svgIcon("M6 3.5L10.5 8L6 12.5");
+
+export const chevronUpIcon = svgIcon("M3.5 10L8 5.5L12.5 10");

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.compose.ts
@@ -1,11 +1,11 @@
 import { FASTAccordionItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./accordion-item.styles.js";
 import { AccordionItemAnatomy, AccordionItemStatics, template } from "./accordion-item.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.definition.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.definition.ts
@@ -1,5 +1,4 @@
-import chevronDownIcon from "@fluentui/svg-icons/icons/chevron_down_12_regular.svg";
-import chevronUpIcon from "@fluentui/svg-icons/icons/chevron_up_12_regular.svg";
+import { chevronDownIcon, chevronUpIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeAccordionItem } from "./accordion-item.compose.js";
 import { AccordionItemStatics } from './accordion-item.template.js';
@@ -18,7 +17,7 @@ export const accordionItemDefinition = composeAccordionItem(
     {
         statics: {
             [AccordionItemStatics.collapsed]: chevronDownIcon,
-            [AccordionItemStatics.expanded]: chevronUpIcon
+            [AccordionItemStatics.expanded]: chevronUpIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.compose.ts
@@ -1,7 +1,7 @@
 import { FASTAccordion } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./accordion.styles.js";
 import { AccordionAnatomy, template } from "./accordion.template.js";
 

--- a/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.compose.ts
@@ -1,6 +1,6 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveAnchor } from "./anchor.js";
 import { aestheticStyles, templateStyles } from "./anchor.styles.js";
 import { AnchorAnatomy, template } from "./anchor.template.js";

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.compose.ts
@@ -1,7 +1,7 @@
 import { FASTAnchoredRegion } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./anchored-region.styles.js";
 import { AnchoredRegionAnatomy, template } from "./anchored-region.template.js";
 

--- a/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.compose.ts
@@ -1,7 +1,7 @@
 import { FASTAvatar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./avatar.styles.js";
 import { AvatarAnatomy, template } from "./avatar.template.js";
 

--- a/packages/adaptive-web-components/src/components/badge/badge.compose.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.compose.ts
@@ -1,7 +1,7 @@
 import { FASTBadge } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./badge.styles.js";
 import { BadgeAnatomy, template } from "./badge.template.js";
 

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.compose.ts
@@ -1,12 +1,12 @@
 import { FASTBreadcrumbItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from "../../styles/styles.js";
 import { AdaptiveBreadcrumbItem } from "./breadcrumb-item.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb-item.styles.js";
 import { BreadcrumbItemAnatomy, BreadcrumbItemStatics, template } from "./breadcrumb-item.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.definition.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.definition.ts
@@ -1,4 +1,4 @@
-import chevronRightIcon from "@fluentui/svg-icons/icons/chevron_right_12_regular.svg";
+import { chevronRightIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeBreadcrumbItem } from "./breadcrumb-item.compose.js";
 import { BreadcrumbItemStatics } from "./breadcrumb-item.template.js";
@@ -16,7 +16,7 @@ export const breadcrumbItemDefinition = composeBreadcrumbItem(
     DefaultDesignSystem,
     {
         statics: {
-            [BreadcrumbItemStatics.separator]: chevronRightIcon
+            [BreadcrumbItemStatics.separator]: chevronRightIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.compose.ts
@@ -1,7 +1,7 @@
 import { FASTBreadcrumb } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./breadcrumb.styles.js";
 import { BreadcrumbAnatomy, template } from "./breadcrumb.template.js";
 

--- a/packages/adaptive-web-components/src/components/button/button.compose.ts
+++ b/packages/adaptive-web-components/src/components/button/button.compose.ts
@@ -1,6 +1,6 @@
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveButton } from "./button.js";
 import { aestheticStyles, templateStyles } from "./button.styles.js";
 import { ButtonAnatomy, template } from "./button.template.js";

--- a/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.compose.ts
@@ -1,7 +1,7 @@
 import { FASTCalendar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./calendar.styles.js";
 import { CalendarAnatomy, template } from "./calendar.template.js";
 

--- a/packages/adaptive-web-components/src/components/card/card.compose.ts
+++ b/packages/adaptive-web-components/src/components/card/card.compose.ts
@@ -1,7 +1,7 @@
 import { FASTCard } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./card.styles.js";
 import { CardAnatomy, template } from "./card.template.js";
 

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.compose.ts
@@ -1,11 +1,11 @@
 import { FASTCheckbox } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./checkbox.styles.js";
 import { CheckboxAnatomy, CheckboxStatics, template } from "./checkbox.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.definition.ts
@@ -1,5 +1,4 @@
-import checkmarkIcon from "@fluentui/svg-icons/icons/checkmark_16_regular.svg";
-import subtractIcon from "@fluentui/svg-icons/icons/subtract_16_regular.svg";
+import { checkboxIcon, checkboxIndeterminateIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeCheckbox } from './checkbox.compose.js';
 import { CheckboxStatics } from "./checkbox.template.js";
@@ -17,8 +16,8 @@ export const checkboxDefinition = composeCheckbox(
     DefaultDesignSystem,
     {
         statics: {
-            [CheckboxStatics.checked]: checkmarkIcon,
-            [CheckboxStatics.indeterminate]: subtractIcon
+            [CheckboxStatics.checked]: checkboxIcon,
+            [CheckboxStatics.indeterminate]: checkboxIndeterminateIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.compose.ts
@@ -1,12 +1,12 @@
 import { FASTCombobox } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from "@microsoft/fast-element";
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from "../../styles/styles.js";
 import { AdaptiveCombobox } from "./combobox.js";
 import { aestheticStyles, templateStyles } from "./combobox.styles.js";
 import { ComboboxAnatomy, ComboboxStatics, template } from "./combobox.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/combobox/combobox.definition.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.definition.ts
@@ -1,4 +1,4 @@
-import chevronDownIcon from "@fluentui/svg-icons/icons/chevron_down_12_regular.svg";
+import { chevronDownIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeCombobox } from "./combobox.compose.js";
 import { ComboboxStatics } from "./combobox.template.js";
@@ -16,7 +16,7 @@ export const comboboxDefinition = composeCombobox(
     DefaultDesignSystem,
     {
         statics: {
-            [ComboboxStatics.indicator]: chevronDownIcon
+            [ComboboxStatics.indicator]: chevronDownIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDataGridCell } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./data-grid-cell.styles.js";
 import { DataGridCellAnatomy, template } from "./data-grid-cell.template.js";
 

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDataGridRow } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./data-grid-row.styles.js";
 import { DataGridRowAnatomy, template } from "./data-grid-row.template.js";
 

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDataGrid } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./data-grid.styles.js";
 import { DataGridAnatomy, template } from "./data-grid.template.js";
 

--- a/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDialog } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./dialog.styles.js";
 import { DialogAnatomy, template } from "./dialog.template.js";
 

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDisclosure } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./disclosure.styles.js";
 import { DisclosureAnatomy, template } from "./disclosure.template.js";
 

--- a/packages/adaptive-web-components/src/components/divider/divider.compose.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.compose.ts
@@ -1,7 +1,7 @@
 import { FASTDivider } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./divider.styles.js";
 import { DividerAnatomy, template } from "./divider.template.js";
 

--- a/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.compose.ts
@@ -1,11 +1,11 @@
 import { FASTFlipper } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./flipper.styles.js";
 import { FlipperAnatomy, FlipperStatics, template } from "./flipper.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/flipper/flipper.definition.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.definition.ts
@@ -1,5 +1,4 @@
-import chevronLeftIcon from "@fluentui/svg-icons/icons/chevron_left_16_regular.svg";
-import chevronRightIcon from "@fluentui/svg-icons/icons/chevron_right_16_regular.svg";
+import { chevronLeftIcon, chevronRightIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeFlipper } from "./flipper.compose.js";
 import { FlipperStatics } from "./flipper.template.js";
@@ -18,7 +17,7 @@ export const flipperDefinition = composeFlipper(
     {
         statics: {
             [FlipperStatics.previous]: chevronLeftIcon,
-            [FlipperStatics.next]: chevronRightIcon
+            [FlipperStatics.next]: chevronRightIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.compose.ts
@@ -1,6 +1,6 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./horizontal-scroll.styles.js";
 import { HorizontalScrollAnatomy, template } from "./horizontal-scroll.template.js";
 import { AdaptiveHorizontalScroll } from "./horizontal-scroll.js";

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.compose.ts
@@ -1,7 +1,7 @@
 import { FASTListboxOption } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./listbox-option.styles.js";
 import { ListboxOptionAnatomy, template } from "./listbox-option.template.js";
 

--- a/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.compose.ts
@@ -1,7 +1,7 @@
 import { FASTListboxElement } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./listbox.styles.js";
 import { ListboxAnatomy, template } from "./listbox.template.js";
 

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.compose.ts
@@ -1,11 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from '../../styles/styles.js';
 import { AdaptiveMenuItem } from "./menu-item.js";
 import { aestheticStyles, templateStyles } from "./menu-item.styles.js";
 import { MenuItemAnatomy, MenuItemStatics, template } from "./menu-item.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.definition.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.definition.ts
@@ -1,6 +1,4 @@
-import checkmarkIcon from "@fluentui/svg-icons/icons/checkmark_16_regular.svg";
-import chevronRightIcon from "@fluentui/svg-icons/icons/chevron_right_12_regular.svg";
-import circleIcon from "@fluentui/svg-icons/icons/circle_12_filled.svg";
+import { checkboxIcon, chevronRightIcon, radioIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeMenuItem } from "./menu-item.compose.js";
 import { MenuItemStatics } from "./menu-item.template.js";
@@ -18,9 +16,9 @@ export const menuItemDefinition = composeMenuItem(
     DefaultDesignSystem,
     {
         statics: {
-            [MenuItemStatics.checkbox]: checkmarkIcon,
-            [MenuItemStatics.radio]: circleIcon,
-            [MenuItemStatics.submenu]: chevronRightIcon
+            [MenuItemStatics.checkbox]: checkboxIcon,
+            [MenuItemStatics.radio]: radioIcon,
+            [MenuItemStatics.submenu]: chevronRightIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/menu/menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.compose.ts
@@ -1,6 +1,6 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveMenu } from "./menu.js";
 import { aestheticStyles, templateStyles } from "./menu.styles.js";
 import { MenuAnatomy, template } from "./menu.template.js";

--- a/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.compose.ts
@@ -1,12 +1,12 @@
 import { FASTNumberField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from '../../styles/styles.js';
 import { AdaptiveNumberField } from "./number-field.js";
 import { aestheticStyles, templateStyles } from "./number-field.styles.js";
 import { NumberFieldAnatomy, NumberFieldStatics, template } from "./number-field.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/number-field/number-field.definition.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.definition.ts
@@ -1,5 +1,4 @@
-import chevronDownIcon from "@fluentui/svg-icons/icons/chevron_down_12_regular.svg";
-import chevronUpIcon from "@fluentui/svg-icons/icons/chevron_up_12_regular.svg";
+import { chevronDownIcon, chevronUpIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeNumberField } from "./number-field.compose.js";
 import { NumberFieldStatics } from "./number-field.template.js";
@@ -18,7 +17,7 @@ export const numberFieldDefinition = composeNumberField(
     {
         statics: {
             [NumberFieldStatics.stepDown]: chevronDownIcon,
-            [NumberFieldStatics.stepUp]: chevronUpIcon
+            [NumberFieldStatics.stepUp]: chevronUpIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.compose.ts
@@ -1,7 +1,7 @@
 import { FASTPickerListItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./picker-list-item.styles.js";
 import { PickerListItemAnatomy, template } from "./picker-list-item.template.js";
 

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.compose.ts
@@ -1,7 +1,7 @@
 import { FASTPickerList } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./picker-list.styles.js";
 import { PickerListAnatomy, template } from "./picker-list.template.js";
 

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.compose.ts
@@ -1,7 +1,7 @@
 import { FASTPickerMenuOption } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./picker-menu-option.styles.js";
 import { PickerMenuOptionAnatomy, template } from "./picker-menu-option.template.js";
 

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.compose.ts
@@ -1,7 +1,7 @@
 import { FASTPickerMenu } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./picker-menu.styles.js";
 import { PickerMenuAnatomy, template } from "./picker-menu.template.js";
 

--- a/packages/adaptive-web-components/src/components/picker/picker.compose.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.compose.ts
@@ -1,7 +1,7 @@
 import { FASTPicker } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./picker.styles.js";
 import { PickerAnatomy, template } from "./picker.template.js";
 

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.compose.ts
@@ -1,7 +1,7 @@
 import { FASTProgressRing } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./progress-ring.styles.js";
 import { ProgressRingAnatomy, template } from "./progress-ring.template.js";
 

--- a/packages/adaptive-web-components/src/components/progress/progress.compose.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.compose.ts
@@ -1,7 +1,7 @@
 import { FASTProgress } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./progress.styles.js";
 import { ProgressAnatomy, template } from "./progress.template.js";
 

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.compose.ts
@@ -1,7 +1,7 @@
 import { FASTRadioGroup } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./radio-group.styles.js";
 import { RadioGroupAnatomy, template } from "./radio-group.template.js";
 

--- a/packages/adaptive-web-components/src/components/radio/radio.compose.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.compose.ts
@@ -1,11 +1,11 @@
 import { FASTRadio } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from '../../styles/styles.js';
 import { aestheticStyles, templateStyles } from "./radio.styles.js";
 import { RadioAnatomy, RadioStatics, template } from "./radio.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/radio/radio.definition.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.definition.ts
@@ -1,4 +1,4 @@
-import circleIcon from "@fluentui/svg-icons/icons/circle_12_filled.svg";
+import { radioIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeRadio } from "./radio.compose.js";
 import { RadioStatics } from "./radio.template.js";
@@ -16,7 +16,7 @@ export const radioDefinition = composeRadio(
     DefaultDesignSystem,
     {
         statics: {
-            [RadioStatics.checked]: circleIcon
+            [RadioStatics.checked]: radioIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/search/search.compose.ts
+++ b/packages/adaptive-web-components/src/components/search/search.compose.ts
@@ -1,7 +1,7 @@
 import { FASTSearch } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveSearch } from "./search.js";
 import { aestheticStyles, templateStyles } from "./search.styles.js";
 import { SearchAnatomy, template } from "./search.template.js";

--- a/packages/adaptive-web-components/src/components/select/select.compose.ts
+++ b/packages/adaptive-web-components/src/components/select/select.compose.ts
@@ -1,11 +1,11 @@
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from '../../styles/styles.js';
 import { AdaptiveSelect } from "./select.js";
 import { aestheticStyles, templateStyles } from "./select.styles.js";
 import { SelectAnatomy, SelectStatics, template } from "./select.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/select/select.definition.ts
+++ b/packages/adaptive-web-components/src/components/select/select.definition.ts
@@ -1,4 +1,4 @@
-import chevronDownIcon from "@fluentui/svg-icons/icons/chevron_down_12_regular.svg";
+import { chevronDownIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeSelect } from "./select.compose.js";
 import { SelectStatics } from "./select.template.js";
@@ -16,7 +16,7 @@ export const selectDefinition = composeSelect(
     DefaultDesignSystem,
     {
         statics: {
-            [SelectStatics.indicator]: chevronDownIcon
+            [SelectStatics.indicator]: chevronDownIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.compose.ts
@@ -1,7 +1,7 @@
 import { FASTSkeleton } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./skeleton.styles.js";
 import { SkeletonAnatomy, template } from "./skeleton.template.js";
 

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.compose.ts
@@ -1,7 +1,7 @@
 import { FASTSliderLabel } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./slider-label.styles.js";
 import { SliderLabelAnatomy, template } from "./slider-label.template.js";
 

--- a/packages/adaptive-web-components/src/components/slider/slider.compose.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.compose.ts
@@ -1,7 +1,7 @@
 import { FASTSlider } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./slider.styles.js";
 import { SliderAnatomy, template } from "./slider.template.js";
 

--- a/packages/adaptive-web-components/src/components/switch/switch.compose.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.compose.ts
@@ -1,7 +1,7 @@
 import { FASTSwitch } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./switch.styles.js";
 import { SwitchAnatomy, template } from "./switch.template.js";
 

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTabPanel } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./tab-panel.styles.js";
 import { TabPanelAnatomy, template } from "./tab-panel.template.js";
 

--- a/packages/adaptive-web-components/src/components/tab/tab.compose.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTab } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./tab.styles.js";
 import { TabAnatomy, template } from "./tab.template.js";
 

--- a/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTabs } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./tabs.styles.js";
 import { TabsAnatomy, template } from "./tabs.template.js";
 

--- a/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTextArea } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveTextArea } from "./text-area.js";
 import { aestheticStyles, templateStyles } from "./text-area.styles.js";
 import { template, TextAreaAnatomy } from "./text-area.template.js";

--- a/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTextField } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { AdaptiveTextField } from "./text-field.js";
 import { aestheticStyles, templateStyles } from "./text-field.styles.js";
 import { template, TextFieldAnatomy } from "./text-field.template.js";

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.compose.ts
@@ -1,7 +1,7 @@
 import { FASTToolbar } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./toolbar.styles.js";
 import { template, ToolbarAnatomy } from "./toolbar.template.js";
 

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTooltip } from '@microsoft/fast-foundation';
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./tooltip.styles.js";
 import { template, TooltipAnatomy } from "./tooltip.template.js";
 

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.compose.ts
@@ -1,11 +1,11 @@
 import { FASTTreeItem } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles, svgIconStyles } from '../../styles/styles.js';
 import { aestheticStyles, templateStyles } from "./tree-item.styles.js";
 import { template, TreeItemAnatomy, TreeItemStatics } from "./tree-item.template.js";
 
-const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
+const defaultStyles = [componentBaseStyles, templateStyles, svgIconStyles, aestheticStyles];
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.definition.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.definition.ts
@@ -1,4 +1,4 @@
-import chevronRightIcon from "@fluentui/svg-icons/icons/chevron_right_12_regular.svg";
+import { chevronRightIcon } from "../../assets.js";
 import { DefaultDesignSystem } from "../../design-system.js";
 import { composeTreeItem } from "./tree-item.compose.js";
 import { TreeItemStatics } from "./tree-item.template.js";
@@ -16,7 +16,7 @@ export const treeItemDefinition = composeTreeItem(
     DefaultDesignSystem,
     {
         statics: {
-            [TreeItemStatics.expandCollapse]: chevronRightIcon
+            [TreeItemStatics.expandCollapse]: chevronRightIcon,
         },
         styleModules,
     }

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -104,7 +104,7 @@ export const aestheticStyles: ElementStyles = css`
     .expand-collapse-button {
         width: var(--expand-collapse-button-size);
         height: var(--expand-collapse-button-size);
-        padding: 6px;
+        padding: 4px;
     }
 
     .expand-collapse-button:hover {

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.compose.ts
@@ -1,7 +1,7 @@
 import { FASTTreeView } from "@microsoft/fast-foundation";
 import type { FASTElementDefinition } from '@microsoft/fast-element';
-import { componentBaseStyles } from "@adaptive-web/adaptive-ui";
 import { ComposeOptions, DesignSystem } from "../../design-system.js";
+import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./tree-view.styles.js";
 import { template, TreeViewAnatomy } from "./tree-view.template.js";
 

--- a/packages/adaptive-web-components/src/styles/index.ts
+++ b/packages/adaptive-web-components/src/styles/index.ts
@@ -14,3 +14,5 @@ export const density: CSSDirective = css.partial`0`;
  * @deprecated
  */
 export const heightNumber: CSSDirective = css.partial`32`;
+
+export * from "./styles.js";

--- a/packages/adaptive-web-components/src/styles/styles.ts
+++ b/packages/adaptive-web-components/src/styles/styles.ts
@@ -18,3 +18,19 @@ export const componentBaseStyles = /* css */`
         box-sizing: inherit;
     }
 `;
+
+/**
+ * Styles for default svg icons.
+ * 
+ * @public
+ * @remarks
+ * Temporary rule to be migrated to style modules structure.
+ */
+export const svgIconStyles = /* css */`
+    .stroked {
+        stroke: currentcolor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 1px;
+    }
+`;


### PR DESCRIPTION
# Pull Request

## Description

We've wanted to remove the dependency on external svgs to simplify build and configuration. This presented an opportunity to align more to adaptive principles as well.

## Reviewer Notes

Moved the base component styles from `adaptive-ui` since it was related to components specifically and I needed to add styles for the stroked icons. This resulted in many file changes though.

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

Updated icon references in the few components which use them.

## ⏭ Next Steps
Continue to evolve styling to better support stroke style decision.