### PR TITLE
Adaptive UI: Update culori imports for tree shaking

### DIFF
--- a/change/@adaptive-web-adaptive-ui-73e391e4-8d30-43d4-adb3-e25f35e09723.json
+++ b/change/@adaptive-web-adaptive-ui-73e391e4-8d30-43d4-adb3-e25f35e09723.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI: Update culori imports for tree shaking",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { Color } from 'culori';
+import { Color } from 'culori/fn';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import type { CSSDirective } from '@microsoft/fast-element';

--- a/packages/adaptive-ui/src/color/palette-okhsl.ts
+++ b/packages/adaptive-ui/src/color/palette-okhsl.ts
@@ -1,7 +1,10 @@
-import { clampChroma, Color, interpolate, okhsl, parse, rgb, samples} from "culori";
+import { clampChroma, Color, interpolate, modeOkhsl, modeRgb, parse, samples, useMode} from "culori/fn";
 import { BasePalette } from "./palette.js";
 import { SwatchRGB } from "./swatch.js";
 import { _black, _white } from "./utilities/color-constants.js";
+
+const okhsl = useMode(modeOkhsl);
+const rgb = useMode(modeRgb);
 
 const stepCount = 56;
 


### PR DESCRIPTION
# Pull Request

## Description

Updates the `culori` imports to use the path that supports tree-shaking.

I missed doing this on the initial PR.

## Test Plan

Tested in one of the example apps.

Took 22k off the minimized size, 44k off the non minimized size.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.