### PR TITLE
Adaptive UI: Migrated from fast-colors to culori

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,6 @@
     },
     "cSpell.words": [
         "Appliable",
-        "ARGB",
         "culori",
         "okhsl",
         "Unregisters"

--- a/change/@adaptive-web-adaptive-ui-82cdb824-eb0c-4e1a-9434-e9e75cd32956.json
+++ b/change/@adaptive-web-adaptive-ui-82cdb824-eb0c-4e1a-9434-e9e75cd32956.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrated from fast-colors to culori",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,11 +4124,6 @@
                 "typescript": "~3.9.0 || ~4.3.5 || ^4.6.2"
             }
         },
-        "node_modules/@microsoft/fast-colors": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/fast-colors/-/fast-colors-5.3.1.tgz",
-            "integrity": "sha512-72RZXVfCbwQzvo5sXXkuLXLT7rMeYaSf5r/6ewQiv/trBtqpWRm4DEH2EilHw/iWTBKOXs1qZNQndgUMa5n4LA=="
-        },
         "node_modules/@microsoft/fast-element": {
             "version": "2.0.0-beta.26",
             "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-2.0.0-beta.26.tgz",
@@ -31380,7 +31375,6 @@
             "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
-                "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-element": "2.0.0-beta.26",
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
                 "culori": "^3.2.0"
@@ -31402,9 +31396,9 @@
             "license": "MIT",
             "dependencies": {
                 "@adaptive-web/adaptive-ui": "0.2.1",
-                "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-element": "2.0.0-beta.26",
-                "@microsoft/fast-foundation": "3.0.0-alpha.31"
+                "@microsoft/fast-foundation": "3.0.0-alpha.31",
+                "culori": "^3.2.0"
             },
             "devDependencies": {
                 "rimraf": "^3.0.2",
@@ -31542,7 +31536,7 @@
             "license": "MIT",
             "dependencies": {
                 "@adaptive-web/adaptive-web-components": "0.4.1",
-                "@microsoft/fast-colors": "^5.3.1"
+                "culori": "^3.2.0"
             },
             "devDependencies": {
                 "@csstools/css-calc": "^1.1.1",
@@ -32073,7 +32067,6 @@
             "version": "file:packages/adaptive-ui",
             "requires": {
                 "@microsoft/api-extractor": "^7.34.4",
-                "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-element": "2.0.0-beta.26",
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
                 "@types/chai": "^4.3.4",
@@ -32090,9 +32083,9 @@
             "version": "file:packages/adaptive-ui-explorer",
             "requires": {
                 "@adaptive-web/adaptive-ui": "0.2.1",
-                "@microsoft/fast-colors": "^5.3.1",
                 "@microsoft/fast-element": "2.0.0-beta.26",
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
+                "culori": "^3.2.0",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.7.0",
                 "vite": "^4.2.3"
@@ -32167,8 +32160,8 @@
                 "@csstools/css-parser-algorithms": "^2.2.0",
                 "@csstools/css-tokenizer": "^2.1.1",
                 "@figma/plugin-typings": "^1.80.0",
-                "@microsoft/fast-colors": "^5.3.1",
                 "concurrently": "^7.6.0",
+                "culori": "^3.2.0",
                 "esbuild": "^0.17.10",
                 "rimraf": "^3.0.2",
                 "typescript": "^4.7.0",
@@ -35167,11 +35160,6 @@
                 "eslint-plugin-import": "^2.25.0",
                 "typescript": "~3.9.0 || ~4.3.5 || ^4.6.2"
             }
-        },
-        "@microsoft/fast-colors": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/fast-colors/-/fast-colors-5.3.1.tgz",
-            "integrity": "sha512-72RZXVfCbwQzvo5sXXkuLXLT7rMeYaSf5r/6ewQiv/trBtqpWRm4DEH2EilHw/iWTBKOXs1qZNQndgUMa5n4LA=="
         },
         "@microsoft/fast-element": {
             "version": "2.0.0-beta.26",

--- a/packages/adaptive-ui-explorer/package.json
+++ b/packages/adaptive-ui-explorer/package.json
@@ -29,9 +29,9 @@
   },
   "dependencies": {
     "@adaptive-web/adaptive-ui": "0.2.1",
-    "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "2.0.0-beta.26",
-    "@microsoft/fast-foundation": "3.0.0-alpha.31"
+    "@microsoft/fast-foundation": "3.0.0-alpha.31",
+    "culori": "^3.2.0"
   },
   "devDependencies": {
     "rimraf": "^3.0.2",

--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -1,7 +1,6 @@
 import {
     Palette,
     Swatch,
-    SwatchRGB
 } from "@adaptive-web/adaptive-ui";
 import {
     accentBaseColor,
@@ -188,7 +187,7 @@ export class App extends FASTElement implements AppAttributes {
             neutralBaseColor.setValueFor(this.canvas, next);
 
             this.neutralPalette = neutralPalette.getValueFor(this.canvas);
-            this.neutralColors = this.neutralPalette.swatches.map((x: SwatchRGB) => x.toColorString());
+            this.neutralColors = this.neutralPalette.swatches.map((x) => x.toColorString());
 
             this.updateBackgrounds();
         }

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -1,4 +1,4 @@
-import { SwatchRGB } from "@adaptive-web/adaptive-ui";
+import { Swatch } from "@adaptive-web/adaptive-ui";
 import {
     accentFillDiscernibleControlStyles,
     accentFillReadableControlStyles,
@@ -24,7 +24,6 @@ import {
     neutralOutlineDiscernibleControlStyles,
     neutralStrokeReadableRest
 } from '@adaptive-web/adaptive-ui/reference';
-import { parseColorHexRGB } from "@microsoft/fast-colors";
 import {
     attr,
     css,
@@ -223,9 +222,9 @@ export class ColorBlock extends FASTElement {
 
     private updateColor(): void {
         if (this.color && this.$fastController.isConnected) {
-            const color = parseColorHexRGB(this.color);
-            if (color) {
-                fillColor.setValueFor(this, SwatchRGB.from(color));
+            const swatch =Swatch.parse(this.color)
+            if (swatch) {
+                fillColor.setValueFor(this, swatch);
             }
         }
     }

--- a/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.template.ts
+++ b/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.template.ts
@@ -1,8 +1,8 @@
 import { html, repeat } from "@microsoft/fast-element";
-import { isDark, Swatch } from "@adaptive-web/adaptive-ui";
+import { Color, isDark, Swatch } from "@adaptive-web/adaptive-ui";
 import { PaletteGradient } from "./palette-gradient.js";
 
-function getClass(swatch: Swatch, source?: Swatch, closestSource?: Swatch) {
+function getClass(swatch: Swatch, source?: Color, closestSource?: Swatch) {
     return swatch.toColorString() === source?.toColorString()
         ? "source"
         : swatch.toColorString() === closestSource?.toColorString()

--- a/packages/adaptive-ui-explorer/src/components/swatch.ts
+++ b/packages/adaptive-ui-explorer/src/components/swatch.ts
@@ -1,7 +1,6 @@
 import { Swatch } from "@adaptive-web/adaptive-ui";
 import { neutralForegroundHint } from "@adaptive-web/adaptive-ui/migration";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
-import { contrastRatio, parseColor } from "@microsoft/fast-colors";
 import {
     attr,
     css,
@@ -12,6 +11,7 @@ import {
     observable,
 } from "@microsoft/fast-element";
 import { DesignToken } from "@microsoft/fast-foundation";
+import { parse, wcagContrast } from "culori";
 
 export enum SwatchType {
     fill = "fill",
@@ -163,9 +163,11 @@ export class AppSwatch extends FASTElement {
 
     private formatContrast(a?: DesignToken<Swatch>, b?: DesignToken<Swatch>): string {
         return a && b
-            ? contrastRatio(
-                  parseColor(this.evaluateToken(a))!,
-                  parseColor(this.evaluateToken(b))!
+            ? wcagContrast(
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  parse(this.evaluateToken(a))!,
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  parse(this.evaluateToken(b))!
               ).toFixed(2)
             : "";
     }

--- a/packages/adaptive-ui-explorer/src/components/swatch.ts
+++ b/packages/adaptive-ui-explorer/src/components/swatch.ts
@@ -11,7 +11,7 @@ import {
     observable,
 } from "@microsoft/fast-element";
 import { DesignToken } from "@microsoft/fast-foundation";
-import { parse, wcagContrast } from "culori";
+import { parse, wcagContrast } from "culori/fn";
 
 export enum SwatchType {
     fill = "fill",

--- a/packages/adaptive-ui-figma-designer/package.json
+++ b/packages/adaptive-ui-figma-designer/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@adaptive-web/adaptive-web-components": "0.4.1",
-    "@microsoft/fast-colors": "^5.3.1"
+    "culori": "^3.2.0"
   },
   "peerDependencies": {
     "@adaptive-web/adaptive-ui": "0.2.1",

--- a/packages/adaptive-ui-figma-designer/package.json
+++ b/packages/adaptive-ui-figma-designer/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "npm run build:ui -- --minify esbuild && npm run build:figma -- --minify",
     "build:debug": "npm run build:ui && npm run build:figma",
-    "build:figma": "esbuild src/figma/main.ts --tsconfig=src/figma/tsconfig.json --bundle --outfile=dist/main.js",
+    "build:figma": "esbuild src/figma/main.ts --tsconfig=src/figma/tsconfig.json --bundle --target=ES2017 --outfile=dist/main.js",
     "build:ui": "npx vite build --emptyOutDir=false --minify false",
     "build:watch": "concurrently -n figma,ui \"npm run build:figma -- --watch\" \"npm run build:ui -- --watch\"",
     "compile": "npm run compile:figma && npm run compile:ui",

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -1,6 +1,6 @@
-import { ColorRGBA64 } from "@microsoft/fast-colors";
 import { ValuesOf } from "@microsoft/fast-foundation";
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
+import { Color, formatHex8 } from "culori";
 import {
     AdditionalData,
     AdditionalDataKeys,
@@ -156,7 +156,7 @@ export abstract class PluginNode {
     /**
      * The fill color of this node.
      */
-    public abstract readonly fillColor: ColorRGBA64 | null;
+    public abstract readonly fillColor: Color | null;
 
     /**
      * The state of stateful component capabilities for this node.
@@ -257,8 +257,8 @@ export abstract class PluginNode {
         }
 
         if (!this._additionalData.has(AdditionalDataKeys.toolParentFillColor) && this.parent?.fillColor) {
-            // console.log("PluginNode.get_additionalData - adding:", AdditionalDataKeys.toolParentFillColor, this.debugInfo, this.parent?.fillColor.toStringHexARGB());
-            this._additionalData.set(AdditionalDataKeys.toolParentFillColor, this.parent.fillColor.toStringHexARGB());
+            // console.log("PluginNode.get_additionalData - adding:", AdditionalDataKeys.toolParentFillColor, this.debugInfo, formatHex8(this.parent?.fillColor));
+            this._additionalData.set(AdditionalDataKeys.toolParentFillColor, formatHex8(this.parent.fillColor));
         }
 
         return this._additionalData;

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -1,6 +1,6 @@
 import { ValuesOf } from "@microsoft/fast-foundation";
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
-import { Color, formatHex8 } from "culori";
+import { type Color, formatHex8 } from "culori/fn";
 import {
     AdditionalData,
     AdditionalDataKeys,

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -1,11 +1,13 @@
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
-import { type Color, modeRgb, parse, type Rgb, useMode, wcagLuminance } from "culori/fn";
+import { type Color, modeLrgb, modeRgb, parse, type Rgb, useMode, wcagLuminance } from "culori/fn";
 import { Controller, STYLE_REMOVE } from "../core/controller.js";
 import { AppliedDesignTokens, AppliedStyleModules, AppliedStyleValues, DesignTokenValues, PluginNodeData } from "../core/model.js";
 import { PluginNode, State, StatesState } from "../core/node.js";
 import { variantBooleanHelper } from "./utility.js";
 
 const rgb = useMode(modeRgb);
+// For luminance
+useMode(modeLrgb);
 
 const stateVariant = "State";
 const disabledVariant = "Disabled";

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -1,5 +1,5 @@
-import { ColorRGBA64, parseColor, rgbToRelativeLuminance } from "@microsoft/fast-colors";
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
+import { Color, parse, rgb, Rgb, wcagLuminance } from "culori";
 import { Controller, STYLE_REMOVE } from "../core/controller.js";
 import { AppliedDesignTokens, AppliedStyleModules, AppliedStyleValues, DesignTokenValues, PluginNodeData } from "../core/model.js";
 import { PluginNode, State, StatesState } from "../core/node.js";
@@ -95,7 +95,7 @@ export class FigmaPluginNode extends PluginNode {
     public id: string;
     public type: string;
     public name: string;
-    public fillColor: ColorRGBA64 | null;
+    public fillColor: Color | null;
     public states: StatesState;
     private _node: BaseNode;
     private _state: State | null = null;
@@ -621,7 +621,7 @@ export class FigmaPluginNode extends PluginNode {
         return FigmaPluginNode.get(parent);
     }
 
-    private getFillColor(): ColorRGBA64 | null {
+    private getFillColor(): Color | null {
         // console.log("FigmaPluginNode.getFillColor", this.debugInfo);
         if ((this._node as GeometryMixin).fills) {
             const fills = (this._node as GeometryMixin).fills;
@@ -633,11 +633,10 @@ export class FigmaPluginNode extends PluginNode {
 
                 // TODO: how do we process multiple paints?
                 if (paints.length === 1) {
-                    const parsed = ColorRGBA64.fromObject(Object.assign({}, paints[0].color, {a: paints[0].opacity}));
-                    if (parsed instanceof ColorRGBA64) {
-                        // console.log("FigmaPluginNode.getFillColor", this.debugInfo, parsed.toStringHexARGB());
-                        return parsed;
-                    }
+                    const rgb = paints[0].color;
+                    const color: Rgb = { mode: "rgb", r: rgb.r, g: rgb.g, b: rgb.b, alpha: paints[0].opacity };
+                    // console.log("FigmaPluginNode.getFillColor", this.debugInfo, formatHex8(color));
+                    return color;
                 }
             }
         }
@@ -654,7 +653,7 @@ export class FigmaPluginNode extends PluginNode {
                 if (currentDarkMode) {
                     const color = this.parent?.fillColor;
                     if (color) {
-                        const containerIsDark = rgbToRelativeLuminance(color) <= this.darkTarget;
+                        const containerIsDark = wcagLuminance(color) <= this.darkTarget;
                         // eslint-disable-next-line max-len
                         // console.log("handleManualDarkMode", this._node.variantProperties['Dark mode'], "color", color.toStringHexRGB(), "dark", containerIsDark);
                         const value = variantBooleanHelper(currentDarkMode, containerIsDark);
@@ -718,7 +717,7 @@ export class FigmaPluginNode extends PluginNode {
                     const stops = array.map((p, index, array) => {
                         const paramMatches = p.match(paramMatch);
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                        const color = parseColor(paramMatches?.groups?.color || "FF00FF")!;
+                        const color = rgb(parse(paramMatches?.groups?.color || "FF00FF")!);
                         let position: number = 0;
                         if (paramMatches?.groups && paramMatches?.groups?.pos) {
                             if (paramMatches.groups.pos.endsWith("%")) {
@@ -743,7 +742,7 @@ export class FigmaPluginNode extends PluginNode {
                                 r: color.r,
                                 g: color.g,
                                 b: color.b,
-                                a: color.a,
+                                a: color.alpha || 1,
                             },
                         };
                         return stop;
@@ -761,24 +760,23 @@ export class FigmaPluginNode extends PluginNode {
                 }
             } else {
                 // Assume it's solid
-                const color = parseColor(value);
-
-                if (color === null) {
+                const color = parse(value);
+                if (!color) {
                     throw new Error(
-                        `The value "${value}" could not be converted to a ColorRGBA64`
+                        `The value "${value}" could not be parsed`
                     );
                 }
 
-                const colorObject = color.toObject();
+                const rgbColor = rgb(color);
                 const solidPaint: SolidPaint = {
                     type: "SOLID",
                     visible: true,
-                    opacity: colorObject.a,
+                    opacity: rgbColor.alpha,
                     blendMode: "NORMAL",
                     color: {
-                        r: colorObject.r,
-                        g: colorObject.g,
-                        b: colorObject.b,
+                        r: rgbColor.r,
+                        g: rgbColor.g,
+                        b: rgbColor.b,
                     },
                 };
                 paint = solidPaint;

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -1,9 +1,11 @@
 import { StyleProperty } from "@adaptive-web/adaptive-ui";
-import { Color, parse, rgb, Rgb, wcagLuminance } from "culori";
+import { type Color, modeRgb, parse, type Rgb, useMode, wcagLuminance } from "culori/fn";
 import { Controller, STYLE_REMOVE } from "../core/controller.js";
 import { AppliedDesignTokens, AppliedStyleModules, AppliedStyleValues, DesignTokenValues, PluginNodeData } from "../core/model.js";
 import { PluginNode, State, StatesState } from "../core/node.js";
 import { variantBooleanHelper } from "./utility.js";
+
+const rgb = useMode(modeRgb);
 
 const stateVariant = "State";
 const disabledVariant = "Disabled";

--- a/packages/adaptive-ui-figma-designer/src/figma/tsconfig.json
+++ b/packages/adaptive-ui-figma-designer/src/figma/tsconfig.json
@@ -1,12 +1,14 @@
 {
     "compilerOptions": {
         "outDir": "../../dist",
-        "moduleResolution": "node16",
-        "target": "ES2018",
+        "moduleResolution": "Node16",
         "module": "ESNext",
+        "target": "ES2018",
         "lib": ["ES2018"],
         "strict": true,
         "skipLibCheck": true,
-        "typeRoots": ["../../../../node_modules/@figma"]
+        "typeRoots": [
+            "../../../../node_modules/@figma"
+        ]
     }
 }

--- a/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
@@ -2,7 +2,7 @@ import { attr, css, customElement, ElementStyles, FASTElement, html, observable 
 import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
 import { ElementStylesRenderer, Interactivity, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
-import { formatHex8, parse } from "culori";
+import { formatHex8, parse } from "culori/fn";
 import BlobIcon from "../../assets/blob.svg";
 
 const template = html<TokenGlyph>`

--- a/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/components/token-glyph/index.ts
@@ -1,8 +1,8 @@
 import { attr, css, customElement, ElementStyles, FASTElement, html, observable } from "@microsoft/fast-element";
 import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
-import { parseColor } from "@microsoft/fast-colors";
 import { ElementStylesRenderer, Interactivity, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
+import { formatHex8, parse } from "culori";
 import BlobIcon from "../../assets/blob.svg";
 
 const template = html<TokenGlyph>`
@@ -136,8 +136,8 @@ export class TokenGlyph extends FASTElement {
     @attr
     public value: string | "none" = "none";
     protected valueChanged(prev: string, next: string) {
-        const color = parseColor(next);
-        this.valueColor = color?.toStringWebRGBA();
+        const color = parse(next);
+        this.valueColor = formatHex8(color);
     }
 
     @observable

--- a/packages/adaptive-ui-figma-designer/src/ui/tsconfig.json
+++ b/packages/adaptive-ui-figma-designer/src/ui/tsconfig.json
@@ -3,9 +3,9 @@
         "experimentalDecorators": true,
         "outDir": "dist",
         "resolveJsonModule": true,
-        "moduleResolution": "node16",
-        "target": "ESNext",
-        "module": "ESNext",
+        "moduleResolution": "Node16",
+        "target": "ES2020",
+        "module": "ES2020",
         "useDefineForClassFields": false,
         "lib": ["DOM", "DOM.Iterable", "ESNext"],
         "strict": false

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-elements.ts
@@ -1,7 +1,6 @@
 import { customElement, FASTElement, html } from "@microsoft/fast-element";
 import type { DesignToken, StaticDesignTokenValue } from "@microsoft/fast-foundation";
-import { parseColorHexRGB } from "@microsoft/fast-colors";
-import { SwatchRGB } from "@adaptive-web/adaptive-ui";
+import { Swatch } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
 import { DesignTokenValue, PluginUINodeData } from "../core/model.js";
 import { UIController } from "./ui-controller.js";
@@ -53,7 +52,7 @@ export class ElementsController {
         try {
             if (value) {
                 // TODO figure out a better way to handle storage data types
-                const color = parseColorHexRGB((value as unknown) as string);
+                const color = Swatch.parse((value as unknown) as string);
                 if (color) {
                     // TODO fix this logic
                     // console.log("        setting DesignToken value (color)", token.name, value);
@@ -67,7 +66,7 @@ export class ElementsController {
                         // console.log("          color object");
                         token.setValueFor(
                             nodeElement,
-                            (SwatchRGB.from(color) as unknown) as StaticDesignTokenValue<T>
+                            (color as unknown) as StaticDesignTokenValue<T>
                         );
                     }
                 } else {

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-tokens.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-tokens.ts
@@ -1,7 +1,8 @@
 import { calc } from '@csstools/css-calc';
 import { observable } from "@microsoft/fast-element";
 import { type DesignToken } from "@microsoft/fast-foundation";
-import { SwatchRGB } from "@adaptive-web/adaptive-ui";
+import { Color } from "@adaptive-web/adaptive-ui";
+import { formatHex8 } from 'culori';
 import { DesignTokenValue, PluginUINodeData } from "../core/model.js";
 import { DesignTokenDefinition } from "../core/registry/design-token-registry.js";
 import { UIController } from "./ui-controller.js";
@@ -110,8 +111,8 @@ export class DesignTokenController {
     private valueToString(value: any): string {
         // TODO figure out a better way to handle storage data types
         // Reconcile with similar block in evaluateEffectiveAppliedDesignToken
-        if (value instanceof SwatchRGB) {
-            return value.color.toStringHexARGB();
+        if (value instanceof Color) {
+            return formatHex8(value.color);
         } else if (typeof value === "string") {
             if (value.startsWith("calc")) {
                 return calc(value);

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
@@ -1,9 +1,9 @@
 import { calc } from '@csstools/css-calc';
-import { parseColorHexARGB } from "@microsoft/fast-colors";
 import { FASTElement } from "@microsoft/fast-element";
 import { CSSDesignToken, type ValuesOf } from "@microsoft/fast-foundation";
-import { InteractiveTokenGroup, StyleProperty, Styles, SwatchRGB } from "@adaptive-web/adaptive-ui";
+import { Color, InteractiveTokenGroup, StyleProperty, Styles, Swatch } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
+import { formatHex8 } from 'culori';
 import { STYLE_REMOVE } from "../core/controller.js";
 import { AdditionalDataKeys, AppliedDesignToken, AppliedStyleModules, AppliedStyleValue, type PluginMessage, type PluginUINodeData } from "../core/model.js";
 import { DesignTokenRegistry } from "../core/registry/design-token-registry.js";
@@ -315,9 +315,8 @@ export class UIController {
             const colorHex = node.additionalData.get(AdditionalDataKeys.toolParentFillColor);
             if (colorHex) {
                 const parentElement = this._elements.getElementForNode(node).parentElement as FASTElement;
-                const color = parseColorHexARGB(colorHex);
-                // console.log("    setting fill color token on parent element", color, color?.toStringHexARGB(), parentElement.id);
-                this._elements.setDesignTokenForElement(parentElement, fillColor, SwatchRGB.from(color));
+                // console.log("    setting fill color token on parent element", colorHex, parentElement.id);
+                this._elements.setDesignTokenForElement(parentElement, fillColor, Swatch.parse(colorHex));
             }
 
             const allApplied = this.collectEffectiveAppliedStyles(node);
@@ -347,9 +346,9 @@ export class UIController {
         const valueOriginal: any = this._elements.getDesignTokenValue(node, token);
         let value: any = valueOriginal;
         // let valueDebug: any;
-        if (valueOriginal instanceof SwatchRGB) {
-            const swatch = valueOriginal as SwatchRGB;
-            value = swatch.color.toStringHexARGB();
+        if (valueOriginal instanceof Color) {
+            const swatch = valueOriginal;
+            value = formatHex8(swatch.color);
             // valueDebug = swatch;
         } else if (typeof valueOriginal === "string") {
             if (valueOriginal.startsWith("calc")) {

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -4,8 +4,7 @@
 
 ```ts
 
-import { Color } from 'culori/fn';
-import { ColorRGBA64 } from '@microsoft/fast-colors';
+import { Color as Color_2 } from 'culori';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import type { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
@@ -15,7 +14,7 @@ import { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public
 export class BasePalette<T extends Swatch> implements Palette<T> {
-    constructor(source: T, swatches: ReadonlyArray<T>);
+    constructor(source: Color, swatches: ReadonlyArray<T>);
     readonly closestIndexCache: Map<number, number>;
     closestIndexOf(reference: RelativeLuminance): number;
     colorContrast(reference: RelativeLuminance, contrastTarget: number, initialSearchIndex?: number, direction?: PaletteDirection): T;
@@ -23,12 +22,12 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
     get(index: number): T;
     readonly lastIndex: number;
     readonly reversedSwatches: ReadonlyArray<T>;
-    readonly source: T;
+    readonly source: Color;
     readonly swatches: ReadonlyArray<T>;
 }
 
 // @internal
-export const _black: SwatchRGB;
+export const _black: Swatch;
 
 // @public
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
@@ -50,6 +49,23 @@ export const BorderStyle: {
 export const BorderThickness: {
     all: (value: StyleValue) => StyleProperties;
 };
+
+// @public
+export class Color implements RelativeLuminance {
+    protected constructor(color: Color_2);
+    readonly color: Color_2;
+    contrast: any;
+    createCSS: () => string;
+    static from(obj: {
+        r: number;
+        g: number;
+        b: number;
+    }): Color;
+    static fromRgb(r: number, g: number, b: number): Color;
+    static parse(color: string): Color | undefined;
+    get relativeLuminance(): number;
+    toColorString(): string;
+}
 
 // @public
 export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
@@ -282,7 +298,7 @@ export interface FocusDefinition<TParts> {
 export type FocusSelector = "focus" | "focus-visible" | "focus-within";
 
 // @public
-export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveSwatchSet;
+export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Color, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveSwatchSet;
 
 // @public
 export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
@@ -357,7 +373,7 @@ export interface Palette<T extends Swatch = Swatch> {
     colorContrast(reference: RelativeLuminance, minContrast: number, initialIndex?: number, direction?: PaletteDirection): T;
     delta(reference: RelativeLuminance, delta: number, direction: PaletteDirection): T;
     get(index: number): T;
-    readonly source: T;
+    readonly source: Color;
     readonly swatches: ReadonlyArray<T>;
 }
 
@@ -374,16 +390,14 @@ export const PaletteDirectionValue: Readonly<{
 export type PaletteDirectionValue = typeof PaletteDirectionValue[keyof typeof PaletteDirectionValue];
 
 // @public
-export class PaletteOkhsl extends BasePalette<SwatchRGB> {
+export class PaletteOkhsl extends BasePalette<Swatch> {
     // (undocumented)
-    static from(source: SwatchRGB | string): PaletteOkhsl;
-    // (undocumented)
-    static swatchToColor(swatch: SwatchRGB): Color;
+    static from(source: Color | string): PaletteOkhsl;
 }
 
 // @public
-export class PaletteRGB extends BasePalette<SwatchRGB> {
-    static from(source: SwatchRGB | string, options?: Partial<PaletteRGBOptions>): PaletteRGB;
+export class PaletteRGB extends BasePalette<Swatch> {
+    static from(source: Swatch | string, options?: Partial<PaletteRGBOptions>): PaletteRGB;
 }
 
 // @public
@@ -524,34 +538,23 @@ export class Styles {
 export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string;
 
 // @public
-export interface Swatch extends RelativeLuminance {
-    contrast(target: RelativeLuminance): number;
-    toColorString(): string;
-}
-
-// @public
-export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null;
-
-// @public
-export class SwatchRGB implements Swatch {
-    constructor(red: number, green: number, blue: number, alpha?: number, intendedColor?: SwatchRGB);
-    static asOverlay(intendedColor: SwatchRGB, reference: SwatchRGB): SwatchRGB;
-    readonly b: number;
-    readonly color: ColorRGBA64;
-    contrast: any;
-    createCSS: () => string;
+export class Swatch extends Color {
+    protected constructor(color: Color_2, intendedColor?: Swatch);
+    static asOverlay(intendedColor: Swatch, reference: Swatch): Swatch;
     static from(obj: {
         r: number;
         g: number;
         b: number;
-    }): SwatchRGB;
-    readonly g: number;
-    readonly intendedColor?: SwatchRGB;
-    readonly r: number;
-    readonly relativeLuminance: number;
-    toColorString(): string;
-    toTransparent(): SwatchRGB;
+    }): Swatch;
+    static fromColor(color: Color): Swatch;
+    static fromRgb(r: number, g: number, b: number): Swatch;
+    static parse(color: string): Swatch | undefined;
+    get relativeLuminance(): number;
+    toTransparent(alpha?: number): Swatch;
 }
+
+// @public
+export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null;
 
 // @public
 export interface TokenGroup {
@@ -587,7 +590,7 @@ export interface TypedDesignToken<T> extends DesignTokenMetadata {
 }
 
 // @internal
-export const _white: SwatchRGB;
+export const _white: Swatch;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { Color as Color_2 } from 'culori';
+import { Color as Color_2 } from 'culori/fn';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import type { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
@@ -60,8 +60,9 @@ export class Color implements RelativeLuminance {
         r: number;
         g: number;
         b: number;
+        alpha?: number;
     }): Color;
-    static fromRgb(r: number, g: number, b: number): Color;
+    static fromRgb(r: number, g: number, b: number, alpha?: number): Color;
     static parse(color: string): Color | undefined;
     get relativeLuminance(): number;
     toColorString(): string;
@@ -545,9 +546,10 @@ export class Swatch extends Color {
         r: number;
         g: number;
         b: number;
+        alpha?: number;
     }): Swatch;
     static fromColor(color: Color): Swatch;
-    static fromRgb(r: number, g: number, b: number): Swatch;
+    static fromRgb(r: number, g: number, b: number, alpha?: number): Swatch;
     static parse(color: string): Swatch | undefined;
     get relativeLuminance(): number;
     toTransparent(alpha?: number): Swatch;

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -34,7 +34,6 @@
     "postbuild": "npm run doc"
   },
   "dependencies": {
-    "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-element": "2.0.0-beta.26",
     "@microsoft/fast-foundation": "3.0.0-alpha.31",
     "culori": "^3.2.0"

--- a/packages/adaptive-ui/src/color/README.md
+++ b/packages/adaptive-ui/src/color/README.md
@@ -2,26 +2,27 @@
 
 Color recipes are algorithmic patterns that produce individual or sets of colors from a variety of inputs. Components can apply these recipes to achieve expressive theming options while maintaining color accessability targets.
 
+## Color
+A Swatch is a representation of a color that has a `relativeLuminance` value and a method to convert the swatch to a color string. It is the base type for color design tokens.
+
 ## Swatch
-A Swatch is a representation of a color that has a `relativeLuminance` value and a method to convert the swatch to a color string. It is used by recipes to determine which colors to use for UI.
+A Swatch is an extension of a Color for use in a recipe. It adds support for calculating a color as an overlay or transparency
+over another Swatch.
 
-### SwatchRGB
-A concrete implementation of `Swatch`, it is a swatch with red, green, and blue 64bit color channels.
-
-**Example: Creating a SwatchRGB**
+**Example: Creating a Swatch**
 ```ts
-import { SwatchRGB } from "@adaptive-web/adaptive-ui";
+import { Swatch } from "@adaptive-web/adaptive-ui";
 
-const red = new SwatchRGB(1, 0, 0);
+const red = Swatch.fromRgb(1, 0, 0);
 ```
 
 ## Palette
 A palette is a collection `Swatch` instances, ordered by relative luminance, and provides mechanisms to safely retrieve swatches by index and by target contrast ratios. It also contains a `source` color, which is the color from which the palette is derived.
 
 ### PaletteRGB
-An implementation of `Palette` of `SwatchRGB` instances. 
+An implementation of `Palette` of `Swatch` instances with RGB colors.
 
 ```ts
-// Create a PaletteRGB from a SwatchRGB 
+// Create a PaletteRGB from a Swatch
 const redPalette = PaletteRGB.from(red):
 ```

--- a/packages/adaptive-ui/src/color/color.spec.ts
+++ b/packages/adaptive-ui/src/color/color.spec.ts
@@ -1,0 +1,46 @@
+import chai from "chai";
+import { Color } from "./color.js";
+import { type Rgb } from "culori/fn";
+
+const { expect } = chai;
+
+const greyColor: Rgb = { mode: "rgb", r: 0.5, g: 0.5, b: 0.5, alpha: undefined };
+const greyObject = { r: 0.5, g: 0.5, b: 0.5, alpha: undefined };
+const greyHex = "#808080";
+
+const opacityColor: Rgb = { mode: "rgb", r: 0.2, g: 0.4, b: 0.6, alpha: 0.5019607843137255 };
+const opacityHex = "#33669980";
+const opacityRgba = "rgba(51, 102, 153, 0.5)";
+
+describe("Color", () => {
+    it("should create a Color from the provided object", () => {
+        const color = Color.from(greyObject);
+
+        expect(color).to.be.instanceof(Color);
+        expect(color.color).to.deep.equal(greyColor);
+        expect(color.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Color from the provided RGB values", () => {
+        const color = Color.fromRgb(0.5, 0.5, 0.5);
+
+        expect(color).to.be.instanceof(Color);
+        expect(color.color).to.deep.equal(greyColor);
+        expect(color.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Color from the provided hex color", () => {
+        const color = Color.parse(greyHex)!;
+
+        expect(color).to.be.instanceof(Color);
+        expect(color.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Color with opacity", () => {
+        const color = Color.parse(opacityHex)!;
+
+        expect(color).to.be.instanceof(Color);
+        expect(color.color).to.deep.equal(opacityColor);
+        expect(color.toColorString()).to.equal(opacityRgba);
+    });
+});

--- a/packages/adaptive-ui/src/color/color.ts
+++ b/packages/adaptive-ui/src/color/color.ts
@@ -41,7 +41,7 @@ export class Color implements RelativeLuminance {
      * @returns The color value in string format
      */
     public toColorString(): string {
-        return this.color.alpha && this.color.alpha < 1 ? formatRgb(this.color) : formatHex(this.color);
+        return this.color.alpha !== undefined && this.color.alpha < 1 ? formatRgb(this.color) : formatHex(this.color);
     }
 
     /**

--- a/packages/adaptive-ui/src/color/color.ts
+++ b/packages/adaptive-ui/src/color/color.ts
@@ -1,5 +1,5 @@
-import { Color as CuloriColor, formatHex, formatRgb, parse, Rgb, wcagLuminance } from "culori";
-import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
+import { type Color as CuloriColor, formatHex, formatRgb, parse, type Rgb, wcagLuminance } from "culori/fn";
+import { contrast, type RelativeLuminance } from "./utilities/relative-luminance.js";
 
 /**
  * Represents a color.
@@ -57,11 +57,13 @@ export class Color implements RelativeLuminance {
     /**
      * Creates a new Color from and object with R, G, and B values expressed as a number between 0 to 1.
      *
-     * @param obj - An object with `r`, `g`, and `b` values expressed as a number between 0 and 1.
+     * @param obj - An object with `r`, `g`, and `b`, and optional `alpha` values expressed as a number between 0 and 1.
      * @returns A new Color
      */
-    public static from(obj: { r: number; g: number; b: number }): Color {
-        const color: Rgb = { mode: "rgb", r: obj.r, g: obj.g, b: obj.b };
+    public static from(obj: { r: number; g: number; b: number, alpha?: number }): Color {
+        const color: Rgb = { mode: "rgb", ...obj };
+        console.log("from", color);
+        
         return new Color(color);
     }
 
@@ -71,10 +73,12 @@ export class Color implements RelativeLuminance {
      * @param r - Red channel expressed as a number between 0 and 1.
      * @param g - Green channel expressed as a number between 0 and 1.
      * @param b - Blue channel expressed as a number between 0 and 1.
+     * @param alpha - Alpha channel expressed as a number between 0 and 1.
      * @returns A new Color
      */
-    public static fromRgb(r: number, g: number, b: number): Color {
-        const color: Rgb = { mode: "rgb", r, g, b };
+    public static fromRgb(r: number, g: number, b: number, alpha?: number): Color {
+        const color: Rgb = { mode: "rgb", r, g, b, alpha };
+        console.log("fromRgb", color);
         return new Color(color);
     }
 

--- a/packages/adaptive-ui/src/color/color.ts
+++ b/packages/adaptive-ui/src/color/color.ts
@@ -1,0 +1,93 @@
+import { Color as CuloriColor, formatHex, formatRgb, parse, Rgb, wcagLuminance } from "culori";
+import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
+
+/**
+ * Represents a color.
+ *
+ * @public
+ */
+export class Color implements RelativeLuminance {
+    /**
+     * The underlying Color value.
+     */
+    public readonly color: CuloriColor;
+
+    private readonly _relativeLuminance: number;
+
+    /**
+     * Creates a new Color.
+     *
+     * @param color - The underlying Color value
+     */
+    protected constructor(color: CuloriColor) {
+        this.color = Object.freeze(color);
+        this._relativeLuminance = wcagLuminance(this.color);
+    }
+
+    /**
+     * {@inheritdoc RelativeLuminance.relativeLuminance}
+     */
+    public get relativeLuminance(): number {
+        return this._relativeLuminance;
+    }
+
+    /**
+     * Gets this color value as a string.
+     *
+     * @returns The color value in string format
+     */
+    public toColorString(): string {
+        return this.color.alpha && this.color.alpha < 1 ? formatRgb(this.color) : formatHex(this.color);
+    }
+
+    /**
+     * Gets the contrast between this Color and another.
+     *
+     * @returns The contrast between the two luminance values, for example, 4.54
+     */
+    public contrast = contrast.bind(null, this);
+
+    /**
+     * Gets this color value as a string for use in css.
+     *
+     * @returns The color value in a valid css string format
+     */
+    public createCSS = this.toColorString;
+
+    /**
+     * Creates a new Color from and object with R, G, and B values expressed as a number between 0 to 1.
+     *
+     * @param obj - An object with `r`, `g`, and `b` values expressed as a number between 0 and 1.
+     * @returns A new Color
+     */
+    public static from(obj: { r: number; g: number; b: number }): Color {
+        const color: Rgb = { mode: "rgb", r: obj.r, g: obj.g, b: obj.b };
+        return new Color(color);
+    }
+
+    /**
+     * Creates a new Color from R, G, and B values expressed as a number between 0 to 1.
+     *
+     * @param r - Red channel expressed as a number between 0 and 1.
+     * @param g - Green channel expressed as a number between 0 and 1.
+     * @param b - Blue channel expressed as a number between 0 and 1.
+     * @returns A new Color
+     */
+    public static fromRgb(r: number, g: number, b: number): Color {
+        const color: Rgb = { mode: "rgb", r, g, b };
+        return new Color(color);
+    }
+
+    /**
+     * Creates a new Color from a parsable string.
+     *
+     * @param color - A string representation of the Color.
+     * @returns The Color object or undefined.
+     */
+    public static parse(color: string): Color | undefined {
+        const parsedColor = parse(color);
+        if (parsedColor) {
+            return new Color(parsedColor);
+        }
+    }
+}

--- a/packages/adaptive-ui/src/color/color.ts
+++ b/packages/adaptive-ui/src/color/color.ts
@@ -1,5 +1,9 @@
-import { type Color as CuloriColor, formatHex, formatRgb, parse, type Rgb, wcagLuminance } from "culori/fn";
+import { type Color as CuloriColor, formatHex, formatRgb, modeLrgb, modeRgb, parse, type Rgb, useMode, wcagLuminance } from "culori/fn";
 import { contrast, type RelativeLuminance } from "./utilities/relative-luminance.js";
+
+useMode(modeRgb);
+// For luminance
+useMode(modeLrgb);
 
 /**
  * Represents a color.

--- a/packages/adaptive-ui/src/color/index.ts
+++ b/packages/adaptive-ui/src/color/index.ts
@@ -1,5 +1,6 @@
 export * from "./recipes/index.js";
 export * from "./utilities/index.js";
+export * from "./color.js";
 export * from "./palette-okhsl.js";
 export * from "./palette-rgb.js";
 export * from "./palette.js";

--- a/packages/adaptive-ui/src/color/palette-okhsl.ts
+++ b/packages/adaptive-ui/src/color/palette-okhsl.ts
@@ -1,6 +1,7 @@
-import { clampChroma, Color, interpolate, modeOkhsl, modeRgb, parse, samples, useMode} from "culori/fn";
+import { clampChroma, interpolate, modeOkhsl, modeRgb, samples, useMode} from "culori/fn";
+import { Color } from "./color.js";
 import { BasePalette } from "./palette.js";
-import { SwatchRGB } from "./swatch.js";
+import { Swatch } from "./swatch.js";
 import { _black, _white } from "./utilities/color-constants.js";
 
 const okhsl = useMode(modeOkhsl);
@@ -14,25 +15,14 @@ const stepCount = 56;
  *
  * @public
  */
-export class PaletteOkhsl extends BasePalette<SwatchRGB> {
-    static swatchToColor(swatch: SwatchRGB): Color {
-        return {mode: "rgb", r: swatch.r, g: swatch.g, b: swatch.b};
-    }
-
-    static from(source: SwatchRGB | string): PaletteOkhsl {
-        let swatch;
-        if (source instanceof SwatchRGB) {
-            swatch = source;
-        } else {
-            const color = parse(source);
-            if (color === undefined) {
-                throw new Error(`Unable to parse Color as hex string: ${source}`);
-            }
-            swatch = SwatchRGB.from(rgb(color));
+export class PaletteOkhsl extends BasePalette<Swatch> {
+    public static from(source: Color | string): PaletteOkhsl {
+        const color = source instanceof Color ? source : Color.parse(source);
+        if (!color) {
+            throw new Error(`Unable to parse source: ${source}`);
         }
 
-        const sourceRgb = this.swatchToColor(swatch);
-        const sourceHsl = okhsl(sourceRgb);
+        const sourceHsl = okhsl(color.color);
 
         const lo = Object.assign({}, sourceHsl, {l: 0.01});
         const hi = Object.assign({}, sourceHsl, {l: 0.99});
@@ -49,13 +39,13 @@ export class PaletteOkhsl extends BasePalette<SwatchRGB> {
 
         const ramp = [...samplesLeft, ...samplesRight.slice(1)];
         const swatches = ramp.map((value) =>
-            SwatchRGB.from(rgb(clampChroma(value, "okhsl")))
+            Swatch.from(rgb(clampChroma(value, "okhsl")))
         );
 
         // It's important that the ends are full white and black.
         swatches[0] = _white;
         swatches[swatches.length - 1] = _black;
 
-        return new PaletteOkhsl(swatch, swatches);
+        return new PaletteOkhsl(color, swatches);
     }
 }

--- a/packages/adaptive-ui/src/color/palette-rgb.spec.ts
+++ b/packages/adaptive-ui/src/color/palette-rgb.spec.ts
@@ -1,13 +1,12 @@
-import { parseColorHexRGB } from "@microsoft/fast-colors";
 import chai from "chai";
 import { PaletteRGB, PaletteRGBOptions } from "./palette-rgb.js";
-import { SwatchRGB } from "./swatch.js";
+import { Swatch } from "./swatch.js";
 import { contrast } from "./utilities/relative-luminance.js";
 
 const { expect } = chai;
 
 const greyHex = "#808080";
-const greySwatch: SwatchRGB = SwatchRGB.from(parseColorHexRGB(greyHex)!);
+const greySwatch = Swatch.parse(greyHex)!;
 
 describe("PaletteRGB.from", () => {
     it("should create a palette from the provided swatch", () => {

--- a/packages/adaptive-ui/src/color/palette-rgb.ts
+++ b/packages/adaptive-ui/src/color/palette-rgb.ts
@@ -1,8 +1,12 @@
-import { clampRgb, hsl, Hsl, interpolate, lab, rgb, Rgb } from "culori";
+import { clampRgb, type Hsl, interpolate, modeHsl, modeLab, modeRgb, type Rgb, useMode } from "culori/fn";
 import { BasePalette } from "./palette.js";
 import { Swatch } from "./swatch.js";
 import { contrast } from "./utilities/relative-luminance.js";
 import { _black, _white } from "./utilities/color-constants.js";
+
+const hsl = useMode(modeHsl);
+const lab = useMode(modeLab);
+const rgb = useMode(modeRgb);
 
 /**
  * A utility Palette that generates many Swatches used for selection in the actual Palette.

--- a/packages/adaptive-ui/src/color/palette.ts
+++ b/packages/adaptive-ui/src/color/palette.ts
@@ -1,4 +1,4 @@
-import { clamp } from "@microsoft/fast-colors";
+import { Color } from "./color.js";
 import { Swatch } from "./swatch.js";
 import { binarySearch } from "./utilities/binary-search.js";
 import { directionByIsDark } from "./utilities/direction-by-is-dark.js";
@@ -60,7 +60,7 @@ export interface Palette<T extends Swatch = Swatch> {
     /**
      * The Swatch used to create the full palette.
      */
-    readonly source: T;
+    readonly source: Color;
 
     /**
      * The array of all Swatches from light to dark.
@@ -122,7 +122,8 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
     /**
      * {@inheritdoc Palette.source}
      */
-    readonly source: T;
+    readonly source: Color;
+
     /**
      * {@inheritdoc Palette.swatches}
      */
@@ -149,7 +150,7 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
      * @param source - The source color for the Palette
      * @param swatches - All Swatches in the Palette
      */
-    constructor(source: T, swatches: ReadonlyArray<T>) {
+    constructor(source: Color, swatches: ReadonlyArray<T>) {
         this.source = source;
         this.swatches = swatches;
 
@@ -222,9 +223,25 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
     }
 
     /**
+     * Ensures that an input number does not exceed a max value and is not less than a min value.
+     *
+     * @param i - the number to clamp
+     * @param min - the maximum (inclusive) value
+     * @param max - the minimum (inclusive) value
+     */
+    private clamp(i: number, min: number, max: number): number {
+        if (isNaN(i) || i <= min) {
+            return min;
+        } else if (i >= max) {
+            return max;
+        }
+        return i;
+    }
+
+    /**
      * {@inheritdoc Palette.get}
      */
     get(index: number): T {
-        return this.swatches[index] || this.swatches[clamp(index, 0, this.lastIndex)];
+        return this.swatches[index] || this.swatches[this.clamp(index, 0, this.lastIndex)];
     }
 }

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast-set.ts
@@ -1,5 +1,5 @@
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch, SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 /**
@@ -38,10 +38,10 @@ export function blackOrWhiteByContrastSet(
             ? restForeground
             : defaultRule(set.active);
     const focusForeground = defaultRule(set.focus);
-    const disabled = defaultRule(set.disabled) as SwatchRGB;
+    const disabled = defaultRule(set.disabled);
     // TODO: Reasonable disabled opacity, but not configurable.
     // Considering replacing these recipes anyway.
-    const disabledForeground = new SwatchRGB(disabled.r, disabled.g, disabled.b, 0.3);
+    const disabledForeground = disabled?.toTransparent(0.3) ?? null;
 
     return {
         rest: restForeground,

--- a/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/black-or-white-by-contrast.spec.ts
@@ -1,53 +1,38 @@
-import { parseColorHexRGB } from "@microsoft/fast-colors";
 import chai from "chai";
-import { SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { _black, _white } from "../utilities/color-constants.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 const { expect } = chai;
 
-const middleGrey = SwatchRGB.from(parseColorHexRGB("#808080")!);
+const middleGrey = Swatch.parse("#808080")!;
 
 describe("blackOrWhiteByContrast", (): void => {
     it("should return black when background does not meet contrast ratio with white", (): void => {
-        const small = blackOrWhiteByContrast(_white, 4.5, false) as SwatchRGB;
-        const large = blackOrWhiteByContrast(_white, 3, false) as SwatchRGB;
+        const small = blackOrWhiteByContrast(_white, 4.5, false);
+        const large = blackOrWhiteByContrast(_white, 3, false);
 
-        expect(small.r).to.equal(_black.r);
-        expect(small.g).to.equal(_black.g);
-        expect(small.b).to.equal(_black.b);
-
-        expect(large.r).to.equal(_black.r);
-        expect(large.g).to.equal(_black.g);
-        expect(large.b).to.equal(_black.b);
+        expect(small.color).to.equal(_black.color);
+        expect(large.color).to.equal(_black.color);
     });
 
     it("should return black when default if either pass", (): void => {
-        const result = blackOrWhiteByContrast(middleGrey, 3, true) as SwatchRGB;
+        const result = blackOrWhiteByContrast(middleGrey, 3, true);
 
-        expect(result.r).to.equal(_black.r);
-        expect(result.g).to.equal(_black.g);
-        expect(result.b).to.equal(_black.b);
+        expect(result.color).to.equal(_black.color);
     });
 
     it("should return white when default if either pass", (): void => {
-        const result = blackOrWhiteByContrast(middleGrey, 3, false) as SwatchRGB;
+        const result = blackOrWhiteByContrast(middleGrey, 3, false);
 
-        expect(result.r).to.equal(_white.r);
-        expect(result.g).to.equal(_white.g);
-        expect(result.b).to.equal(_white.b);
+        expect(result.color).to.equal(_white.color);
     });
 
     it("should return highest contrast when neither black nor white pass", (): void => {
-        const resultDefaultWhite = blackOrWhiteByContrast(middleGrey, 7, false) as SwatchRGB;
-        const resultDefaultBlack = blackOrWhiteByContrast(middleGrey, 7, true) as SwatchRGB;
+        const resultDefaultWhite = blackOrWhiteByContrast(middleGrey, 7, false);
+        const resultDefaultBlack = blackOrWhiteByContrast(middleGrey, 7, true);
 
-        expect(resultDefaultWhite.r).to.equal(_black.r);
-        expect(resultDefaultWhite.g).to.equal(_black.g);
-        expect(resultDefaultWhite.b).to.equal(_black.b);
-
-        expect(resultDefaultBlack.r).to.equal(_black.r);
-        expect(resultDefaultBlack.g).to.equal(_black.g);
-        expect(resultDefaultBlack.b).to.equal(_black.b);
+        expect(resultDefaultWhite.color).to.equal(_black.color);
+        expect(resultDefaultBlack.color).to.equal(_black.color);
     });
 });

--- a/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/contrast-and-delta-swatch-set.ts
@@ -1,6 +1,6 @@
 import { Palette, PaletteDirection, PaletteDirectionValue, resolvePaletteDirection } from "../palette.js";
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch, SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
@@ -63,7 +63,7 @@ export function contrastAndDeltaSwatchSet(
     }
 
     function getSwatch(palette: Palette, index: number): Swatch {
-        const swatch = palette.get(index) as SwatchRGB;
+        const swatch = palette.get(index);
         if (zeroAsTransparent === true && index === referenceIndex) {
             return swatch.toTransparent();
         } else {

--- a/packages/adaptive-ui/src/color/recipes/contrast-swatch.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/contrast-swatch.spec.ts
@@ -1,13 +1,12 @@
 import chai from "chai";
-import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { PaletteRGB } from "../palette-rgb.js";
-import { SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { contrastSwatch } from "./contrast-swatch.js";
 
 const { expect } = chai;
 
-const neutralBase = SwatchRGB.from(parseColorHexRGB("#808080")!);
-const accentBase = SwatchRGB.from(parseColorHexRGB("#80DEEA")!);
+const neutralBase = Swatch.parse("#808080")!;
+const accentBase = Swatch.parse("#80DEEA")!;
 
 describe("contrastSwatch", (): void => {
     const neutralPalette = PaletteRGB.from(neutralBase);
@@ -16,7 +15,7 @@ describe("contrastSwatch", (): void => {
     neutralPalette.swatches.concat(accentPalette.swatches).forEach((swatch): void => {
         it(`${swatch.toColorString()} should resolve a color from the neutral palette`, (): void => {
             expect(
-                neutralPalette.swatches.indexOf(contrastSwatch(neutralPalette, swatch, 4.5) as SwatchRGB)
+                neutralPalette.swatches.indexOf(contrastSwatch(neutralPalette, swatch, 4.5))
             ).not.to.equal(-1);
         });
     });

--- a/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/delta-swatch-set.ts
@@ -1,6 +1,6 @@
 import { Palette, PaletteDirection, resolvePaletteDirection } from "../palette.js";
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch, SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
@@ -36,7 +36,7 @@ export function deltaSwatchSet(
     const dir = resolvePaletteDirection(direction);
 
     function getSwatch(palette: Palette, delta: number): Swatch {
-        const swatch = palette.get(referenceIndex + dir * delta) as SwatchRGB;
+        const swatch = palette.get(referenceIndex + dir * delta);
         if (zeroAsTransparent === true && delta === 0) {
             return swatch.toTransparent();
         } else {

--- a/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
+++ b/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.spec.ts
@@ -1,14 +1,13 @@
 import chai from "chai";
-import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { PaletteRGB } from "../palette-rgb.js";
-import { SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 import { _black, _white } from "../utilities/color-constants.js";
 import { idealColorDeltaSwatchSet } from "./ideal-color-delta-swatch-set.js";
 
 const { expect } = chai;
 
-const neutralBase = SwatchRGB.from(parseColorHexRGB("#808080")!);
-const accentBase = SwatchRGB.from(parseColorHexRGB("#80DEEA")!);
+const neutralBase = Swatch.parse("#808080")!;
+const accentBase = Swatch.parse("#80DEEA")!;
 
 describe("idealColorDeltaSwatchSet", (): void => {
     const neutralPalette = PaletteRGB.from(neutralBase);
@@ -24,11 +23,11 @@ describe("idealColorDeltaSwatchSet", (): void => {
 
     it("should have accessible rest and hover colors against the background color", (): void => {
         const accentColors = [
-            SwatchRGB.from(parseColorHexRGB("#0078D4")!),
-            SwatchRGB.from(parseColorHexRGB("#107C10")!),
-            SwatchRGB.from(parseColorHexRGB("#5C2D91")!),
-            SwatchRGB.from(parseColorHexRGB("#D83B01")!),
-            SwatchRGB.from(parseColorHexRGB("#F2C812")!),
+            Swatch.parse("#0078D4")!,
+            Swatch.parse("#107C10")!,
+            Swatch.parse("#5C2D91")!,
+            Swatch.parse("#D83B01")!,
+            Swatch.parse("#F2C812")!,
         ];
 
         accentColors.forEach((accent): void => {

--- a/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/color/recipes/ideal-color-delta-swatch-set.ts
@@ -1,3 +1,4 @@
+import { Color } from "../color.js";
 import { Palette, PaletteDirection, PaletteDirectionValue, resolvePaletteDirection } from "../palette.js";
 import { InteractiveSwatchSet } from "../recipe.js";
 import { Swatch } from "../swatch.js";
@@ -36,7 +37,7 @@ export function idealColorDeltaSwatchSet(
     palette: Palette,
     reference: Swatch,
     minContrast: number,
-    idealColor: Swatch,
+    idealColor: Color,
     restDelta: number,
     hoverDelta: number,
     activeDelta: number,

--- a/packages/adaptive-ui/src/color/swatch.spec.ts
+++ b/packages/adaptive-ui/src/color/swatch.spec.ts
@@ -1,0 +1,46 @@
+import chai from "chai";
+import { Swatch } from "./swatch.js";
+import { type Rgb } from "culori/fn";
+
+const { expect } = chai;
+
+const greyColor: Rgb = { mode: "rgb", r: 0.5, g: 0.5, b: 0.5, alpha: undefined };
+const greyObject = { r: 0.5, g: 0.5, b: 0.5, alpha: undefined };
+const greyHex = "#808080";
+
+const opacityColor: Rgb = { mode: "rgb", r: 0.2, g: 0.4, b: 0.6, alpha: 0.5019607843137255 };
+const opacityHex = "#33669980";
+const opacityRgba = "rgba(51, 102, 153, 0.5)";
+
+describe("Swatch", () => {
+    it("should create a Swatch from the provided object", () => {
+        const swatch = Swatch.from(greyObject);
+
+        expect(swatch).to.be.instanceof(Swatch);
+        expect(swatch.color).to.deep.equal(greyColor);
+        expect(swatch.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Swatch from the provided RGB values", () => {
+        const swatch = Swatch.fromRgb(0.5, 0.5, 0.5);
+
+        expect(swatch).to.be.instanceof(Swatch);
+        expect(swatch.color).to.deep.equal(greyColor);
+        expect(swatch.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Swatch from the provided hex swatch", () => {
+        const swatch = Swatch.parse(greyHex)!;
+
+        expect(swatch).to.be.instanceof(Swatch);
+        expect(swatch.toColorString()).to.equal(greyHex);
+    });
+
+    it("should create a Swatch with opacity", () => {
+        const swatch = Swatch.parse(opacityHex)!;
+
+        expect(swatch).to.be.instanceof(Swatch);
+        expect(swatch.color).to.deep.equal(opacityColor);
+        expect(swatch.toColorString()).to.equal(opacityRgba);
+    });
+});

--- a/packages/adaptive-ui/src/color/swatch.ts
+++ b/packages/adaptive-ui/src/color/swatch.ts
@@ -1,5 +1,7 @@
-import { type Color as CuloriColor, parse, rgb, type Rgb } from "culori";
+import { type Color as CuloriColor, modeRgb, parse, type Rgb, useMode } from "culori/fn";
 import { Color } from "./color.js";
+
+const rgb = useMode(modeRgb);
 
 const rgbBlack: Rgb = { mode: "rgb", r: 0, g: 0, b: 0 };
 const rgbWhite: Rgb = { mode: "rgb", r: 1, g: 1, b: 1 };
@@ -26,10 +28,8 @@ function calcRgbOverlay(rgbMatch: Rgb, rgbBackground: Rgb, rgbOverlay: Rgb): num
  * @param rgbMatch - The solid color the overlay should match in appearance when placed over the rgbBackground
  * @param rgbBackground - The background on which the overlay rests
  * @returns The rgba (rgb + alpha) color of the overlay
- *
- * @public
  */
-function calculateOverlayColor(rgbMatch: Rgb, rgbBackground: Rgb,): Rgb {
+function calculateOverlayColor(rgbMatch: Rgb, rgbBackground: Rgb): Rgb {
     let overlay = rgbBlack;
     let alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
     if (alpha <= 0) {
@@ -86,11 +86,11 @@ export class Swatch extends Color {
     /**
      * Creates a new Swatch from and object with R, G, and B values expressed as a number between 0 to 1.
      *
-     * @param obj - An object with `r`, `g`, and `b` values expressed as a number between 0 and 1.
+     * @param obj - An object with `r`, `g`, and `b`, and optional `alpha` values expressed as a number between 0 and 1.
      * @returns A new Swatch
      */
-    public static from(obj: { r: number; g: number; b: number }): Swatch {
-        const color: Rgb = { mode: "rgb", r: obj.r, g: obj.g, b: obj.b };
+    public static from(obj: { r: number; g: number; b: number, alpha?: number }): Swatch {
+        const color: Rgb = { mode: "rgb", ...obj };
         return new Swatch(color);
     }
 
@@ -100,10 +100,11 @@ export class Swatch extends Color {
      * @param r - Red channel expressed as a number between 0 and 1.
      * @param g - Green channel expressed as a number between 0 and 1.
      * @param b - Blue channel expressed as a number between 0 and 1.
+     * @param alpha - Alpha channel expressed as a number between 0 and 1.
      * @returns A new Swatch
      */
-    public static fromRgb(r: number, g: number, b: number): Swatch {
-        const color: Rgb = { mode: "rgb", r, g, b };
+    public static fromRgb(r: number, g: number, b: number, alpha?: number): Swatch {
+        const color: Rgb = { mode: "rgb", r, g, b, alpha };
         return new Swatch(color);
     }
 

--- a/packages/adaptive-ui/src/color/swatch.ts
+++ b/packages/adaptive-ui/src/color/swatch.ts
@@ -1,138 +1,150 @@
-import { calculateOverlayColor, ColorRGBA64, rgbToRelativeLuminance } from "@microsoft/fast-colors";
-import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
+import { type Color as CuloriColor, parse, rgb, type Rgb } from "culori";
+import { Color } from "./color.js";
 
-/**
- * Represents a color in a {@link Palette}.
- *
- * @public
- */
-export interface Swatch extends RelativeLuminance {
-    /**
-     * Gets a string representation of the color.
-     */
-    toColorString(): string;
+const rgbBlack: Rgb = { mode: "rgb", r: 0, g: 0, b: 0 };
+const rgbWhite: Rgb = { mode: "rgb", r: 1, g: 1, b: 1 };
 
-    /**
-     * Gets the contrast between this Swatch and another one.
-     * @param target - The relative luminance for comparison
-     */
-    contrast(target: RelativeLuminance): number;
+function calcChannelOverlay(match: number, background: number, overlay: number): number {
+    if (overlay - background === 0) {
+        return 0;
+    } else {
+        return (match - background) / (overlay - background);
+    }
+}
+
+function calcRgbOverlay(rgbMatch: Rgb, rgbBackground: Rgb, rgbOverlay: Rgb): number {
+    const rChannel: number = calcChannelOverlay(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
+    const gChannel: number = calcChannelOverlay(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
+    const bChannel: number = calcChannelOverlay(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
+    return (rChannel + gChannel + bChannel) / 3;
 }
 
 /**
- * Represents a color in a {@link Palette} using RGB.
+ * Calculate an overlay color that uses rgba (rgb + alpha) that matches the appearance of a given solid color
+ * when placed on the same background.
+ *
+ * @param rgbMatch - The solid color the overlay should match in appearance when placed over the rgbBackground
+ * @param rgbBackground - The background on which the overlay rests
+ * @returns The rgba (rgb + alpha) color of the overlay
  *
  * @public
  */
-export class SwatchRGB implements Swatch {
+function calculateOverlayColor(rgbMatch: Rgb, rgbBackground: Rgb,): Rgb {
+    let overlay = rgbBlack;
+    let alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
+    if (alpha <= 0) {
+        overlay = rgbWhite;
+        alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
+    }
+    alpha = Math.round(alpha * 1000) / 1000;
+
+    return Object.assign({}, overlay, { alpha });
+}
+
+/**
+ * Extends {@link Color} adding support for relative opacity.
+ *
+ * @public
+ */
+export class Swatch extends Color {
     /**
-     * Red channel expressed as a number between 0 and 1.
+     * The opaque value this Swatch represents if opacity is used.
      */
-    readonly r: number;
+    private readonly _intendedColor?: Swatch;
 
     /**
-     * Green channel expressed as a number between 0 and 1.
+     * Creates a new Swatch.
+     *
+     * @param color - The underlying Color value
+     * @param intendedColor - If `color.alpha` &lt; 1 this tracks the intended opaque color value for dependent calculations
      */
-    readonly g: number;
-
-    /**
-     * Blue channel expressed as a number between 0 and 1.
-     */
-    readonly b: number;
-
-    /**
-     * The opaque color this Swatch represents if opacity is used.
-     */
-    readonly intendedColor?: SwatchRGB;
+    protected constructor(color: CuloriColor, intendedColor?: Swatch) {
+        super(color);
+        this._intendedColor = intendedColor;
+    }
 
     /**
      * {@inheritdoc RelativeLuminance.relativeLuminance}
      */
-    readonly relativeLuminance: number;
-
-    /**
-     * Internal representation of the Swatch in the format used by fast-colors.
-     */
-    readonly color: ColorRGBA64;
-
-    /**
-     * Creates a new SwatchRGB.
-     *
-     * @param red - Red channel expressed as a number between 0 and 1
-     * @param green - Green channel expressed as a number between 0 and 1
-     * @param blue - Blue channel expressed as a number between 0 and 1
-     * @param alpha - Alpha channel expressed as a number between 0 and 1, default 1
-     * @param intendedColor - If `alpha` &lt; 1 this tracks the intended opaque color value for dependent calculations
-     */
-    constructor(red: number, green: number, blue: number, alpha: number = 1, intendedColor?: SwatchRGB) {
-        this.r = red;
-        this.g = green;
-        this.b = blue;
-        this.color = new ColorRGBA64(red, green, blue, alpha);
-
-        this.intendedColor = intendedColor;
-        this.relativeLuminance = intendedColor
-            ? rgbToRelativeLuminance(intendedColor.color)
-            : rgbToRelativeLuminance(this.color);
+    public get relativeLuminance(): number {
+        return this._intendedColor
+            ? this._intendedColor.relativeLuminance
+            : super.relativeLuminance;
     }
 
     /**
-     * Gets this color value as a string.
-     *
-     * @returns The color value in string format
-     */
-    toColorString() {
-        return this.color.a < 1 ? this.color.toStringWebRGBA() : this.color.toStringHexRGB();
-    }
-
-    /**
-     * Gets the contrast between this Swatch and another.
-     *
-     * @returns The contrast between the two luminance values, for example, 4.54
-     */
-    contrast = contrast.bind(null, this);
-
-    /**
-     * Gets this color value as a string for use in css.
-     *
-     * @returns The color value in a valid css string format
-     */
-    createCSS = this.toColorString;
-
-    /**
-     * Gets this color as full transparent.
+     * Gets this color with transparency.
      *
      * @returns The color with full transparency
      */
-    toTransparent() {
-        return new SwatchRGB(this.r, this.g, this.b, 0, this);
+    public toTransparent(alpha: number = 0): Swatch {
+        const transparentColor = { ...this.color };
+        transparentColor.alpha = alpha;
+        return new Swatch(transparentColor, this);
     }
 
     /**
-     * Creates a new SwatchRGB from and object with R, G, and B values expressed as a number between 0 to 1.
+     * Creates a new Swatch from and object with R, G, and B values expressed as a number between 0 to 1.
      *
-     * @param obj - An object with `r`, `g`, and `b` values expressed as a number between 0 and 1
-     * @returns A new SwatchRGB
+     * @param obj - An object with `r`, `g`, and `b` values expressed as a number between 0 and 1.
+     * @returns A new Swatch
      */
-    static from(obj: { r: number; g: number; b: number }): SwatchRGB {
-        return new SwatchRGB(obj.r, obj.g, obj.b);
+    public static from(obj: { r: number; g: number; b: number }): Swatch {
+        const color: Rgb = { mode: "rgb", r: obj.r, g: obj.g, b: obj.b };
+        return new Swatch(color);
     }
 
     /**
-     * Creates a new SwatchRGB as an overlay representation of the `intendedColor` over `reference`.
+     * Creates a new Swatch from R, G, and B values expressed as a number between 0 to 1.
+     *
+     * @param r - Red channel expressed as a number between 0 and 1.
+     * @param g - Green channel expressed as a number between 0 and 1.
+     * @param b - Blue channel expressed as a number between 0 and 1.
+     * @returns A new Swatch
+     */
+    public static fromRgb(r: number, g: number, b: number): Swatch {
+        const color: Rgb = { mode: "rgb", r, g, b };
+        return new Swatch(color);
+    }
+
+    /**
+     * Creates a new Swatch from a Color.
+     *
+     * @param color - A Color
+     * @returns A new Swatch
+     */
+    public static fromColor(color: Color): Swatch {
+        return new Swatch(color.color);
+    }
+
+    /**
+     * Creates a new Swatch from a parsable string.
+     *
+     * @param color - A string representation of the Swatch.
+     * @returns The Swatch object or undefined.
+     */
+    public static parse(color: string): Swatch | undefined {
+        const parsedColor = parse(color);
+        if (parsedColor) {
+            return new Swatch(parsedColor);
+        }
+    }
+
+    /**
+     * Creates a new Swatch as an overlay representation of the `intendedColor` over `reference`.
      *
      * Currently the overlay will only be black or white, so this works best with a plain grey neutral palette.
      * Otherwise it will attempt to match the luminance value of the Swatch, so it will likely be close, but not an
      * exact match to the color from another palette.
      *
-     * @param intendedColor - The color the overlay should look like over the `reference` color
-     * @param reference - The color under the overlay color
-     * @returns A semitransparent color that implies the `intendedColor` over the `reference` color.
+     * @param intendedColor - The Swatch the overlay should look like over the `reference` Swatch.
+     * @param reference - The Swatch under the overlay color.
+     * @returns A semitransparent Swatch that represents the `intendedColor` over the `reference` Swatch.
      */
-    static asOverlay(intendedColor: SwatchRGB, reference: SwatchRGB): SwatchRGB {
-        const refColor = reference.intendedColor ?? reference;
-        const colorWithAlpha = calculateOverlayColor(intendedColor.color, refColor.color);
+    public static asOverlay(intendedColor: Swatch, reference: Swatch): Swatch {
+        const refColor = reference._intendedColor ? reference._intendedColor.color : reference.color;
+        const colorWithAlpha = calculateOverlayColor(rgb(intendedColor.color), rgb(refColor));
 
-        return new SwatchRGB(colorWithAlpha.r, colorWithAlpha.g, colorWithAlpha.b, colorWithAlpha.a, intendedColor);
+        return new Swatch(colorWithAlpha, intendedColor);
     }
 }

--- a/packages/adaptive-ui/src/color/utilities/color-constants.ts
+++ b/packages/adaptive-ui/src/color/utilities/color-constants.ts
@@ -1,15 +1,15 @@
-import { SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 
 /**
- * A {@link SwatchRGB} convenience for white.
+ * A {@link Swatch} convenience for white.
  *
  * @internal
  */
-export const _white = new SwatchRGB(1, 1, 1);
+export const _white = Swatch.fromRgb(1, 1, 1);
 
 /**
- * A {@link SwatchRGB} convenience for black.
+ * A {@link Swatch} convenience for black.
  *
  * @internal
  */
-export const _black = new SwatchRGB(0, 0, 0);
+export const _black = Swatch.fromRgb(0, 0, 0);

--- a/packages/adaptive-ui/src/color/utilities/conditional.ts
+++ b/packages/adaptive-ui/src/color/utilities/conditional.ts
@@ -1,6 +1,8 @@
 import { InteractiveSwatchSet } from "../recipe.js";
 import { _white } from "./color-constants.js";
 
+const transparentWhite = _white.toTransparent();
+
 /**
  * Return an interactive set of the provided tokens or a no-op "transparent" set of tokens.
  *
@@ -16,12 +18,11 @@ export function conditionalSwatchSet(
         return set;
     }
 
-    const transparent = _white.toTransparent();
     return {
-        rest: transparent,
-        hover: transparent,
-        active: transparent,
-        focus: transparent,
-        disabled: transparent,
+        rest: transparentWhite,
+        hover: transparentWhite,
+        active: transparentWhite,
+        focus: transparentWhite,
+        disabled: transparentWhite,
     };
 }

--- a/packages/adaptive-ui/src/color/utilities/luminance-swatch.ts
+++ b/packages/adaptive-ui/src/color/utilities/luminance-swatch.ts
@@ -1,4 +1,4 @@
-import { Swatch, SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 
 /**
  * Create a grey {@link Swatch} for the specified `luminance`. Note this is absolute luminance not 'relative' luminance.
@@ -9,5 +9,5 @@ import { Swatch, SwatchRGB } from "../swatch.js";
  * @public
  */
 export function luminanceSwatch(luminance: number): Swatch {
-    return new SwatchRGB(luminance, luminance, luminance);
+    return Swatch.fromRgb(luminance, luminance, luminance);
 }

--- a/packages/adaptive-ui/src/color/utilities/opacity.ts
+++ b/packages/adaptive-ui/src/color/utilities/opacity.ts
@@ -1,5 +1,5 @@
 import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch, SwatchRGB } from "../swatch.js";
+import { Swatch } from "../swatch.js";
 
 /**
  * Returns an opaque {@link Swatch} or a {@link Swatch} with opacity relative to the reference color.
@@ -12,8 +12,8 @@ import { Swatch, SwatchRGB } from "../swatch.js";
  * @public
  */
 export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null {
-    return swatch instanceof SwatchRGB && asOverlay
-        ? SwatchRGB.asOverlay(swatch as SwatchRGB, reference as SwatchRGB)
+    return swatch && asOverlay
+        ? Swatch.asOverlay(swatch, reference)
         : swatch;
 }
 


### PR DESCRIPTION
# Pull Request

## Description

PR #131 added a new palette based on the okhsl color model. At that time, I evaluated other color libraries with this support and went with Culori. The underlying color handling was still based on `fast-colors`. This migrates the rest of the color support to Culori and removes fast-colors.

## Test Plan

Tested in Storybook, Explorer, and Figma Designer.

Values are identical in Explorer, only difference is added space in rgba values.

Before:
![before](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/c1410f85-dbb0-4385-8aec-077778c912cb)

Update:
![update](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/115b4049-0432-4ced-8c11-879cdfd1405e)

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.