### PR TITLE
Component style cleanup

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-71eb14e3-f8d5-4ef7-8a87-7f748d117bde.json
+++ b/change/@adaptive-web-adaptive-web-components-71eb14e3-f8d5-4ef7-8a87-7f748d117bde.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Component style cleanup",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -176,6 +176,7 @@ export const AnchorAnatomy: ComponentAnatomy<typeof AnchorConditions, typeof Anc
 // @public (undocumented)
 export const AnchorConditions: {
     iconOnly: string;
+    noHref: string;
 };
 
 // @public
@@ -286,7 +287,10 @@ export const breadcrumbItemAestheticStyles: ElementStyles;
 export const BreadcrumbItemAnatomy: ComponentAnatomy<typeof BreadcrumbItemConditions, typeof BreadcrumbItemParts>;
 
 // @public (undocumented)
-export const BreadcrumbItemConditions: {};
+export const BreadcrumbItemConditions: {
+    noHref: string;
+    current: string;
+};
 
 // @public (undocumented)
 export const BreadcrumbItemParts: {
@@ -1223,7 +1227,9 @@ export const pickerMenuOptionAestheticStyles: ElementStyles;
 export const PickerMenuOptionAnatomy: ComponentAnatomy<typeof PickerMenuOptionConditions, typeof PickerMenuOptionParts>;
 
 // @public (undocumented)
-export const PickerMenuOptionConditions: {};
+export const PickerMenuOptionConditions: {
+    selected: string;
+};
 
 // @public (undocumented)
 export const PickerMenuOptionParts: {};

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.ts
@@ -22,7 +22,6 @@ export const templateStyles: ElementStyles = css`
     }
 
     .button {
-        appearance: none;
         border: none;
         background: none;
         text-align: left;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.stories.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.stories.ts
@@ -43,7 +43,7 @@ export const storyTemplate = html<StoryArgs<AdaptiveAnchor>>`
 
 export default {
     title: "Components/Anchor",
-    includeStories: ["Anchor", "AnchorWithoutHref"],
+    includeStories: ["Anchor", "AnchorIconOnly", "AnchorWithoutHref"],
     args: {
         startSlotIcon: false,
         endSlotIcon: false,
@@ -84,6 +84,15 @@ export default {
 } as Meta<AdaptiveAnchor>;
 
 export const Anchor: Story<AdaptiveAnchor> = renderComponent(storyTemplate).bind({});
+
+export const AnchorIconOnly: Story<AdaptiveAnchor> = Anchor.bind({});
+AnchorIconOnly.args = {
+    storyContent: html`
+        <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8.26 4.6a5.21 5.21 0 0 1 9.03 5.22l-.2.34a.5.5 0 0 1-.67.19l-3.47-2-1.93 3.38c1.34.4 2.5 1.33 3.31 2.52h-.09c-.34 0-.66.11-.92.31A4.9 4.9 0 0 0 9.5 12.5a4.9 4.9 0 0 0-3.82 2.06 1.5 1.5 0 0 0-1.01-.3 5.94 5.94 0 0 1 5.31-2.74l2.1-3.68-3.83-2.2a.5.5 0 0 1-.18-.7l.2-.33Zm.92.42 1.7.98.02-.02a8.08 8.08 0 0 1 3.27-2.74 4.22 4.22 0 0 0-4.99 1.78ZM14 7.8c.47-.82.7-1.46.77-2.09a5.8 5.8 0 0 0-.06-1.62 6.96 6.96 0 0 0-2.95 2.41L14 7.8Zm.87.5 1.61.93a4.22 4.22 0 0 0-.74-5.02c.07.56.09 1.1.02 1.63-.1.79-.38 1.56-.89 2.46Zm-9.63 7.3a.5.5 0 0 0-.96.03c-.17.7-.5 1.08-.86 1.3-.38.23-.87.32-1.42.32a.5.5 0 0 0 0 1c.64 0 1.33-.1 1.94-.47.34-.2.64-.5.88-.87a2.96 2.96 0 0 0 4.68-.01 2.96 2.96 0 0 0 4.74-.06c.64.9 1.7 1.41 2.76 1.41a.5.5 0 1 0 0-1c-.98 0-1.96-.64-2.29-1.65a.5.5 0 0 0-.95 0 1.98 1.98 0 0 1-3.79.07.5.5 0 0 0-.94 0 1.98 1.98 0 0 1-3.8-.08Z"/>
+        </svg>
+    `,
+};
 
 export const AnchorWithoutHref: Story<AdaptiveAnchor> = Anchor.bind({});
 AnchorWithoutHref.args = {

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
@@ -1,5 +1,11 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { actionStyles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import {
+    accentForegroundReadableControlStyles,
+    controlShapeStyles,
+    densityControl,
+    neutralForegroundStrongElementStyles,
+    typeRampBaseStyles
+} from "@adaptive-web/adaptive-ui/reference";
 import { AnchorAnatomy } from "./anchor.template.js";
 
 /**
@@ -12,6 +18,20 @@ export const styleModules: StyleModules = [
         {
             part: AnchorAnatomy.parts.control,
         },
-        actionStyles
+        Styles.compose([
+            controlShapeStyles,
+            typeRampBaseStyles,
+            accentForegroundReadableControlStyles,
+        ],
+        {
+            gap: densityControl.horizontalGap,
+        }),
+    ],
+    [
+        {
+            hostCondition: AnchorAnatomy.conditions.noHref,
+            part: AnchorAnatomy.parts.control,
+        },
+        neutralForegroundStrongElementStyles,
     ],
 ];

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.ts
@@ -11,13 +11,12 @@ export const templateStyles: ElementStyles = css`
     }
 
     .control {
-        display: inline-flex;
-        flex-grow: 1;
-        justify-content: center;
+        display: flex;
         align-items: center;
         white-space: nowrap;
-        font: inherit;
-        text-decoration: none;
+        /* explicit width */
+        flex-grow: 1;
+        justify-content: center;
     }
 
     ::slotted([slot="start"]),
@@ -31,8 +30,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .control.icon-only {
-        padding: 0;
-        line-height: 0;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.template.ts
@@ -8,6 +8,7 @@ import { DesignSystem } from "../../design-system.js";
  */
 export const AnchorConditions = {
     iconOnly: ".icon-only",
+    noHref: ":not([href])",
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -6,6 +6,7 @@ import {
     accentForegroundReadableControlStyles,
     controlDensityStyles,
     controlShapeStyles,
+    neutralForegroundStrongElementStyles,
     plainTextStyles
 } from "@adaptive-web/adaptive-ui/reference";
 import { BreadcrumbItemAnatomy } from "./breadcrumb-item.template.js";
@@ -31,6 +32,21 @@ export const styleModules: StyleModules = [
                 controlDensityStyles,
             ],
         )
+    ],
+    [
+        {
+            hostCondition: BreadcrumbItemAnatomy.conditions.noHref,
+            part: BreadcrumbItemAnatomy.parts.control,
+        },
+        neutralForegroundStrongElementStyles,
+    ],
+    [
+        {
+            hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            part: BreadcrumbItemAnatomy.parts.control,
+            partCondition: BreadcrumbItemAnatomy.conditions.current,
+        },
+        neutralForegroundStrongElementStyles,
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.ts
@@ -1,5 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { neutralForegroundRest } from "@adaptive-web/adaptive-ui/migration";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -25,8 +24,8 @@ export const templateStyles: ElementStyles = css`
         cursor: pointer;
     }
 
-    :host([aria-current]) .control {
-        cursor: default;
+    .control[aria-current] {
+        text-decoration: none;
     }
 
     ::slotted([slot="start"]),
@@ -41,9 +40,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host(:not([href])),
-    :host([aria-current]) .control {
-        color: ${neutralForegroundRest} !important;
-        fill: currentcolor;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.template.ts
@@ -21,7 +21,10 @@ export type BreadcrumbItemStatics = ValuesOf<typeof BreadcrumbItemStatics>;
 /**
  * @public
  */
-export const BreadcrumbItemConditions = {};
+export const BreadcrumbItemConditions = {
+    noHref: ":not([href])",
+    current: "[aria-current]",
+};
 
 /**
  * @public

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.stories.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.stories.ts
@@ -42,12 +42,3 @@ BreadcrumbsWithTextSeparators.args = {
         </adaptive-breadcrumb-item>
     `,
 };
-
-export const BreadcrumbsWithAnchors: Story<FASTBreadcrumb> = renderComponent(storyTemplate).bind({});
-BreadcrumbsWithAnchors.args = {
-    storyContent: html`
-        <a href="#">Breadcrumb Item 1</a>
-        <a href="#">Breadcrumb Item 2</a>
-        <a href="#">Breadcrumb Item 3</a>
-    `,
-};

--- a/packages/adaptive-web-components/src/components/button/button.stories.ts
+++ b/packages/adaptive-web-components/src/components/button/button.stories.ts
@@ -2,6 +2,7 @@ import { html } from "@microsoft/fast-element";
 import { ButtonType, FASTButton } from "@microsoft/fast-foundation";
 import { maybeEndSlotIcon, maybeStartSlotIcon, renderComponent } from "../../utilities/storybook-helpers.js";
 import type { Meta, Story, StoryArgs } from "../../utilities/storybook-helpers.js";
+import { AdaptiveButton } from "./button.js";
 
 export const storyTemplate = html<StoryArgs<FASTButton>>`
     <adaptive-button
@@ -46,7 +47,7 @@ export const storyTemplate = html<StoryArgs<FASTButton>>`
 
 export default {
     title: "Components/Button",
-    includeStories: ["Button"],
+    includeStories: ["Button", "ButtonIconOnly"],
     args: {
         startSlotIcon: false,
         endSlotIcon: false,
@@ -91,3 +92,12 @@ export default {
 } as Meta<FASTButton>;
 
 export const Button: Story<FASTButton> = renderComponent(storyTemplate).bind({});
+
+export const ButtonIconOnly: Story<AdaptiveButton> = Button.bind({});
+ButtonIconOnly.args = {
+    storyContent: html`
+        <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+            <path d="M8.26 4.6a5.21 5.21 0 0 1 9.03 5.22l-.2.34a.5.5 0 0 1-.67.19l-3.47-2-1.93 3.38c1.34.4 2.5 1.33 3.31 2.52h-.09c-.34 0-.66.11-.92.31A4.9 4.9 0 0 0 9.5 12.5a4.9 4.9 0 0 0-3.82 2.06 1.5 1.5 0 0 0-1.01-.3 5.94 5.94 0 0 1 5.31-2.74l2.1-3.68-3.83-2.2a.5.5 0 0 1-.18-.7l.2-.33Zm.92.42 1.7.98.02-.02a8.08 8.08 0 0 1 3.27-2.74 4.22 4.22 0 0 0-4.99 1.78ZM14 7.8c.47-.82.7-1.46.77-2.09a5.8 5.8 0 0 0-.06-1.62 6.96 6.96 0 0 0-2.95 2.41L14 7.8Zm.87.5 1.61.93a4.22 4.22 0 0 0-.74-5.02c.07.56.09 1.1.02 1.63-.1.79-.38 1.56-.89 2.46Zm-9.63 7.3a.5.5 0 0 0-.96.03c-.17.7-.5 1.08-.86 1.3-.38.23-.87.32-1.42.32a.5.5 0 0 0 0 1c.64 0 1.33-.1 1.94-.47.34-.2.64-.5.88-.87a2.96 2.96 0 0 0 4.68-.01 2.96 2.96 0 0 0 4.74-.06c.64.9 1.7 1.41 2.76 1.41a.5.5 0 1 0 0-1c-.98 0-1.96-.64-2.29-1.65a.5.5 0 0 0-.95 0 1.98 1.98 0 0 1-3.79.07.5.5 0 0 0-.94 0 1.98 1.98 0 0 1-3.8-.08Z"/>
+        </svg>
+    `,
+};

--- a/packages/adaptive-web-components/src/components/button/button.styles.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.ts
@@ -10,13 +10,13 @@ export const templateStyles: ElementStyles = css`
     }
 
     .control {
-        display: inline-flex;
-        flex-grow: 1;
-        justify-content: center;
+        display: flex;
         align-items: center;
         white-space: nowrap;
+        /* explicit width */
+        flex-grow: 1;
+        justify-content: center;
         /* reset */
-        font: inherit;
         border: none;
         margin: 0;
         padding: 0;
@@ -37,8 +37,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .control.icon-only {
-        padding: 0;
-        line-height: 0;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.ts
@@ -1,10 +1,11 @@
-import { foregroundOnAccentRest } from "@adaptive-web/adaptive-ui/migration";
 import {
     accentFillReadableRest,
     cornerRadiusControl,
     designUnit,
     fillColor,
+    neutralFillSubtleRest,
     neutralStrokeReadableRest,
+    neutralStrokeStrongRest,
     strokeThickness,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
@@ -106,12 +107,12 @@ export const aestheticStyles: ElementStyles = css`
     }
 
     .today.disabled::before {
-        color: ${foregroundOnAccentRest};
+        color: ${neutralStrokeStrongRest};
     }
 
     .today .date {
-        color: ${foregroundOnAccentRest};
-        background: ${accentFillReadableRest};
+        color: ${neutralStrokeStrongRest};
+        background: ${neutralFillSubtleRest};
         border-radius: 50%;
         position: relative;
     }

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
@@ -1,5 +1,6 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
+    densityControl,
     labelTextStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles
@@ -12,6 +13,13 @@ import { CheckboxAnatomy } from "./checkbox.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        Styles.fromProperties({
+            gap: densityControl.horizontalGap,
+        })
+    ],
     [
         {
             part: CheckboxAnatomy.parts.label,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.ts
@@ -12,7 +12,6 @@ export const templateStyles: ElementStyles = css`
     :host {
         display: inline-flex;
         align-items: center;
-        user-select: none;
     }
 
     .control {
@@ -53,9 +52,5 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
-    }
-
-    .label {
-        padding-inline-start: calc((${designUnit} * 2) + 2px);
     }
 `;

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.ts
@@ -12,7 +12,6 @@ export const templateStyles: ElementStyles = css`
     :host {
         display: inline-flex;
         position: relative;
-        user-select: none;
         vertical-align: top;
     }
 
@@ -29,16 +28,13 @@ export const templateStyles: ElementStyles = css`
     }
 
     .selected-value {
-        -webkit-appearance: none;
+        width: 100%;
+        /* reset */
         background: transparent;
         border: none;
         color: inherit;
         font: inherit;
         padding: unset;
-    }
-
-    :host(:active) .selected-value {
-        user-select: none;
     }
 
     .listbox {
@@ -53,11 +49,6 @@ export const templateStyles: ElementStyles = css`
         display: none;
     }
 
-    :host([disabled]) .control,
-    :host([disabled]) .selected-value {
-        user-select: none;
-    }
-
     ::slotted([role="option"]) {
         flex: 0 0 auto;
     }
@@ -68,22 +59,8 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        min-width: 250px;
-    }
-
-    .control {
-        min-height: 100%;
-        width: 100%;
-    }
-
-    .selected-value {
-        flex: 1 1 auto;
-        text-align: start;
-    }
-
     .listbox {
-        background: ${layerFillFixedPlus1};
+        background-color: ${layerFillFixedPlus1};
         box-shadow: ${elevationFlyout};
     }
 `;

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -7,6 +7,7 @@ import {
     controlShapeStyles,
     plainTextStyles
 } from "@adaptive-web/adaptive-ui/reference";
+import { DataGridCellAnatomy } from "./data-grid-cell.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -24,5 +25,21 @@ export const styleModules: StyleModules = [
                 plainTextStyles,
             ],
         )
+    ],
+    [
+        {
+            hostCondition: DataGridCellAnatomy.conditions.cellTypeColumnHeader,
+        },
+        Styles.fromProperties({
+            fontWeight: "600",
+        }),
+    ],
+    [
+        {
+            hostCondition: DataGridCellAnatomy.conditions.cellTypeRowHeader,
+        },
+        Styles.fromProperties({
+            fontWeight: "600",
+        }),
     ],
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.ts
@@ -7,6 +7,7 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 export const templateStyles: ElementStyles = css`
     :host {
         overflow: hidden;
+        white-space: nowrap;
     }
 `;
 
@@ -15,12 +16,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        white-space: nowrap;
-    }
-
-    :host([cell-type="columnheader"]),
-    :host([cell-type="rowheader"]) {
-        font-weight: 600;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -1,8 +1,8 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
-    accentStrokeReadableRest,
     cornerRadiusControl,
     focusStrokeThickness,
+    highlightStrokeReadableRest,
     neutralFillSubtleRest,
 } from "@adaptive-web/adaptive-ui/reference";
 import { heightNumber } from "../../styles/index.js";
@@ -28,12 +28,8 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        padding: 1px 0;
-    }
-
     :host([row-type="sticky-header"]) {
-        background: ${neutralFillSubtleRest};
+        background-color: ${neutralFillSubtleRest};
     }
 
     :host([aria-selected="true"])::after {
@@ -41,7 +37,7 @@ export const aestheticStyles: ElementStyles = css`
         display: block;
         position: absolute;
         border-radius: ${cornerRadiusControl};
-        background: ${accentStrokeReadableRest};
+        background-color: ${highlightStrokeReadableRest};
         align-self: center;
         left: ${focusStrokeThickness};
         width: 3px;

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.ts
@@ -7,6 +7,8 @@ import { elevationDialog, fillColor } from "@adaptive-web/adaptive-ui/reference"
  */
 export const templateStyles: ElementStyles = css`
     :host {
+        --dialog-height: 480px;
+        --dialog-width: 640px;
         display: flex;
         align-items: center;
         position: fixed;
@@ -15,6 +17,7 @@ export const templateStyles: ElementStyles = css`
         bottom: 0;
         left: 0;
         overflow: auto;
+        justify-content: center;
     }
 
     .overlay {
@@ -29,6 +32,10 @@ export const templateStyles: ElementStyles = css`
     .control {
         position: relative;
         z-index: 1;
+        margin-top: auto;
+        margin-bottom: auto;
+        width: var(--dialog-width);
+        height: var(--dialog-height);
     }
 `;
 
@@ -37,22 +44,12 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        --dialog-height: 480px;
-        --dialog-width: 640px;
-        justify-content: center;
-    }
-
     .overlay {
-        background: rgba(0, 0, 0, 0.3);
+        background-color: rgba(0, 0, 0, 0.3);
     }
 
     .control {
-        margin-top: auto;
-        margin-bottom: auto;
-        width: var(--dialog-width);
-        height: var(--dialog-height);
-        background: ${fillColor};
+        background-color: ${fillColor};
         box-shadow: ${elevationDialog};
     }
 `;

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.ts
@@ -1,13 +1,3 @@
-import {
-    foregroundOnAccentActive,
-    foregroundOnAccentHover,
-    foregroundOnAccentRest,
-} from "@adaptive-web/adaptive-ui/migration";
-import {
-    accentFillReadableActive,
-    accentFillReadableHover,
-    accentFillReadableRest,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -19,14 +9,9 @@ export const templateStyles: ElementStyles = css`
         display: block;
     }
 
-    .invoker::-webkit-details-marker {
-        display: none;
-    }
-
     .invoker {
         display: flex;
         align-items: center;
-        list-style-type: none;
         cursor: pointer;
     }
 
@@ -50,19 +35,6 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     .invoker {
-        background: ${accentFillReadableRest};
-        color: ${foregroundOnAccentRest};
-        fill: currentcolor;
         max-width: max-content;
-    }
-
-    .invoker:hover {
-        background: ${accentFillReadableHover};
-        color: ${foregroundOnAccentHover};
-    }
-
-    .invoker:active {
-        background: ${accentFillReadableActive};
-        color: ${foregroundOnAccentActive};
     }
 `;

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.template.ts
@@ -21,7 +21,7 @@ export const DisclosureParts = {
  * @public
  */
 export const DisclosureAnatomy: ComponentAnatomy<typeof DisclosureConditions, typeof DisclosureParts> = {
-    interactivity: Interactivity.never,
+    interactivity: Interactivity.always,
     conditions: DisclosureConditions,
     parts: DisclosureParts,
     focus: Focus.partFocused("invoker"),

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.modules.ts
@@ -1,5 +1,5 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { actionStyles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { actionStyles, controlSquareDensityStyles, roundShapeStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
  * Visual styles composed by modules.
@@ -10,6 +10,10 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        actionStyles
+        Styles.compose([
+            actionStyles,
+            roundShapeStyles,
+            controlSquareDensityStyles,
+        ]),
     ],
 ];

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.ts
@@ -1,5 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -8,7 +7,6 @@ import { heightNumber } from "../../styles/index.js";
 export const templateStyles: ElementStyles = css`
     :host {
         display: inline-flex;
-        justify-content: center;
         align-items: center;
         cursor: pointer;
     }
@@ -17,10 +15,6 @@ export const templateStyles: ElementStyles = css`
     .previous {
         display: flex;
     }
-
-    :host([disabled]) {
-        cursor: not-allowed;
-    }
 `;
 
 /**
@@ -28,14 +22,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        width: calc(${heightNumber} * 1px);
-        height: calc(${heightNumber} * 1px);
-        border-radius: 50% !important;
-        padding: 0 !important;
-    }
-
-    :host([disabled]) {
-        opacity: 0.3;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.stories.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.stories.ts
@@ -56,6 +56,17 @@ export default {
                         max-width: 620px;
                         margin: 20px;
                     }
+
+                    .scroll-view
+                    /*TODO part selectors outside of component*/
+                    /*adaptive-horizontal-scroll::part(scroll-view)*/ {
+                        padding: 4px;
+                    }
+
+                    .content
+                    /*adaptive-horizontal-scroll::part(content)*/ {
+                        gap: 4px;
+                    }
                 `);
             });
 

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
@@ -1,9 +1,4 @@
-import {
-    StyleModules,
-    Styles,
-} from "@adaptive-web/adaptive-ui";
-import { densityControl } from "@adaptive-web/adaptive-ui/reference";
-import { HorizontalScrollAnatomy } from "./horizontal-scroll.template.js";
+import { StyleModules } from "@adaptive-web/adaptive-ui";
 
 /**
  * Visual styles composed by modules.
@@ -11,12 +6,4 @@ import { HorizontalScrollAnatomy } from "./horizontal-scroll.template.js";
  * @public
  */
 export const styleModules: StyleModules = [
-    [
-        {
-            part: HorizontalScrollAnatomy.parts.content
-        },
-        Styles.fromProperties({
-            gap: densityControl.horizontalGap,
-        })
-    ],
 ];

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.ts
@@ -33,9 +33,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .scroll-view {
-        padding: 4px;
-    }
 `;
 
 /**

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.ts
@@ -25,6 +25,11 @@ export const templateStyles: ElementStyles = css`
         text-overflow: ellipsis;
         flex-grow: 1;
     }
+
+    ::slotted([slot="start"]),
+    ::slotted([slot="end"]) {
+        display: flex;
+    }
 `;
 
 /**
@@ -32,8 +37,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    ::slotted([slot="start"]),
-    ::slotted([slot="end"]) {
-        display: flex;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.ts
@@ -1,7 +1,6 @@
 import {
     focusStrokeOuter,
     focusStrokeThickness,
-    layerFillFixedPlus1,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
@@ -21,10 +20,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        background: ${layerFillFixedPlus1};
-    }
-
     :host(:not([aria-multiselectable]):not([disabled]):focus-visible) ::slotted([aria-selected="true"][role="option"]:not([disabled])),
     :host([aria-multiselectable="true"]:not([disabled]):focus-visible) ::slotted([aria-checked="true"][role="option"]:not([disabled])) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
@@ -1,6 +1,7 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
     autofillInnerDensityStyles,
+    densityControl,
     inputAutofillStyles,
     labelTextStyles,
     typeRampBaseStyles
@@ -16,7 +17,14 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampBaseStyles
+        Styles.compose(
+            [
+                typeRampBaseStyles,
+            ],
+            {
+                gap: densityControl.verticalGap,
+            }
+        ),
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.ts
@@ -6,12 +6,12 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  */
 export const templateStyles: ElementStyles = css`
     :host {
-        display: inline-block;
-        user-select: none;
+        display: inline-flex;
+        flex-direction: column;
     }
 
     .label {
-        display: inline-block;
+        align-self: start;
         cursor: pointer;
     }
 
@@ -26,15 +26,13 @@ export const templateStyles: ElementStyles = css`
     }
 
     .control {
-        -webkit-appearance: none;
         width: 100%;
-        font: inherit;
+        /* reset */
         background: transparent;
-        border: 0;
-        color: inherit;
-        margin-top: auto;
-        margin-bottom: auto;
         border: none;
+        color: inherit;
+        font: inherit;
+        padding: unset;
     }
 
     .controls {
@@ -63,16 +61,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .label {
-        margin-bottom: 4px;
-    }
-
-    .control {
-        height: calc(100% - 4px);
-    }
-
-    .step-up,
-    .step-down {
-        padding: 1px 10px;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.ts
@@ -31,10 +31,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        gap: ${densityControl.horizontalGap};
-    }
-
     :host(:not([disabled]):focus-within) {
         outline: ${focusStrokeThickness} solid ${focusStrokeOuter};
     }

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
@@ -1,5 +1,6 @@
 import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { itemStyles } from "@adaptive-web/adaptive-ui/reference";
+import { highlightFillReadableControlStyles, itemStyles } from "@adaptive-web/adaptive-ui/reference";
+import { PickerMenuOptionAnatomy } from "./picker-menu-option.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -10,6 +11,12 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        itemStyles
+        itemStyles,
+    ],
+    [
+        {
+            hostCondition: PickerMenuOptionAnatomy.conditions.selected,
+        },
+        highlightFillReadableControlStyles,
     ],
 ];

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.ts
@@ -1,9 +1,3 @@
-import {
-    foregroundOnAccentRest,
-} from "@adaptive-web/adaptive-ui/migration";
-import {
-    accentFillReadableRest,
-} from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -27,8 +21,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host([aria-selected="true"]) {
-        background: ${accentFillReadableRest};
-        color: ${foregroundOnAccentRest};
-    }
 `;

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.template.ts
@@ -7,6 +7,7 @@ import { DesignSystem } from "../../design-system.js";
  * @public
  */
 export const PickerMenuOptionConditions = {
+    selected: "[aria-selected='true']",
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
@@ -1,6 +1,8 @@
 import {
-    StyleModules,
+    StyleModules, Styles,
 } from "@adaptive-web/adaptive-ui";
+import { densityControl } from "@adaptive-web/adaptive-ui/reference";
+import { RadioGroupAnatomy } from "./radio-group.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +10,19 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        Styles.fromProperties({
+            gap: densityControl.verticalGap,
+        })
+    ],
+    [
+        {
+            part: RadioGroupAnatomy.parts.positioningRegion,
+        },
+        Styles.fromProperties({
+            gap: densityControl.verticalGap,
+        }),
+    ]
 ];

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.ts
@@ -7,6 +7,8 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 export const templateStyles: ElementStyles = css`
     :host {
         display: flex;
+        flex-direction: column;
+        align-items: flex-start;
     }
 
     .positioning-region {
@@ -24,12 +26,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        align-items: flex-start;
-        flex-direction: column;
-    }
-
-    .positioning-region {
-        gap: 8px;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
@@ -1,6 +1,8 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
+    densityControl,
     labelTextStyles,
+    roundShapeStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles
 } from "@adaptive-web/adaptive-ui/reference";
@@ -14,6 +16,13 @@ import { RadioAnatomy } from "./radio.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        Styles.fromProperties({
+            gap: densityControl.horizontalGap,
+        })
+    ],
+    [
+        {
             part: RadioAnatomy.parts.label,
         },
         labelTextStyles
@@ -22,13 +31,19 @@ export const styleModules: StyleModules = [
         {
             part: RadioAnatomy.parts.control,
         },
-        selectableUnselectedStyles
+        Styles.compose([
+            selectableUnselectedStyles,
+            roundShapeStyles,
+        ]),
     ],
     [
         {
             hostCondition: RadioAnatomy.conditions.checked,
             part: RadioAnatomy.parts.control,
         },
-        selectableSelectedStyles
+        Styles.compose([
+            selectableSelectedStyles,
+            roundShapeStyles,
+        ]),
     ],
 ];

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.ts
@@ -54,10 +54,5 @@ export const aestheticStyles: ElementStyles = css`
     .control {
         width: calc((${heightNumber} / 2) * 1px + ${designUnit});
         height: calc((${heightNumber} / 2) * 1px + ${designUnit});
-        border-radius: 50% !important;
-    }
-
-    .label {
-        padding-inline-start: calc((${designUnit} * 2) + 2px);
     }
 `;

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -4,6 +4,7 @@ import {
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
+    densityControl,
     inputStyles,
     labelTextStyles,
     neutralFillStealthControlStyles,
@@ -20,7 +21,14 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampBaseStyles
+        Styles.compose(
+            [
+                typeRampBaseStyles,
+            ],
+            {
+                gap: densityControl.verticalGap,
+            }
+        ),
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/search/search.styles.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.ts
@@ -10,24 +10,34 @@ import { density, heightNumber } from "../../styles/index.js";
  */
 export const templateStyles: ElementStyles = css`
     :host {
-        display: inline-block;
-        user-select: none;
-        /* position: relative; */
+        display: inline-flex;
+        flex-direction: column;
+    }
+
+    .label {
+        align-self: start;
+        cursor: pointer;
+    }
+
+    .label.label__hidden {
+        display: none;
+        visibility: hidden;
     }
 
     .root,
     .input-wrapper {
         display: flex;
+        align-items: center;
     }
 
     .control {
         -webkit-appearance: none;
-        margin: 0;
-        padding: unset;
-        border: none;
+        /* reset */
         background: transparent;
+        border: none;
         color: inherit;
         font: inherit;
+        padding: unset;
     }
 
     .control::-webkit-search-cancel-button {
@@ -58,16 +68,6 @@ export const templateStyles: ElementStyles = css`
         opacity: 0;
     }
 
-    .label.label__hidden {
-        display: none;
-        visibility: hidden;
-    }
-
-    .label {
-        display: inline-block;
-        cursor: pointer;
-    }
-
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
         display: flex;
@@ -79,14 +79,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .label {
-        margin-bottom: 4px;
-    }
-
-    .root {
-        /*position: relative;*/
-    }
-
     .clear-button {
         margin: 1px;
         height: calc(100% - 2px);

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
@@ -1,5 +1,5 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { controlShapeStyles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { controlShapeStyles, neutralFillSubtleRest, roundShapeStyles } from "@adaptive-web/adaptive-ui/reference";
 import { SkeletonAnatomy } from "./skeleton.template.js";
 
 /**
@@ -10,8 +10,21 @@ import { SkeletonAnatomy } from "./skeleton.template.js";
 export const styleModules: StyleModules = [
     [
         {
-            hostCondition: SkeletonAnatomy.conditions.rectangle
         },
-        controlShapeStyles
+        Styles.fromProperties({
+            backgroundFill: neutralFillSubtleRest,
+        })
+    ],
+    [
+        {
+            hostCondition: SkeletonAnatomy.conditions.rectangle,
+        },
+        controlShapeStyles,
+    ],
+    [
+        {
+            hostCondition: SkeletonAnatomy.conditions.circle,
+        },
+        roundShapeStyles,
     ]
 ];

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.ts
@@ -1,4 +1,4 @@
-import { neutralFillSubtleHover, neutralFillSubtleRest } from "@adaptive-web/adaptive-ui/reference";
+import { neutralFillSubtleHover } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -11,10 +11,6 @@ export const templateStyles: ElementStyles = css`
         display: block;
         width: 100%;
         overflow: hidden;
-    }
-
-    :host([shape="circle"]) {
-        border-radius: 100%;
     }
 
     object {
@@ -52,10 +48,6 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        background-color: ${neutralFillSubtleRest};
-    }
-
     .shimmer {
         background-image: linear-gradient(
             90deg,

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
@@ -1,5 +1,7 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { typeRampMinus1Styles } from "@adaptive-web/adaptive-ui/reference";
+import { css } from "@microsoft/fast-element";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { designUnit, neutralStrokeSubtleRest, typeRampMinus1Styles } from "@adaptive-web/adaptive-ui/reference";
+import { SliderLabelAnatomy } from "./slider-label.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -10,6 +12,16 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampMinus1Styles
+        typeRampMinus1Styles,
     ],
+    [
+        {
+            part: SliderLabelAnatomy.parts.mark,
+        },
+        Styles.fromProperties({
+            backgroundFill: neutralStrokeSubtleRest,
+            height: css.partial`calc(${designUnit} *2)`, 
+            width: css.partial`calc(${designUnit} / 2)`,
+        }),
+    ]
 ];

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.ts
@@ -1,6 +1,4 @@
-import { designUnit, neutralStrokeSubtleRest } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -42,17 +40,15 @@ export const templateStyles: ElementStyles = css`
         align-self: center;
         white-space: nowrap;
         max-width: 30px;
-        margin: 2px 0;
+        margin-top: 4px;
     }
 
     :host([orientation="vertical"]) .content {
-        margin-left: calc((${designUnit} / 2) * 2);
+        margin-left: 4px;
     }
 
     .mark {
         justify-self: center;
-        height: calc(${heightNumber} * 0.25 * 1px);
-        width: calc(${designUnit} / 2);
     }
 
     :host([orientation="vertical"]) .mark {
@@ -66,7 +62,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .mark {
-        background: ${neutralStrokeSubtleRest};
-    }
 `;

--- a/packages/adaptive-web-components/src/components/slider/slider.stories.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.stories.ts
@@ -12,7 +12,6 @@ const storyTemplate = html<StoryArgs<FASTSlider>>`
         orientation="${(x) => x.orientation}"
         step="${(x) => x.step}"
         value="${(x) => x.value}"
-        style="min-height: 200px;"
     >
         ${(x) => x.storyContent}
     </adaptive-slider>
@@ -81,3 +80,13 @@ export const SliderVertical: Story<FASTSlider> = renderComponent(
 SliderVertical.args = {
     orientation: Orientation.vertical,
 };
+
+export const SliderVerticalWithLabels: Story<FASTSlider> = renderComponent(
+    html<StoryArgs<FASTSlider>>`
+        <div style="height: 300px;">
+            ${storyTemplate}
+        </div>
+    `
+).bind({});
+SliderVerticalWithLabels.args =
+    Object.assign({}, SliderWithLabels.args, { orientation: Orientation.vertical });

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
@@ -1,5 +1,10 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
-import { controlShapeStyles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import {
+    controlShapeStyles,
+    highlightFillReadableControlStyles,
+    neutralStrokeDiscernibleRest,
+    roundShapeStyles
+} from "@adaptive-web/adaptive-ui/reference";
 import { SliderAnatomy } from "./slider.template.js";
 
 /**
@@ -11,12 +16,37 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        controlShapeStyles
+        controlShapeStyles,
     ],
     [
         {
-            part: SliderAnatomy.parts.trackStart
+            part: SliderAnatomy.parts.track,
         },
-        controlShapeStyles
+        Styles.compose([
+            controlShapeStyles,
+        ],
+        {
+            backgroundFill: neutralStrokeDiscernibleRest,
+        })
+    ],
+    [
+        {
+            part: SliderAnatomy.parts.trackStart,
+        },
+        Styles.compose([
+            controlShapeStyles,
+            highlightFillReadableControlStyles,
+        ]),
+    ],
+    [
+        {
+            part: SliderAnatomy.parts.thumb,
+        },
+        Styles.compose(
+            [
+                roundShapeStyles,
+                highlightFillReadableControlStyles,
+            ],
+        )
     ],
 ];

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.ts
@@ -1,15 +1,5 @@
-import {
-    accentForegroundRest,
-    neutralForegroundRest,
-} from "@adaptive-web/adaptive-ui/migration";
-import {
-    designUnit,
-    neutralStrokeDiscernibleRest,
-    neutralStrokeSubtleActive,
-    neutralStrokeSubtleHover,
-} from "@adaptive-web/adaptive-ui/reference";
+import { designUnit } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -106,7 +96,6 @@ export const templateStyles: ElementStyles = css`
         height: 100%;
         width: var(--track-width);
     }
-
 `;
 
 /**
@@ -115,7 +104,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        --thumb-size: calc((${heightNumber} * 0.5) * 1px);
+        --thumb-size: 16px;
         --track-width: ${designUnit};
         --track-overhang: calc((${designUnit} / 2) * -1);
         margin: ${designUnit} 0;
@@ -127,29 +116,5 @@ export const aestheticStyles: ElementStyles = css`
 
     :host([orientation="vertical"]) .positioning-region {
         margin: 0 8px;
-    }
-
-    .thumb {
-        border: none;
-        border-radius: 50%;
-        background: ${neutralForegroundRest};
-    }
-
-    .thumb:hover {
-        border-color: ${neutralStrokeSubtleHover};
-        background: ${neutralForegroundRest};
-    }
-
-    .thumb:active {
-        border-color: ${neutralStrokeSubtleActive};
-        background: ${neutralForegroundRest};
-    }
-
-    .track-start {
-        background: ${accentForegroundRest};
-    }
-
-    .track {
-        background: ${neutralStrokeDiscernibleRest};
     }
 `;

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
@@ -1,6 +1,8 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
+    densityControl,
     labelTextStyles,
+    roundShapeStyles,
     selectableSelectedStyles,
     selectableUnselectedStyles
 } from "@adaptive-web/adaptive-ui/reference";
@@ -14,21 +16,40 @@ import { SwitchAnatomy } from "./switch.template.js";
 export const styleModules: StyleModules = [
     [
         {
+        },
+        Styles.fromProperties({
+            gap: densityControl.horizontalGap,
+        }),
+    ],
+    [
+        {
             part: SwitchAnatomy.parts.label,
         },
-        labelTextStyles
+        labelTextStyles,
     ],
     [
         {
             part: SwitchAnatomy.parts.switch,
         },
-        selectableUnselectedStyles
+        Styles.compose([
+            selectableUnselectedStyles,
+            roundShapeStyles,
+        ]),
     ],
     [
         {
             hostCondition: SwitchAnatomy.conditions.checked,
             part: SwitchAnatomy.parts.switch,
         },
-        selectableSelectedStyles
+        Styles.compose([
+            selectableSelectedStyles,
+            roundShapeStyles,
+        ]),
     ],
+    [
+        {
+            part: SwitchAnatomy.parts.thumb,
+        },
+        roundShapeStyles,
+    ]
 ];

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.ts
@@ -39,15 +39,10 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        gap: 8px;
-    }
-
     .switch {
         position: relative;
         width: calc(((${heightNumber} / 2)) * 2px + (${designUnit} * 2));
         height: calc(((${heightNumber} / 2)) * 1px + ${designUnit});
-        border-radius: calc(${heightNumber} * 1px) !important;
         padding: 4px;
     }
 
@@ -58,7 +53,6 @@ export const aestheticStyles: ElementStyles = css`
         top: ${designUnit};
         background: currentcolor;
         fill: currentcolor;
-        border-radius: 50%;
         transition: all 0.2s ease-in-out;
     }
 `;

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.ts
@@ -1,7 +1,7 @@
 import {
-    accentStrokeReadableRest,
     cornerRadiusControl,
     focusStrokeThickness,
+    highlightStrokeReadableRest,
 } from "@adaptive-web/adaptive-ui/reference";
 import { css, ElementStyles } from "@microsoft/fast-element";
 import { heightNumber } from "../../styles/index.js";
@@ -76,7 +76,7 @@ export const aestheticStyles: ElementStyles = css`
         display: block;
         position: absolute;
         border-radius: ${cornerRadiusControl};
-        background: ${accentStrokeReadableRest};
+        background: ${highlightStrokeReadableRest};
     }
 
     :host([orientation="horizontal"]) ::slotted([role="tab"][aria-selected="true"])::after {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
@@ -1,5 +1,6 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
+    densityControl,
     inputStyles,
     labelTextStyles,
     typeRampBaseStyles
@@ -15,7 +16,14 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampBaseStyles
+        Styles.compose(
+            [
+                typeRampBaseStyles,
+            ],
+            {
+                gap: densityControl.verticalGap,
+            }
+        ),
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.ts
@@ -1,5 +1,4 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import { heightNumber } from "../../styles/index.js";
 
 /**
  * Basic layout styling associated with the anatomy of the template.
@@ -11,7 +10,6 @@ export const templateStyles: ElementStyles = css`
         flex-direction: column;
         vertical-align: bottom;
         user-select: none;
-        /* position: relative; */
     }
 
     .label.label__hidden {
@@ -20,7 +18,7 @@ export const templateStyles: ElementStyles = css`
     }
 
     .label {
-        display: inline-block;
+        align-self: start;
         cursor: pointer;
     }
 
@@ -47,13 +45,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .label {
-        margin-bottom: 4px;
-    }
-
-    .control {
-        /* position: relative; */
-        height: calc(${heightNumber} * 2px);
-        width: 100%;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
@@ -1,6 +1,7 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
 import {
     autofillInnerDensityStyles,
+    densityControl,
     inputAutofillStyles,
     labelTextStyles,
     typeRampBaseStyles
@@ -16,7 +17,14 @@ export const styleModules: StyleModules = [
     [
         {
         },
-        typeRampBaseStyles
+        Styles.compose(
+            [
+                typeRampBaseStyles,
+            ],
+            {
+                gap: densityControl.verticalGap,
+            }
+        ),
     ],
     [
         {

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.ts
@@ -6,9 +6,18 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  */
 export const templateStyles: ElementStyles = css`
     :host {
-        display: inline-block;
-        user-select: none;
-        /* position: relative; */
+        display: inline-flex;
+        flex-direction: column;
+    }
+
+    .label {
+        align-self: start;
+        cursor: pointer;
+    }
+
+    .label.label__hidden {
+        display: none;
+        visibility: hidden;
     }
 
     .root {
@@ -17,25 +26,15 @@ export const templateStyles: ElementStyles = css`
     }
 
     .control {
-        -webkit-appearance: none;
         width: 100%;
-        margin: 0;
-        padding: unset;
-        border: none;
+        /* reset */
         background: transparent;
+        border: none;
         color: inherit;
         font: inherit;
+        padding: unset;
     }
 
-    .label.label__hidden {
-        display: none;
-        visibility: hidden;
-    }
-
-    .label {
-        display: inline-block;
-        cursor: pointer;
-    }
 
     ::slotted([slot="start"]),
     ::slotted([slot="end"]) {
@@ -48,15 +47,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    .label {
-        margin-bottom: 4px;
-    }
-
-    .root {
-        /*position: relative;*/
-    }
-
-    .control {
-        height: 100%;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
@@ -1,6 +1,6 @@
-import {
-    StyleModules,
-} from "@adaptive-web/adaptive-ui";
+import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { densityControl, neutralStrokeStrong } from "@adaptive-web/adaptive-ui/reference";
+import { ToolbarAnatomy } from "./toolbar.template.js";
 
 /**
  * Visual styles composed by modules.
@@ -8,4 +8,20 @@ import {
  * @public
  */
 export const styleModules: StyleModules = [
+    [
+        {
+        },
+        Styles.fromProperties({
+            foregroundFill: neutralStrokeStrong,
+            gap: densityControl.horizontalGap,
+        }),
+    ],
+    [
+        {
+            part: ToolbarAnatomy.parts.positioningRegion,
+        },
+        Styles.fromProperties({
+            gap: densityControl.horizontalGap,
+        }),
+    ],
 ];

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.ts
@@ -1,4 +1,3 @@
-import { neutralForegroundRest } from "@adaptive-web/adaptive-ui/migration";
 import { css, ElementStyles } from "@microsoft/fast-element";
 
 /**
@@ -16,7 +15,7 @@ export const templateStyles: ElementStyles = css`
     }
 
     .positioning-region {
-        display: inline-flex;
+        display: flex;
         flex-grow: 1;
         flex-wrap: wrap;
         align-items: center;
@@ -39,13 +38,4 @@ export const templateStyles: ElementStyles = css`
  * @public
  */
 export const aestheticStyles: ElementStyles = css`
-    :host {
-        gap: 8px;
-        color: ${neutralForegroundRest};
-        fill: currentcolor;
-    }
-
-    .positioning-region {
-        gap: 8px;
-    }
 `;

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -4,6 +4,7 @@ import {
     Styles
 } from "@adaptive-web/adaptive-ui";
 import {
+    controlDensityStyles,
     controlShapeStyles,
     neutralStrokeSubtleRest,
     plainTextStyles
@@ -21,6 +22,7 @@ export const styleModules: StyleModules = [
         Styles.compose(
             [
                 controlShapeStyles,
+                controlDensityStyles,
                 plainTextStyles,
             ],
             {

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.ts
@@ -10,15 +10,14 @@ import { css, ElementStyles } from "@microsoft/fast-element";
  */
 export const templateStyles: ElementStyles = css`
     :host {
+        height: fit-content;
+        width: fit-content;
+        white-space: nowrap;
         visibility: hidden;
     }
 
     :host([visible]) {
         visibility: visible;
-    }
-    
-    :host(:not([visible])) {
-        visibility: hidden;
     }
 `;
 
@@ -28,12 +27,7 @@ export const templateStyles: ElementStyles = css`
  */
 export const aestheticStyles: ElementStyles = css`
     :host {
-        position: fixed;
-        height: fit-content;
-        width: fit-content;
-        padding: 4px 12px;
         background: ${neutralFillSubtleRest};
-        white-space: nowrap;
         box-shadow: ${elevationTooltip};
     }
 

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -1,8 +1,8 @@
 import { Swatch } from"@adaptive-web/adaptive-ui";
-import { accentForegroundRest } from "@adaptive-web/adaptive-ui/migration";
 import {
     cornerRadiusControl,
     focusStrokeThickness,
+    highlightStrokeReadableRest,
     neutralFillStealthRecipe,
     neutralFillSubtleRecipe,
     neutralFillSubtleRest,
@@ -127,7 +127,7 @@ export const aestheticStyles: ElementStyles = css`
         left: ${focusStrokeThickness};
         width: 3px;
         height: calc((${heightNumber} / 2) * 1px);
-        border-radius: calc(${cornerRadiusControl} * 1px);
-        background: ${accentForegroundRest};
+        border-radius: ${cornerRadiusControl};
+        background: ${highlightStrokeReadableRest};
     }
 `;


### PR DESCRIPTION
# Pull Request

## Description

A style pass through the components, mostly focused on migrating manual styles to declarative.

Fixed consistency issues as well. Using highlight color for selection or values instead of accent color.

## Reviewer Notes

Per above, many of the changes migrate styles from the `styles` file to the associated `style.modules` file. Compare between.
Also removes css that wasn't necessary.

## Test Plan

Tested in Storybook. Comparison:

![style-cleanup](https://github.com/Adaptive-Web-Community/Adaptive-Web-Components/assets/47367562/b65576f1-a39a-4ee4-a22b-b8be96ea22f9)

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

This isn't perfect, but it's a lot better. Keep migrating the aesthetic styles. Also fix a border issue on selectable controls like checkbox.