### PR TITLE
feat: update data-grid to use CSS subgrid.

### DIFF
--- a/change/@adaptive-web-adaptive-web-components-cc7e748e-c4f1-4ef1-88bf-b0c93ae66117.json
+++ b/change/@adaptive-web-adaptive-web-components-cc7e748e-c4f1-4ef1-88bf-b0c93ae66117.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update data grid styles to use subgrid.",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-web-components/src/components/anchor/anchor.options.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.options.ts
@@ -1,0 +1,5 @@
+import { ComposeOptions } from "../../design-system.js";
+
+export default {
+    baseName: "anchor"
+} as ComposeOptions;

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.compose.ts
@@ -4,6 +4,7 @@ import { ComposeOptions, DesignSystem } from "../../design-system.js";
 import { componentBaseStyles } from "../../styles/styles.js";
 import { aestheticStyles, templateStyles } from "./data-grid-row.styles.js";
 import { DataGridRowAnatomy, template } from "./data-grid-row.template.js";
+import { DataGridRow } from './data-grid-row.js';
 
 const defaultStyles = [componentBaseStyles, templateStyles, aestheticStyles];
 
@@ -16,7 +17,7 @@ export function composeDataGridRow(
 ): FASTElementDefinition {
     const styles = DesignSystem.assembleStyles(defaultStyles, DataGridRowAnatomy, options);
 
-    return FASTDataGridRow.compose({
+    return DataGridRow.compose({
         name: `${ds.prefix}-data-grid-row`,
         template: options?.template?.(ds) ?? template(ds),
         styles,

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.ts
@@ -6,14 +6,18 @@ import {
     neutralFillSubtleRest,
 } from "@adaptive-web/adaptive-ui/reference";
 import { heightNumber } from "../../styles/index.js";
+import { DataGridRow } from './data-grid-row.js';
 
 /**
  * Basic layout styling associated with the anatomy of the template.
  * @public
  */
-export const templateStyles: ElementStyles = css`
+export const templateStyles: ElementStyles = css<DataGridRow>/* CSS */`
     :host {
         display: grid;
+        grid-template-columns: subgrid;
+        grid-column: span ${x => x.columnDefinitions?.length ?? 1 };
+        grid-auto-flow: row;
         width: 100%;
     }
 

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.ts
@@ -1,0 +1,7 @@
+import { FASTDataGridRow } from '@microsoft/fast-foundation';
+
+export class DataGridRow extends FASTDataGridRow {
+    protected updateRowStyle(): void {
+        return;
+    }
+}

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.ts
@@ -1,14 +1,16 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
+import { FASTDataGrid } from '@microsoft/fast-foundation';
 
 /**
  * Basic layout styling associated with the anatomy of the template.
  * @public
  */
-export const templateStyles: ElementStyles = css`
+export const templateStyles: ElementStyles = css<FASTDataGrid>/* CSS */`
     :host {
-        display: flex;
+        display: grid;
         position: relative;
-        flex-direction: column;
+        grid-auto-flow: row;
+        grid-template-columns: ${x => x.gridTemplateColumns};
     }
 
     :host([selection-mode="multi-row"]) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## Description
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This PR updates data grid to use CSS subgrid rather than flexbox on the grid and grid on the rows. This makes it easier to have column widths be consistent across the header row, if present, and regular rows in the grid because now they are all aligned to the same grid rather than each row being a separate grid.

I ran into this issue of differing column widths while creating a grid that can have variable width content in the header cells (sortable columns where the sort arrow icons are hidden until the column is being sorted on) **AND** when trying to set the `grid-template-columns` on the parent data-grid to `fit-content`. This resulted in the header cells being wider than the cells in the regular rows and is only made worse when the cells have left/right borders on them as the borders between cells in the header and the next row don't align vertically. With this change the rows now inherit their `grid-template-columns` from their parent grid and made to span all the columns of the parent grid so any changes to column widths on the grid are matched on all of the rows consistently.

CSS subgrid has support in all three major browser engines going back at least two versions so I am confident with making this change now.

### Issues
<!---
* List and link relevant issues here.
-->
https://github.com/microsoft/fast/pull/6886

## Reviewer Notes
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Draft for now until https://github.com/microsoft/fast/pull/6886 gets released in Foundation.

## Test Plan
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->