### PR TITLE
Designer: Fix containment issue with focus indicators in Figma.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,13 @@
         "editor.defaultFormatter": "vscode.typescript-language-features"
     },
     "cSpell.words": [
+        "activeid",
         "Appliable",
         "culori",
+        "Demi",
+        "Lrgb",
         "okhsl",
+        "tablist",
         "Unregisters"
     ],
     "editor.insertSpaces": true,

--- a/change/@adaptive-web-adaptive-ui-d998460b-6962-454f-b19c-e2d7d55ff826.json
+++ b/change/@adaptive-web-adaptive-ui-d998460b-6962-454f-b19c-e2d7d55ff826.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated focus stroke recipes for more control",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-figma-designer/package.json
+++ b/packages/adaptive-ui-figma-designer/package.json
@@ -19,8 +19,8 @@
     "directory": "packages/adaptive-ui-figma-designer"
   },
   "scripts": {
-    "build": "npm run build:ui -- --minify esbuild && npm run build:figma -- --minify",
-    "build:debug": "npm run build:ui && npm run build:figma",
+    "build": "npm run compile && npm run build:ui -- --minify esbuild && npm run build:figma -- --minify",
+    "build:debug": "npm run compile && npm run build:ui && npm run build:figma",
     "build:figma": "esbuild src/figma/main.ts --tsconfig=src/figma/tsconfig.json --bundle --target=ES2017 --outfile=dist/main.js",
     "build:ui": "npx vite build --emptyOutDir=false --minify false",
     "build:watch": "concurrently -n figma,ui \"npm run build:figma -- --watch\" \"npm run build:ui -- --watch\"",

--- a/packages/adaptive-ui-figma-designer/src/core/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/node.ts
@@ -14,6 +14,16 @@ import {
     ReadonlyDesignTokenValues,
 } from "./model.js";
 
+/**
+ * Layer name for special handling of the focus indicator in design tools.
+ */
+export const focusIndicatorNodeName = "Focus indicator";
+// This is not ideal, but Figma doesn't support `outline` and there's no great way to approximate it.
+// The best option is to include the indicator as a _child_ of element it indicates. The problem with
+// this is it then picks up the colors and token values of that parent, when instead those values
+// should come from the parent's parent.
+// We'll re-parent the focus indicator for the purposes of evaluating styling definitions.
+
 const DesignTokenCache: Map<string, ReadonlyDesignTokenValues> = new Map();
 
 export const StatesState = {

--- a/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
+++ b/packages/adaptive-ui-figma-designer/src/core/registry/recipes.ts
@@ -39,6 +39,7 @@ import {
     fillReadableRestDelta,
     fillStealthRestDelta,
     fillSubtleRestDelta,
+    focusStroke,
     focusStrokeInner,
     focusStrokeOuter,
     focusStrokeThickness,
@@ -177,6 +178,7 @@ const colorTokens: DesignTokenStore<Swatch> = [
     neutralFillDiscernibleRest,
     neutralFillReadableRest,
     // Stroke
+    focusStroke,
     focusStrokeOuter,
     focusStrokeInner,
     accentStrokeSafetyRest,

--- a/packages/adaptive-ui-figma-designer/src/figma/controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/controller.ts
@@ -7,7 +7,7 @@ export class FigmaController extends Controller {
     public getNode(id: string): FigmaPluginNode | null {
         const node = figma.getNodeById(id);
         if (node) {
-            return FigmaPluginNode.get(node);
+            return FigmaPluginNode.get(node, true);
         } else {
             return null;
         }

--- a/packages/adaptive-ui-figma-designer/src/figma/node.ts
+++ b/packages/adaptive-ui-figma-designer/src/figma/node.ts
@@ -557,9 +557,9 @@ export class FigmaPluginNode extends PluginNode {
                 case StyleProperty.backgroundFill:
                 case StyleProperty.foregroundFill:
                     // I'd like to describe this better, but for now don't pass `foregroundFill`
-                    // to children other than vector nodes (for icon support)
+                    // to children other than text and vector nodes (for icon support)
                     if (this.supports.includes(target) &&
-                        (inherited ? isVectorNode(this._node) : true)) {
+                        (inherited ? isTextNode(this._node) || isVectorNode(this._node) : true)) {
                         this.paintColor(target, value);
                     }
                     break;

--- a/packages/adaptive-ui-figma-designer/src/ui/app.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/app.ts
@@ -570,7 +570,7 @@ export class App extends FASTElement {
     public appliedStyleModules: StyleModuleDisplayList = new Map();
 
     @observable
-    public statesState: StatesState;
+    public statesState: StatesState | "unknown" = "unknown";
 
     @observable
     public selectionDescription: string;

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller-elements.ts
@@ -143,6 +143,7 @@ export class ElementsController {
         // Create an element representing this node in our local dom.
         const nodeElement = document.createElement(providerElementName) as FASTElement;
         nodeElement.id = node.id;
+        nodeElement.title = node.name;
         element.appendChild(nodeElement);
 
         // Set all the inherited design token values for the local element.

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
@@ -315,7 +315,7 @@ export class UIController {
             const colorHex = node.additionalData.get(AdditionalDataKeys.toolParentFillColor);
             if (colorHex) {
                 const parentElement = this._elements.getElementForNode(node).parentElement as FASTElement;
-                // console.log("    setting fill color token on parent element", colorHex, parentElement.id);
+                // console.log("    setting fill color token on parent element", colorHex, parentElement.id, parentElement.title);
                 this._elements.setDesignTokenForElement(parentElement, fillColor, Swatch.parse(colorHex));
             }
 

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -1,7 +1,9 @@
 import type { DesignTokenResolver, ValuesOf } from "@microsoft/fast-foundation";
+import { Palette } from "../color/palette.js";
 import { ColorRecipePaletteParams, ColorRecipeParams, InteractiveSwatchSet } from "../color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../color/recipes/black-or-white-by-contrast-set.js";
 import { blackOrWhiteByContrast } from "../color/recipes/black-or-white-by-contrast.js";
+import { contrastSwatch } from "../color/recipes/contrast-swatch.js";
 import { contrastAndDeltaSwatchSet } from "../color/recipes/contrast-and-delta-swatch-set.js";
 import { deltaSwatchSet } from "../color/recipes/delta-swatch-set.js";
 import { Swatch } from "../color/swatch.js";
@@ -1333,6 +1335,46 @@ export const neutralStrokeStrongActive = neutralStrokeStrong.active;
 
 /** @public */
 export const neutralStrokeStrongFocus = neutralStrokeStrong.focus;
+
+/**
+ * The {@link Palette} to use for focus stroke recipes.
+ *
+ * @remarks
+ * By default this maps to the {@link accentPalette}.
+ * Use a custom palette like `focusStrokePalette.withDefault(PaletteRGB.from("#[HEX_COLOR]"))`.
+ *
+ * @public
+ */
+export const focusStrokePalette = createTokenNonCss<Palette>("focus-stroke-palette", DesignTokenType.palette).withDefault(accentPalette);
+
+/**
+ * The minimum contrast for the focus stroke recipe.
+ *
+ * @remarks
+ * By default this maps to the {@link minContrastDiscernible}, which by default meets 3:1 contrast recommendation.
+ *
+ * @public
+ */
+export const focusStrokeMinContrast = createTokenNonCss<number>("focus-stroke-min-contrast", DesignTokenType.number).withDefault(minContrastDiscernible);
+
+// Focus Stroke
+
+const focusStrokeName = "focus-stroke";
+
+/** @public */
+export const focusStrokeRecipe = createTokenColorRecipe(
+    focusStrokeName,
+    [...stylePropertyBorderFillAll, StyleProperty.outlineColor],
+    (resolve: DesignTokenResolver, params?: ColorRecipeParams): Swatch =>
+        contrastSwatch(
+            resolve(focusStrokePalette),
+            params?.reference || resolve(fillColor),
+            resolve(focusStrokeMinContrast)
+        )
+);
+
+/** @public */
+export const focusStroke = createTokenColorRecipeValue(focusStrokeRecipe);
 
 // Focus Stroke Outer
 

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -20,7 +20,7 @@ import {
     criticalStrokeReadableRecipe,
     criticalStrokeSafety,
     fillColor,
-    focusStrokeOuter,
+    focusStroke,
     highlightFillDiscernible,
     highlightFillReadable,
     highlightFillStealth,
@@ -997,7 +997,7 @@ export const disabledStyles: Styles = Styles.fromProperties(
  */
 export const focusIndicatorStyles: Styles = Styles.fromProperties(
     {
-        outlineColor: focusStrokeOuter,
+        outlineColor: focusStroke,
         outlineOffset: "1px",
         outlineStyle: "solid",
         outlineWidth: focusStrokeThickness,


### PR DESCRIPTION
# Pull Request

## Description

As part of #156 an interactive component set gets a "focus" state. A common treatment for focus is the css `outline` property. Figma currently doesn't support this treatment, and the best way to accomplish it is to nest an edge-to-edge constrained element _within_ the element for which it represents focus. Since it actually draws outside of that element, the context for color recipes should be the parent of the focused element, but since in Figma it must be nested within, it picks up the context of the element itself.

This PR adds support for special handling for a layer named "Focus indicator" which relocates it to the correct parent.

Related to this, it adds a new focus recipe based on a palette (rather than black or white) to enable more subtle or customized focus treatments. The default contrast is 3:1 in accordance with the new guidance in WCAG 2.2.

Here's a before and after of the default treatment - from neutral to accent 3:1

![image](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/e66438fc-4ad5-4589-b5a3-687a0c96f79f)

## Reviewer Notes

I wish there was a better way to handle this, but I can't think of one until Figma adds native support for outline.

## Test Plan

Tested in Explorer and Designer plugin.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.