### PR TITLE
Adaptive UI: Cleaned up type definition for Style Rules (formerly Style Modules)

### DIFF
--- a/change/@adaptive-web-adaptive-ui-02928a5b-1a67-41dc-bae7-720ad5e0156e.json
+++ b/change/@adaptive-web-adaptive-ui-02928a5b-1a67-41dc-bae7-720ad5e0156e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI : Cleaned up type definition for Style Rules (formerly Style Modules)",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-2f8d5909-eef1-4f94-82f8-d87f8d652ba2.json
+++ b/change/@adaptive-web-adaptive-web-components-2f8d5909-eef1-4f94-82f8-d87f8d652ba2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adaptive UI : Cleaned up type definition for Style Rules (formerly Style Modules)",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -55,33 +55,33 @@ const myCheckboxDefinition = composeCheckbox(
         },
         // Custom modular styles.
         styleModules: [
-            [
-                {
+            {
+                target: {
                     part: CheckboxAnatomy.parts.control,
                 },
-                accentOutlineReadableControlStyles
-            ],
-            [
-                {
+                styles: accentOutlineReadableControlStyles,
+            },
+            {
+                target: {
                     hostCondition: CheckboxAnatomy.conditions.checked,
                     part: CheckboxAnatomy.parts.control,
                 },
-                accentFillReadableControlStyles
-            ],
-            [
-                {
+                styles: accentFillReadableControlStyles,
+            },
+            {
+                target: {
                     part: CheckboxAnatomy.parts.label,
                 },
-                Styles.fromProperties({
+                properties: {
                     fontFamily: "Times",
                     fontSize: "20px",
-                })
-            ],
+                },
+            },
         ],
     }
 );
 
-AdaptiveDesignSystem.defineComponents({
+myDS.defineComponents({
     myCheckboxDefinition,
 });
 

--- a/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-figma-designer/src/ui/ui-controller.ts
@@ -247,7 +247,7 @@ export class UIController {
                         return;
                     }
                 }
-                styles.effectiveProperties.forEach((value, target) => {
+                styles.effectiveAdaptiveProperties.forEach((value, target) => {
                     if (remove) {
                         allApplied.set(target, {
                             value: STYLE_REMOVE,

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Color as Color_2 } from 'culori/fn';
+import { ComposableStyles } from '@microsoft/fast-element';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
@@ -276,6 +277,7 @@ export function directionByIsDark(color: RelativeLuminance): PaletteDirectionVal
 export class ElementStylesRenderer {
     constructor(styles: Styles);
     render(target: StyleModuleTarget, interactivity?: InteractivityDefinition): ElementStyles;
+    static renderStyleRules(baseStyles: ComposableStyles[] | undefined, styleRules: StyleRules, anatomy?: ComponentAnatomy<any, any>): ElementStyles;
 }
 
 // @public
@@ -446,10 +448,13 @@ export function resolvePaletteDirection(direction: PaletteDirection): PaletteDir
 export type StateSelector = "hover" | "active" | FocusSelector | "disabled";
 
 // @public
-export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
+export type StyleDeclaration = {
+    styles?: Styles | Iterable<Styles>;
+    properties?: StyleProperties;
+};
 
-// @public (undocumented)
-export type StyleModules = Iterable<readonly [StyleModuleTarget, Styles]>;
+// @public
+export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
 
 // @public
 export interface StyleModuleTarget {
@@ -463,10 +468,10 @@ export interface StyleModuleTarget {
 }
 
 // @public
-export type StyleProperties = Partial<Record<StyleProperty, StyleValue>>;
+export type StyleProperties = Partial<Record<StylePropertyCss, StyleValue>>;
 
 // @public
-export type StylePropertiesMap = Map<StyleProperty, StyleValue>;
+export type StylePropertiesMap = Map<StylePropertyCss, StyleValue>;
 
 // @public
 export const StyleProperty: {
@@ -515,20 +520,31 @@ export const StyleProperty: {
 // @public
 export type StyleProperty = ValuesOf<typeof StyleProperty>;
 
-// @public (undocumented)
+// @public
 export const stylePropertyBorderFillAll: ("borderFillTop" | "borderFillRight" | "borderFillBottom" | "borderFillLeft")[];
 
-// @public (undocumented)
+// @public
 export const stylePropertyBorderStyleAll: ("borderStyleTop" | "borderStyleRight" | "borderStyleBottom" | "borderStyleLeft")[];
 
-// @public (undocumented)
+// @public
 export const stylePropertyBorderThicknessAll: ("borderThicknessTop" | "borderThicknessRight" | "borderThicknessBottom" | "borderThicknessLeft")[];
 
-// @public (undocumented)
+// @public
 export const stylePropertyCornerRadiusAll: ("cornerRadiusTopLeft" | "cornerRadiusTopRight" | "cornerRadiusBottomRight" | "cornerRadiusBottomLeft")[];
 
-// @public (undocumented)
+// @public
+export type StylePropertyCss = StyleProperty | (string & Record<never, never>);
+
+// @public
 export const stylePropertyPaddingAll: ("paddingBottom" | "paddingLeft" | "paddingRight" | "paddingTop")[];
+
+// @public
+export type StyleRule = {
+    target?: StyleModuleTarget;
+} & StyleDeclaration;
+
+// @public
+export type StyleRules = Iterable<StyleRule>;
 
 // @public
 export class Styles {
@@ -537,7 +553,9 @@ export class Styles {
     clearComposed(): void;
     static compose(styles: Styles[], properties?: StyleProperties, name?: string): Styles;
     get composed(): Styles[] | undefined;
+    get effectiveAdaptiveProperties(): Map<StyleProperty, StyleValue>;
     get effectiveProperties(): StylePropertiesMap;
+    static fromDeclaration(declaration: StyleDeclaration, name?: string): Styles;
     static fromProperties(properties: StyleProperties, name?: string): Styles;
     readonly name: string | undefined;
     get properties(): StylePropertiesMap | undefined;
@@ -547,7 +565,7 @@ export class Styles {
 }
 
 // @public
-export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string;
+export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string | number;
 
 // @public
 export class Swatch extends Color {

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -11,7 +11,7 @@ import { Styles } from "./styles.js";
 /**
  * The properties and values of a css declaration.
  */
-type DeclarationMap = Map<string, string | CSSDirective>;
+type DeclarationMap = Map<string, string | number | CSSDirective>;
 
 /**
  * The selector and set of declarations for a css rule.
@@ -51,7 +51,7 @@ export class ElementStylesRenderer {
 
     private static declaration(
         property: StylePropertyCss,
-        value: string | CSSDirective,
+        value: string | number | CSSDirective,
         state?: StateSelector,
     ): DeclarationMap {
         const cssProperty = property in StyleProperty ?
@@ -70,7 +70,7 @@ export class ElementStylesRenderer {
 
     private static propertySingle(
         property: StylePropertyCss,
-        value: string | CSSDirective,
+        value: string | number | CSSDirective,
     ): StyleModuleEvaluate {
         return (params: StyleModuleEvaluateParameters): RuleMap => {
             return new Map([
@@ -110,7 +110,7 @@ export class ElementStylesRenderer {
 
     private createStyleModules(styles: Styles): StyleModuleEvaluate[] {
         const modules: StyleModuleEvaluate[] = new Array(...styles.effectiveProperties.entries()).map(([property, value]) => {
-            if (typeof value === "string" || value instanceof CSSDesignToken) {
+            if (typeof value === "string" || typeof value === "number" || value instanceof CSSDesignToken) {
                 return ElementStylesRenderer.propertySingle(property, value);
             } else if (value && typeof (value as any).createCSS === "function") {
                 return ElementStylesRenderer.propertySingle(property, value as CSSDirective);
@@ -123,7 +123,8 @@ export class ElementStylesRenderer {
 
     private appendRule(selector: string, declarations: DeclarationMap) {
         const cssProperties = new Array(...declarations.entries()).map(([property, value]) => {
-            return css.partial`${property}: ${value};`;
+            const valueToUse = typeof value === "number" ? value.toString() : value;
+            return css.partial`${property}: ${valueToUse};`;
         });
         if (this._rules.has(selector)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -1,5 +1,5 @@
 import type { ValuesOf } from "@microsoft/fast-foundation";
-import { Styles } from "./styles.js";
+import { StyleRule } from "./styles.js";
 
 /**
  * Selectors for focus state.
@@ -261,7 +261,10 @@ export const Focus = {
 export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDefinition;
 
 /**
- * The style property, like background color or border thickness.
+ * Supported style properties for design-to-code with Adaptive UI.
+ *
+ * Generalizes CSS properties which are also commonly supported in design tools (Figma) so the recipes can
+ * be applied in tooling or in the browser.
  *
  * @public
  */
@@ -309,38 +312,85 @@ export const StyleProperty = {
 } as const;
 
 /**
- * @public
- */
-export const stylePropertyBorderFillAll = [StyleProperty.borderFillTop, StyleProperty.borderFillRight, StyleProperty.borderFillBottom, StyleProperty.borderFillLeft];
-
-/**
- * @public
- */
-export const stylePropertyBorderThicknessAll = [StyleProperty.borderThicknessTop, StyleProperty.borderThicknessRight, StyleProperty.borderThicknessBottom, StyleProperty.borderThicknessLeft];
-
-/**
- * @public
- */
-export const stylePropertyBorderStyleAll = [StyleProperty.borderStyleTop, StyleProperty.borderStyleRight, StyleProperty.borderStyleBottom, StyleProperty.borderStyleLeft];
-
-/**
- * @public
- */
-export const stylePropertyCornerRadiusAll = [StyleProperty.cornerRadiusTopLeft, StyleProperty.cornerRadiusTopRight, StyleProperty.cornerRadiusBottomRight, StyleProperty.cornerRadiusBottomLeft];
-
-/**
- * @public
- */
-export const stylePropertyPaddingAll = [StyleProperty.paddingTop, StyleProperty.paddingRight, StyleProperty.paddingBottom, StyleProperty.paddingLeft];
-
-/**
- * The style property, like background color or border thickness.
+ * Supported style properties for design-to-code with Adaptive UI.
+ *
+ * Generalizes CSS properties which are also commonly supported in design tools (Figma) so the recipes can
+ * be applied in tooling or in the browser.
  *
  * @public
  */
 export type StyleProperty = ValuesOf<typeof StyleProperty>;
 
 /**
+ * Any style property, either an {@link (StyleProperty:type)} or a string for any other CSS property.
+ *
  * @public
  */
-export type StyleModules = Iterable<readonly [StyleModuleTarget, Styles]>;
+export type StylePropertyCss = StyleProperty | (string & Record<never, never>);
+
+/**
+ * A convenience shorthand for all border fill {@link (StyleProperty:type)} values.
+ *
+ * @public
+ */
+export const stylePropertyBorderFillAll = [
+    StyleProperty.borderFillTop,
+    StyleProperty.borderFillRight,
+    StyleProperty.borderFillBottom,
+    StyleProperty.borderFillLeft
+];
+
+/**
+ * A convenience shorthand for all border thickness {@link (StyleProperty:type)} values.
+ *
+ * @public
+ */
+export const stylePropertyBorderThicknessAll = [
+    StyleProperty.borderThicknessTop,
+    StyleProperty.borderThicknessRight,
+    StyleProperty.borderThicknessBottom,
+    StyleProperty.borderThicknessLeft
+];
+
+/**
+ * A convenience shorthand for all border style {@link (StyleProperty:type)} values.
+ *
+ * @public
+ */
+export const stylePropertyBorderStyleAll = [
+    StyleProperty.borderStyleTop,
+    StyleProperty.borderStyleRight,
+    StyleProperty.borderStyleBottom,
+    StyleProperty.borderStyleLeft
+];
+
+/**
+ * A convenience shorthand for all corner radius {@link (StyleProperty:type)} values.
+ *
+ * @public
+ */
+export const stylePropertyCornerRadiusAll = [
+    StyleProperty.cornerRadiusTopLeft,
+    StyleProperty.cornerRadiusTopRight,
+    StyleProperty.cornerRadiusBottomRight,
+    StyleProperty.cornerRadiusBottomLeft
+];
+
+/**
+ * A convenience shorthand for all padding {@link (StyleProperty:type)} values.
+ *
+ * @public
+ */
+export const stylePropertyPaddingAll = [
+    StyleProperty.paddingTop,
+    StyleProperty.paddingRight,
+    StyleProperty.paddingBottom,
+    StyleProperty.paddingLeft
+];
+
+/**
+ * A list of {@link StyleRule}s in the context of a component.
+ *
+ * @public
+ */
+export type StyleRules = Iterable<StyleRule>;

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -63,9 +63,8 @@ import { FASTTreeView } from '@microsoft/fast-foundation';
 import { HorizontalScrollView } from '@microsoft/fast-foundation';
 import { ShadowRootOptions } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '@microsoft/fast-foundation';
-import { StyleModules } from '@adaptive-web/adaptive-ui';
-import { StyleModuleTarget } from '@adaptive-web/adaptive-ui';
-import { Styles } from '@adaptive-web/adaptive-ui';
+import { StyleRule } from '@adaptive-web/adaptive-ui';
+import { StyleRules } from '@adaptive-web/adaptive-ui';
 import type { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public
@@ -107,7 +106,7 @@ export const AccordionItemStatics: {
 export type AccordionItemStatics = ValuesOf<typeof AccordionItemStatics>;
 
 // @public
-export const accordionItemStyleModules: StyleModules;
+export const accordionItemStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -121,7 +120,7 @@ export const accordionItemTemplateStyles: ElementStyles;
 export const AccordionParts: {};
 
 // @public
-export const accordionStyleModules: StyleModules;
+export const accordionStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -195,7 +194,7 @@ export const AnchoredRegionConditions: {
 export const AnchoredRegionParts: {};
 
 // @public
-export const anchoredRegionStyleModules: StyleModules;
+export const anchoredRegionStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -212,7 +211,7 @@ export const AnchorParts: {
 };
 
 // @public
-export const anchorStyleModules: StyleModules;
+export const anchorStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -237,7 +236,7 @@ export const AvatarParts: {
 };
 
 // @public
-export const avatarStyleModules: StyleModules;
+export const avatarStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -262,7 +261,7 @@ export const BadgeParts: {
 };
 
 // @public
-export const badgeStyleModules: StyleModules;
+export const badgeStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -315,7 +314,7 @@ export const BreadcrumbItemStatics: {
 export type BreadcrumbItemStatics = ValuesOf<typeof BreadcrumbItemStatics>;
 
 // @public
-export const breadcrumbItemStyleModules: StyleModules;
+export const breadcrumbItemStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -331,7 +330,7 @@ export const BreadcrumbParts: {
 };
 
 // @public
-export const breadcrumbStyleModules: StyleModules;
+export const breadcrumbStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -359,7 +358,7 @@ export const ButtonParts: {
 };
 
 // @public
-export const buttonStyleModules: StyleModules;
+export const buttonStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -393,7 +392,7 @@ export const CalendarParts: {
 };
 
 // @public
-export const calendarStyleModules: StyleModules;
+export const calendarStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -416,7 +415,7 @@ export const CardConditions: {};
 export const CardParts: {};
 
 // @public
-export const cardStyleModules: StyleModules;
+export const cardStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -454,7 +453,7 @@ export const CheckboxStatics: {
 export type CheckboxStatics = ValuesOf<typeof CheckboxStatics>;
 
 // @public
-export const checkboxStyleModules: StyleModules;
+export const checkboxStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -490,7 +489,7 @@ export const ComboboxStatics: {
 export type ComboboxStatics = ValuesOf<typeof ComboboxStatics>;
 
 // @public
-export const comboboxStyleModules: StyleModules;
+export const comboboxStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -788,7 +787,7 @@ export const DataGridCellConditions: {
 export const DataGridCellParts: {};
 
 // @public
-export const dataGridCellStyleModules: StyleModules;
+export const dataGridCellStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -822,7 +821,7 @@ export const DataGridRowConditions: {
 export const DataGridRowParts: {};
 
 // @public
-export const dataGridRowStyleModules: StyleModules;
+export const dataGridRowStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -833,7 +832,7 @@ export const dataGridRowTemplate: (ds: DesignSystem) => ElementViewTemplate<FAST
 export const dataGridRowTemplateStyles: ElementStyles;
 
 // @public
-export const dataGridStyleModules: StyleModules;
+export const dataGridStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -882,7 +881,7 @@ export const DialogParts: {
 };
 
 // @public
-export const dialogStyleModules: StyleModules;
+export const dialogStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -909,7 +908,7 @@ export const DisclosureParts: {
 };
 
 // @public
-export const disclosureStyleModules: StyleModules;
+export const disclosureStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -935,7 +934,7 @@ export const DividerConditions: {
 export const DividerParts: {};
 
 // @public
-export const dividerStyleModules: StyleModules;
+export const dividerStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -973,7 +972,7 @@ export const FlipperStatics: {
 export type FlipperStatics = ValuesOf<typeof FlipperStatics>;
 
 // @public
-export const flipperStyleModules: StyleModules;
+export const flipperStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -984,7 +983,7 @@ export const flipperTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTFlip
 export const flipperTemplateStyles: ElementStyles;
 
 // @public
-export const globalStyleModules: (anatomy?: ComponentAnatomy<any, any>) => StyleModules;
+export const globalStyleRules: (anatomy?: ComponentAnatomy<any, any>) => StyleRules;
 
 // Warning: (ae-internal-missing-underscore) The name "heightNumber" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1012,7 +1011,7 @@ export const HorizontalScrollParts: {
 };
 
 // @public
-export const horizontalScrollStyleModules: StyleModules;
+export const horizontalScrollStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1049,7 +1048,7 @@ export const ListboxOptionParts: {
 };
 
 // @public
-export const listboxOptionStyleModules: StyleModules;
+export const listboxOptionStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1063,7 +1062,7 @@ export const listboxOptionTemplateStyles: ElementStyles;
 export const ListboxParts: {};
 
 // @public
-export const listboxStyleModules: StyleModules;
+export const listboxStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1112,7 +1111,7 @@ export const MenuItemStatics: {
 export type MenuItemStatics = ValuesOf<typeof MenuItemStatics>;
 
 // @public
-export const menuItemStyleModules: StyleModules;
+export const menuItemStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1126,7 +1125,7 @@ export const menuItemTemplateStyles: ElementStyles;
 export const MenuParts: {};
 
 // @public
-export const menuStyleModules: StyleModules;
+export const menuStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1165,7 +1164,7 @@ export const NumberFieldStatics: {
 export type NumberFieldStatics = ValuesOf<typeof NumberFieldStatics>;
 
 // @public
-export const numberFieldStyleModules: StyleModules;
+export const numberFieldStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1206,7 +1205,7 @@ export const PickerListItemConditions: {};
 export const PickerListItemParts: {};
 
 // @public
-export const pickerListItemStyleModules: StyleModules;
+export const pickerListItemStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1220,7 +1219,7 @@ export const pickerListItemTemplateStyles: ElementStyles;
 export const PickerListParts: {};
 
 // @public
-export const pickerListStyleModules: StyleModules;
+export const pickerListStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1254,7 +1253,7 @@ export const PickerMenuOptionConditions: {
 export const PickerMenuOptionParts: {};
 
 // @public
-export const pickerMenuOptionStyleModules: StyleModules;
+export const pickerMenuOptionStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1273,7 +1272,7 @@ export const PickerMenuParts: {
 };
 
 // @public
-export const pickerMenuStyleModules: StyleModules;
+export const pickerMenuStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1292,7 +1291,7 @@ export const PickerParts: {
 };
 
 // @public
-export const pickerStyleModules: StyleModules;
+export const pickerStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1335,7 +1334,7 @@ export const ProgressRingParts: {
 };
 
 // @public
-export const progressRingStyleModules: StyleModules;
+export const progressRingStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1346,7 +1345,7 @@ export const progressRingTemplate: (ds: DesignSystem) => ElementViewTemplate<FAS
 export const progressRingTemplateStyles: ElementStyles;
 
 // @public
-export const progressStyleModules: StyleModules;
+export const progressStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1385,7 +1384,7 @@ export const RadioGroupParts: {
 };
 
 // @public
-export const radioGroupStyleModules: StyleModules;
+export const radioGroupStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1410,7 +1409,7 @@ export const RadioStatics: {
 export type RadioStatics = ValuesOf<typeof RadioStatics>;
 
 // @public
-export const radioStyleModules: StyleModules;
+export const radioStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1438,7 +1437,7 @@ export const SearchParts: {
 };
 
 // @public
-export const searchStyleModules: StyleModules;
+export const searchStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1477,7 +1476,7 @@ export const SelectStatics: {
 export type SelectStatics = ValuesOf<typeof SelectStatics>;
 
 // @public
-export const selectStyleModules: StyleModules;
+export const selectStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1503,7 +1502,7 @@ export const SkeletonConditions: {
 export const SkeletonParts: {};
 
 // @public
-export const skeletonStyleModules: StyleModules;
+export const skeletonStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1545,7 +1544,7 @@ export const SliderLabelParts: {
 };
 
 // @public
-export const sliderLabelStyleModules: StyleModules;
+export const sliderLabelStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1565,7 +1564,7 @@ export const SliderParts: {
 };
 
 // @public
-export const sliderStyleModules: StyleModules;
+export const sliderStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1597,7 +1596,7 @@ export const SwitchParts: {
 };
 
 // @public
-export const switchStyleModules: StyleModules;
+export const switchStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1629,7 +1628,7 @@ export const TabPanelConditions: {};
 export const TabPanelParts: {};
 
 // @public
-export const tabPanelStyleModules: StyleModules;
+export const tabPanelStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1661,7 +1660,7 @@ export const TabsParts: {
 };
 
 // @public
-export const tabsStyleModules: StyleModules;
+export const tabsStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1672,7 +1671,7 @@ export const tabsTemplate: (ds: DesignSystem) => ElementViewTemplate<FASTTabs>;
 export const tabsTemplateStyles: ElementStyles;
 
 // @public
-export const tabStyleModules: StyleModules;
+export const tabStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1698,7 +1697,7 @@ export const TextAreaParts: {
 };
 
 // @public
-export const textAreaStyleModules: StyleModules;
+export const textAreaStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1725,7 +1724,7 @@ export const TextFieldParts: {
 };
 
 // @public
-export const textFieldStyleModules: StyleModules;
+export const textFieldStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1753,7 +1752,7 @@ export const ToolbarParts: {
 };
 
 // @public
-export const toolbarStyleModules: StyleModules;
+export const toolbarStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1779,7 +1778,7 @@ export const TooltipConditions: {
 export const TooltipParts: {};
 
 // @public
-export const tooltipStyleModules: StyleModules;
+export const tooltipStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1817,7 +1816,7 @@ export const TreeItemStatics: {
 export type TreeItemStatics = ValuesOf<typeof TreeItemStatics>;
 
 // @public
-export const treeItemStyleModules: StyleModules;
+export const treeItemStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //
@@ -1840,7 +1839,7 @@ export const TreeViewConditions: {};
 export const TreeViewParts: {};
 
 // @public
-export const treeViewStyleModules: StyleModules;
+export const treeViewStyleModules: StyleRules;
 
 // Warning: (ae-incompatible-release-tags) The symbol "template" is marked as @public, but its signature references "DesignSystem" which is marked as @beta
 //

--- a/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion-item/accordion-item.styles.modules.ts
@@ -1,65 +1,56 @@
 import {
-    StyleModules,
-    Styles,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     accentForegroundReadableControlStyles,
     controlDensityStyles,
     controlShapeStyles,
     neutralForegroundStrongElementStyles,
-    neutralStrokeSubtleRest,
+    neutralStrokeSubtle,
     plainTextStyles,
     strokeThickness
 } from "@adaptive-web/adaptive-ui/reference";
 import { AccordionItemAnatomy } from "./accordion-item.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: plainTextStyles,
+        properties: {
+            borderFillBottom: neutralStrokeSubtle.rest,
+            borderStyleBottom: "solid",
+            borderThicknessBottom: strokeThickness,
         },
-        Styles.compose(
-            [
-                plainTextStyles
-            ],
-            {
-                borderFillBottom: neutralStrokeSubtleRest,
-                borderStyleBottom: "solid",
-                borderThicknessBottom: strokeThickness,
-            }
-        ),
-    ],
-    [
-        {
+    },
+    {
+        target : {
             part: AccordionItemAnatomy.parts.heading,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                controlDensityStyles,
-            ],
-        )
-    ],
-    [
-        {
+        styles: [
+            controlShapeStyles,
+            controlDensityStyles,
+        ],
+    },
+    {
+        target : {
             part: AccordionItemAnatomy.parts.button,
         },
-        neutralForegroundStrongElementStyles
-    ],
-    [
-        {
+        styles: neutralForegroundStrongElementStyles,
+    },
+    {
+        target : {
             part: AccordionItemAnatomy.parts.icon,
         },
-        accentForegroundReadableControlStyles
-    ],
-    [
-        {
+        styles: accentForegroundReadableControlStyles,
+    },
+    {
+        target : {
             part: AccordionItemAnatomy.parts.region,
         },
-        controlDensityStyles
-    ],
+        styles: controlDensityStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/accordion/accordion.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/accordion/accordion.styles.modules.ts
@@ -1,31 +1,24 @@
 import {
-    StyleModules,
-    Styles,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
-    neutralStrokeSubtleRest,
+    neutralStrokeSubtle,
     plainTextStyles,
     strokeThickness
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                plainTextStyles
-            ],
-            {
-                borderFillTop: neutralStrokeSubtleRest,
-                borderStyleTop: "solid",
-                borderThicknessTop: strokeThickness,
-            }
-        ),
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: plainTextStyles,
+        properties : {
+            borderFillTop: neutralStrokeSubtle.rest,
+            borderStyleTop: "solid",
+            borderThicknessTop: strokeThickness,
+        }
+    },
 ];

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     accentForegroundReadableControlStyles,
     controlShapeStyles,
@@ -9,29 +9,29 @@ import {
 import { AnchorAnatomy } from "./anchor.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        target : {
             part: AnchorAnatomy.parts.control,
         },
-        Styles.compose([
+        styles: [
             controlShapeStyles,
             typeRampBaseStyles,
             accentForegroundReadableControlStyles,
         ],
-        {
+        properties: {
             gap: densityControl.horizontalGap,
-        }),
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             hostCondition: AnchorAnatomy.conditions.noHref,
             part: AnchorAnatomy.parts.control,
         },
-        neutralForegroundStrongElementStyles,
-    ],
+        styles: neutralForegroundStrongElementStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/anchored-region/anchored-region.styles.modules.ts
@@ -1,11 +1,11 @@
 import {
-    StyleModules,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
+export const styleModules: StyleRules = [
 ];

--- a/packages/adaptive-web-components/src/components/avatar/avatar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/avatar/avatar.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     accentFillReadableControlStyles,
     typeRampBaseStyles,
@@ -6,20 +6,18 @@ import {
 import { AvatarAnatomy } from "./avatar.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        typeRampBaseStyles
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+    },
+    {
+        target : {
             part: AvatarAnatomy.parts.backplate,
         },
-        accentFillReadableControlStyles
-    ],
+        styles: accentFillReadableControlStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/badge/badge.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
@@ -10,25 +9,21 @@ import {
 import { BadgeAnatomy } from "./badge.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        typeRampMinus1Styles
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampMinus1Styles,
+    },
+    {
+        target : {
             part: BadgeAnatomy.parts.control,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                neutralFillReadableControlStyles,
-            ],
-        )
-    ],
+        styles: [
+            controlShapeStyles,
+            neutralFillReadableControlStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     accentForegroundReadableControlStyles,
@@ -12,47 +11,43 @@ import {
 import { BreadcrumbItemAnatomy } from "./breadcrumb-item.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        plainTextStyles,
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: plainTextStyles,
+    },
+    {
+        target : {
             part: BreadcrumbItemAnatomy.parts.control,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                controlDensityStyles,
-            ],
-        )
-    ],
-    [
-        {
+        styles: [
+            controlShapeStyles,
+            controlDensityStyles,
+        ],
+    },
+    {
+        target : {
             hostCondition: BreadcrumbItemAnatomy.conditions.noHref,
             part: BreadcrumbItemAnatomy.parts.control,
         },
-        neutralForegroundStrongElementStyles,
-    ],
-    [
-        {
+        styles: neutralForegroundStrongElementStyles,
+    },
+    {
+        target : {
             hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
             part: BreadcrumbItemAnatomy.parts.control,
             partCondition: BreadcrumbItemAnatomy.conditions.current,
         },
-        neutralForegroundStrongElementStyles,
-    ],
-    [
-        {
+        styles: neutralForegroundStrongElementStyles,
+    },
+    {
+        target : {
             hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
             part: BreadcrumbItemAnatomy.parts.control,
         },
-        accentForegroundReadableControlStyles,
-    ],
+        styles: accentForegroundReadableControlStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb/breadcrumb.styles.modules.ts
@@ -1,11 +1,11 @@
 import {
-    StyleModules,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
+export const styleModules: StyleRules = [
 ];

--- a/packages/adaptive-web-components/src/components/button/button.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/button/button.styles.modules.ts
@@ -1,17 +1,17 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { actionStyles } from "@adaptive-web/adaptive-ui/reference";
 import { ButtonAnatomy } from "./button.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        target : {
             part: ButtonAnatomy.parts.control,
         },
-        actionStyles
-    ],
+        styles: actionStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/calendar/calendar.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
     plainTextStyles
@@ -6,20 +6,18 @@ import {
 import { CalendarAnatomy } from "./calendar.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: plainTextStyles,
+    },
+    {
+        target : {
+            part: CalendarAnatomy.parts.day,
         },
-        plainTextStyles
-    ],
-    [
-        {
-            part: CalendarAnatomy.parts.day
-        },
-        controlShapeStyles
-    ],
+        styles: controlShapeStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/card/card.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     layerFillInteractiveRest,
@@ -9,22 +8,19 @@ import {
     shadowCardStyles
 } from "@adaptive-web/adaptive-ui/reference";
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            layerShapeStyles,
+            plainTextStyles,
+            shadowCardStyles,
+        ],
+        properties: {
+            backgroundFill: layerFillInteractiveRest,
         },
-        Styles.compose(
-            [
-                layerShapeStyles,
-                plainTextStyles,
-                shadowCardStyles,
-            ], {
-                backgroundFill: layerFillInteractiveRest,
-            }
-        )
-    ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     densityControl,
     plainTextStyles,
@@ -8,35 +8,33 @@ import {
 import { CheckboxAnatomy } from "./checkbox.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             gap: densityControl.horizontalGap,
-        })
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: CheckboxAnatomy.parts.label,
         },
-        plainTextStyles
-    ],
-    [
-        {
+        styles: plainTextStyles,
+    },
+    {
+        target : {
             part: CheckboxAnatomy.parts.control,
         },
-        selectableUnselectedStyles
-    ],
-    [
-        {
+        styles: selectableUnselectedStyles,
+    },
+    {
+        target : {
             hostCondition: CheckboxAnatomy.conditions.checked,
             part: CheckboxAnatomy.parts.control,
         },
-        selectableSelectedStyles
-    ],
+        styles: selectableSelectedStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/combobox/combobox.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     flyoutStyles,
@@ -10,26 +9,24 @@ import {
 import { ComboboxAnatomy } from "./combobox.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-            part: ComboboxAnatomy.parts.control
+export const styleModules: StyleRules = [
+    {
+        target : {
+            part: ComboboxAnatomy.parts.control,
         },
-        inputStyles
-    ],
-    [
-        {
-            part: ComboboxAnatomy.parts.listbox
+        styles: inputStyles,
+    },
+    {
+        target : {
+            part: ComboboxAnatomy.parts.listbox,
         },
-        Styles.compose(
-            [
-                itemContainerDensityStyles,
-                flyoutStyles,
-            ],
-        )
-    ],
+        styles: [
+            itemContainerDensityStyles,
+            flyoutStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -1,45 +1,37 @@
 import {
-    StyleModules,
-    Styles,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlDensityStyles,
     controlShapeStyles,
+    labelTextStyles,
     plainTextStyles
 } from "@adaptive-web/adaptive-ui/reference";
 import { DataGridCellAnatomy } from "./data-grid-cell.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                controlDensityStyles,
-                plainTextStyles,
-            ],
-        )
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            controlShapeStyles,
+            controlDensityStyles,
+            plainTextStyles,
+        ],
+    },
+    {
+        target : {
             hostCondition: DataGridCellAnatomy.conditions.cellTypeColumnHeader,
         },
-        Styles.fromProperties({
-            fontWeight: "600",
-        }),
-    ],
-    [
-        {
+        styles: labelTextStyles,
+    },
+    {
+        target : {
             hostCondition: DataGridCellAnatomy.conditions.cellTypeRowHeader,
         },
-        Styles.fromProperties({
-            fontWeight: "600",
-        }),
-    ],
+        styles: labelTextStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-row/data-grid-row.styles.modules.ts
@@ -1,21 +1,17 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
-import { neutralStrokeSubtleRest, strokeThickness } from "@adaptive-web/adaptive-ui/reference";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtle, strokeThickness } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties(
-            {
-                borderFillBottom: neutralStrokeSubtleRest,
-                borderStyleBottom: "solid",
-                borderThicknessBottom: strokeThickness,
-            }
-        ),
-    ],
+export const styleModules: StyleRules = [
+    {
+        properties: {
+            borderFillBottom: neutralStrokeSubtle.rest,
+            borderStyleBottom: "solid",
+            borderThicknessBottom: strokeThickness,
+        }
+    },
 ];

--- a/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid/data-grid.styles.modules.ts
@@ -1,11 +1,11 @@
 import {
-    StyleModules,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
+export const styleModules: StyleRules = [
 ];

--- a/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/dialog/dialog.styles.modules.ts
@@ -1,30 +1,31 @@
-import { Color, StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { Color, StyleRules } from "@adaptive-web/adaptive-ui";
 import { layerFillFixedPlus1, layerShapeStyles, shadowDialogStyles } from "@adaptive-web/adaptive-ui/reference";
 import { DialogAnatomy } from "./dialog.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        target : {
             part: DialogAnatomy.parts.control,
         },
-        Styles.compose([
+        styles: [
             layerShapeStyles,
             shadowDialogStyles,
-        ], {
+        ],
+        properties: {
             backgroundFill: layerFillFixedPlus1
-        }),
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: DialogAnatomy.parts.overlay,
         },
-        Styles.fromProperties({
+        properties: {
             backgroundFill: Color.fromRgb(0, 0, 0, 0.3),
-        })
-    ]
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/disclosure/disclosure.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     accentFillReadableControlStyles,
@@ -11,26 +10,22 @@ import {
 import { DisclosureAnatomy } from "./disclosure.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+    },
+    {
+        target : {
+            part: DisclosureAnatomy.parts.invoker,
         },
-        typeRampBaseStyles
-    ],
-    [
-        {
-            part: DisclosureAnatomy.parts.invoker
-        },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                controlDensityStyles,
-                accentFillReadableControlStyles,
-            ],
-        )
-    ],
+        styles: [
+            controlShapeStyles,
+            controlDensityStyles,
+            accentFillReadableControlStyles,
+        ]
+    },
 ];

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
@@ -1,35 +1,31 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
-import { neutralStrokeSubtleRest, strokeThickness } from "@adaptive-web/adaptive-ui/reference";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
+import { neutralStrokeSubtle, strokeThickness } from "@adaptive-web/adaptive-ui/reference";
 import { DividerAnatomy } from "./divider.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        target : {
             hostCondition: DividerAnatomy.conditions.horizontal,
         },
-        Styles.fromProperties(
-            {
-                borderFillTop: neutralStrokeSubtleRest,
-                borderStyleTop: "solid",
-                borderThicknessTop: strokeThickness,
-            }
-        ),
-    ],
-    [
-        {
+        properties: {
+            borderFillTop: neutralStrokeSubtle.rest,
+            borderStyleTop: "solid",
+            borderThicknessTop: strokeThickness,
+        },
+    },
+    {
+        target : {
             hostCondition: DividerAnatomy.conditions.vertical,
         },
-        Styles.fromProperties(
-            {
-                borderFillLeft: neutralStrokeSubtleRest,
-                borderStyleLeft: "solid",
-                borderThicknessLeft: strokeThickness,
-            }
-        ),
-    ],
+        properties: {
+            borderFillLeft: neutralStrokeSubtle.rest,
+            borderStyleLeft: "solid",
+            borderThicknessLeft: strokeThickness,
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/flipper/flipper.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.styles.modules.ts
@@ -1,19 +1,17 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { actionStyles, controlSquareDensityStyles, roundShapeStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose([
+export const styleModules: StyleRules = [
+    {
+        styles: [
             actionStyles,
             roundShapeStyles,
             controlSquareDensityStyles,
-        ]),
-    ],
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/horizontal-scroll/horizontal-scroll.styles.modules.ts
@@ -1,9 +1,9 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
+export const styleModules: StyleRules = [
 ];

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.modules.ts
@@ -1,5 +1,5 @@
 import {
-    StyleModules,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     itemStyles,
@@ -8,20 +8,18 @@ import {
 import { ListboxOptionAnatomy } from "./listbox-option.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        itemStyles
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: itemStyles,
+    },
+    {
+        target : {
             hostCondition: ListboxOptionAnatomy.conditions.selected,
         },
-        selectableSelectedStyles
-    ],
+        styles: selectableSelectedStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
@@ -9,20 +8,16 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                itemContainerDensityStyles,
-                neutralOutlineDiscernibleControlStyles,
-            ],
-        )
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            controlShapeStyles,
+            itemContainerDensityStyles,
+            neutralOutlineDiscernibleControlStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.styles.modules.ts
@@ -1,16 +1,13 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { itemStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules
- = [
-    [
-        {
-        },
-        itemStyles
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: itemStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/menu/menu.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     flyoutStyles,
@@ -8,19 +7,15 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                itemContainerDensityStyles,
-                flyoutStyles,
-            ],
-        )
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            itemContainerDensityStyles,
+            flyoutStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/number-field/number-field.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     autofillInnerDensityStyles,
     densityControl,
@@ -9,39 +9,33 @@ import {
 import { NumberFieldAnatomy } from "./number-field.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+        properties: {
+            gap: densityControl.verticalGap,
         },
-        Styles.compose(
-            [
-                typeRampBaseStyles,
-            ],
-            {
-                gap: densityControl.verticalGap,
-            }
-        ),
-    ],
-    [
-        {
-            part: NumberFieldAnatomy.parts.label
+    },
+    {
+        target : {
+            part: NumberFieldAnatomy.parts.label,
         },
-        labelTextStyles
-    ],
-    [
-        {
-            part: NumberFieldAnatomy.parts.root
+        styles: labelTextStyles,
+    },
+    {
+        target : {
+            part: NumberFieldAnatomy.parts.root,
         },
-        inputAutofillStyles
-    ],
-    [
-        {
-            part: NumberFieldAnatomy.parts.control
+        styles: inputAutofillStyles,
+    },
+    {
+        target : {
+            part: NumberFieldAnatomy.parts.control,
         },
-        autofillInnerDensityStyles
-    ],
+        styles: autofillInnerDensityStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.styles.modules.ts
@@ -1,15 +1,13 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { itemStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        itemStyles
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: itemStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-list/picker-list.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
     neutralOutlineDiscernibleControlStyles,
@@ -6,20 +6,16 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                typeRampBaseStyles,
-                neutralOutlineDiscernibleControlStyles
-            ],
-        )
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            controlShapeStyles,
+            typeRampBaseStyles,
+            neutralOutlineDiscernibleControlStyles
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
@@ -1,22 +1,20 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { highlightFillReadableControlStyles, itemStyles } from "@adaptive-web/adaptive-ui/reference";
 import { PickerMenuOptionAnatomy } from "./picker-menu-option.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        itemStyles,
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: itemStyles,
+    },
+    {
+        target : {
             hostCondition: PickerMenuOptionAnatomy.conditions.selected,
         },
-        highlightFillReadableControlStyles,
-    ],
+        styles: highlightFillReadableControlStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu/picker-menu.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     flyoutStyles,
@@ -8,19 +7,15 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                itemContainerDensityStyles,
-                flyoutStyles,
-            ]
-        )
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            itemContainerDensityStyles,
+            flyoutStyles,
+        ]
+    },
 ];

--- a/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker/picker.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     flyoutStyles,
@@ -9,30 +8,28 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 import { PickerAnatomy } from "./picker.template.js";
 
-const menuStyles = Styles.compose(
-    [
-        plainTextStyles,
-        itemContainerDensityStyles,
-        flyoutStyles,
-    ]
-);
+const menuStyles = [
+    plainTextStyles,
+    itemContainerDensityStyles,
+    flyoutStyles,
+];
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-            part: PickerAnatomy.parts.loadingDisplay
+export const styleModules: StyleRules = [
+    {
+        target : {
+            part: PickerAnatomy.parts.loadingDisplay,
         },
-        menuStyles
-    ],
-    [
-        {
-            part: PickerAnatomy.parts.noOptionsDisplay
+        styles: menuStyles,
+    },
+    {
+        target : {
+            part: PickerAnatomy.parts.noOptionsDisplay,
         },
-        menuStyles
-    ],
+        styles: menuStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.modules.ts
@@ -1,32 +1,29 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
-    accentFillReadableRest,
-    neutralFillSubtleRest
+    accentFillReadable,
+    neutralFillSubtle,
 } from "@adaptive-web/adaptive-ui/reference";
 import { ProgressRingAnatomy } from "./progress-ring.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        properties: {
+            foregroundFill: neutralFillSubtle.rest
         },
-        Styles.fromProperties({
-            foregroundFill: neutralFillSubtleRest
-        })
-    ],
-    [
-        {
-            part: ProgressRingAnatomy.parts.indicator
+    },
+    {
+        target : {
+            part: ProgressRingAnatomy.parts.indicator,
         },
-        Styles.fromProperties({
-            foregroundFill: accentFillReadableRest
-        })
-    ],
+        properties: {
+            foregroundFill: accentFillReadable.rest
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
+++ b/packages/adaptive-web-components/src/components/progress-ring/progress-ring.styles.ts
@@ -38,7 +38,7 @@ export const aestheticStyles: ElementStyles = css`
 
     .indicator {
         stroke: currentcolor;
-        fill: none;
+        fill: none !important;
         stroke-width: 2px;
         stroke-linecap: round;
         transform-origin: 50% 50%;

--- a/packages/adaptive-web-components/src/components/progress/progress.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/progress/progress.styles.modules.ts
@@ -1,36 +1,33 @@
 import {
     CornerRadius,
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
-    accentFillReadableRest,
+    accentFillReadable,
     designUnit,
-    neutralFillSubtleRest
+    neutralFillSubtle,
 } from "@adaptive-web/adaptive-ui/reference";
 import { ProgressAnatomy } from "./progress.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
-            backgroundFill: neutralFillSubtleRest,
+export const styleModules: StyleRules = [
+    {
+        properties: {
+            backgroundFill: neutralFillSubtle.rest,
             ...CornerRadius.all(designUnit),
-        })
-    ],
-    [
-        {
-            part: ProgressAnatomy.parts.indicator
         },
-        Styles.fromProperties({
-            backgroundFill: accentFillReadableRest,
+    },
+    {
+        target : {
+            part: ProgressAnatomy.parts.indicator,
+        },
+        properties: {
+            backgroundFill: accentFillReadable.rest,
             ...CornerRadius.all(designUnit),
-        })
-    ],
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio-group/radio-group.styles.modules.ts
@@ -1,28 +1,26 @@
 import {
-    StyleModules, Styles,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import { densityControl } from "@adaptive-web/adaptive-ui/reference";
 import { RadioGroupAnatomy } from "./radio-group.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             gap: densityControl.verticalGap,
-        })
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: RadioGroupAnatomy.parts.positioningRegion,
         },
-        Styles.fromProperties({
+        properties: {
             gap: densityControl.verticalGap,
-        }),
-    ]
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     densityControl,
     plainTextStyles,
@@ -9,41 +9,39 @@ import {
 import { RadioAnatomy } from "./radio.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             gap: densityControl.horizontalGap,
-        })
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: RadioAnatomy.parts.label,
         },
-        plainTextStyles
-    ],
-    [
-        {
+        styles: plainTextStyles,
+    },
+    {
+        target : {
             part: RadioAnatomy.parts.control,
         },
-        Styles.compose([
+        styles: [
             selectableUnselectedStyles,
             roundShapeStyles,
-        ]),
-    ],
-    [
-        {
+        ],
+    },
+    {
+        target : {
             hostCondition: RadioAnatomy.conditions.checked,
             part: RadioAnatomy.parts.control,
         },
-        Styles.compose([
+        styles: [
             selectableSelectedStyles,
             roundShapeStyles,
-        ]),
-    ],
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/search/search.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
@@ -13,44 +12,36 @@ import {
 import { SearchAnatomy } from "./search.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+        properties: {
+            gap: densityControl.verticalGap,
         },
-        Styles.compose(
-            [
-                typeRampBaseStyles,
-            ],
-            {
-                gap: densityControl.verticalGap,
-            }
-        ),
-    ],
-    [
-        {
-            part: SearchAnatomy.parts.label
+    },
+    {
+        target : {
+            part: SearchAnatomy.parts.label,
         },
-        labelTextStyles
-    ],
-    [
-        {
-            part: SearchAnatomy.parts.root
+        styles: labelTextStyles,
+    },
+    {
+        target : {
+            part: SearchAnatomy.parts.root,
         },
-        inputStyles
-    ],
-    [
-        {
-            part: SearchAnatomy.parts.clearButton
+        styles: inputStyles,
+    },
+    {
+        target : {
+            part: SearchAnatomy.parts.clearButton,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                neutralFillStealthControlStyles,
-            ],
-        )
-    ],
+        styles: [
+            controlShapeStyles,
+            neutralFillStealthControlStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
@@ -12,44 +11,38 @@ import {
 import { SelectAnatomy } from "./select.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-            part: SelectAnatomy.parts.control
+export const styleModules: StyleRules = [
+    {
+        target : {
+            part: SelectAnatomy.parts.control,
         },
-        inputStyles
-    ],
-    [
-        {
-            part: SelectAnatomy.parts.listbox
+        styles: inputStyles,
+    },
+    {
+        target : {
+            part: SelectAnatomy.parts.listbox,
         },
-        Styles.compose(
-            [
-                itemContainerDensityStyles,
-            ],
-        )
-    ],
-    [
-        {
+        styles: itemContainerDensityStyles,
+    },
+    {
+        target : {
             hostCondition: SelectAnatomy.conditions.isListbox,
-            part: SelectAnatomy.parts.listbox
+            part: SelectAnatomy.parts.listbox,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                neutralOutlineDiscernibleControlStyles,
-            ],
-        )
-    ],
-    [
-        {
+        styles: [
+            controlShapeStyles,
+            neutralOutlineDiscernibleControlStyles,
+        ],
+    },
+    {
+        target : {
             hostCondition: SelectAnatomy.conditions.isDropdown,
-            part: SelectAnatomy.parts.listbox
+            part: SelectAnatomy.parts.listbox,
         },
-        flyoutStyles,
-    ],
+        styles: flyoutStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
@@ -1,30 +1,29 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { controlShapeStyles, neutralFillSubtleRest, roundShapeStyles } from "@adaptive-web/adaptive-ui/reference";
 import { SkeletonAnatomy } from "./skeleton.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             backgroundFill: neutralFillSubtleRest,
-        })
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             hostCondition: SkeletonAnatomy.conditions.rectangle,
         },
-        controlShapeStyles,
-    ],
-    [
-        {
+        styles: controlShapeStyles,
+    },
+    
+    {
+        target : {
             hostCondition: SkeletonAnatomy.conditions.circle,
         },
-        roundShapeStyles,
-    ]
+        styles: roundShapeStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider-label/slider-label.styles.modules.ts
@@ -1,27 +1,25 @@
 import { css } from "@microsoft/fast-element";
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
-import { designUnit, neutralStrokeSubtleRest, typeRampMinus1Styles } from "@adaptive-web/adaptive-ui/reference";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
+import { designUnit, neutralStrokeSubtle, typeRampMinus1Styles } from "@adaptive-web/adaptive-ui/reference";
 import { SliderLabelAnatomy } from "./slider-label.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        typeRampMinus1Styles,
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampMinus1Styles,
+    },
+    {
+        target : {
             part: SliderLabelAnatomy.parts.mark,
         },
-        Styles.fromProperties({
-            backgroundFill: neutralStrokeSubtleRest,
+        properties: {
+            backgroundFill: neutralStrokeSubtle.rest,
             height: css.partial`calc(${designUnit} *2)`, 
             width: css.partial`calc(${designUnit} / 2)`,
-        }),
-    ]
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.styles.modules.ts
@@ -1,52 +1,46 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     controlShapeStyles,
     highlightFillReadableControlStyles,
-    neutralStrokeDiscernibleRest,
+    neutralStrokeDiscernible,
     roundShapeStyles
 } from "@adaptive-web/adaptive-ui/reference";
 import { SliderAnatomy } from "./slider.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        controlShapeStyles,
-    ],
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: controlShapeStyles,
+    },
+    {
+        target : {
             part: SliderAnatomy.parts.track,
         },
-        Styles.compose([
-            controlShapeStyles,
-        ],
-        {
-            backgroundFill: neutralStrokeDiscernibleRest,
-        })
-    ],
-    [
-        {
+        styles: controlShapeStyles,
+        properties: {
+            backgroundFill: neutralStrokeDiscernible.rest,
+        },
+    },
+    {
+        target : {
             part: SliderAnatomy.parts.trackStart,
         },
-        Styles.compose([
+        styles: [
             controlShapeStyles,
             highlightFillReadableControlStyles,
-        ]),
-    ],
-    [
-        {
+        ],
+    },
+    {
+        target : {
             part: SliderAnatomy.parts.thumb,
         },
-        Styles.compose(
-            [
-                roundShapeStyles,
-                highlightFillReadableControlStyles,
-            ],
-        )
-    ],
+        styles: [
+            roundShapeStyles,
+            highlightFillReadableControlStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     densityControl,
     plainTextStyles,
@@ -9,47 +9,45 @@ import {
 import { SwitchAnatomy } from "./switch.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             gap: densityControl.horizontalGap,
-        }),
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: SwitchAnatomy.parts.label,
         },
-        plainTextStyles,
-    ],
-    [
-        {
+        styles: plainTextStyles,
+    },
+    {
+        target : {
             part: SwitchAnatomy.parts.switch,
         },
-        Styles.compose([
+        styles: [
             selectableUnselectedStyles,
             roundShapeStyles,
-        ]),
-    ],
-    [
-        {
+        ],
+    },
+    {
+        target : {
             hostCondition: SwitchAnatomy.conditions.checked,
             part: SwitchAnatomy.parts.switch,
         },
-        Styles.compose([
+        styles: [
             selectableSelectedStyles,
             roundShapeStyles,
-        ]),
-    ],
-    [
-        {
+        ],
+    },
+    {
+        target : {
             part: SwitchAnatomy.parts.thumb,
         },
-        roundShapeStyles,
-    ]
+        styles: roundShapeStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tab-panel/tab-panel.styles.modules.ts
@@ -1,6 +1,5 @@
 import {
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlDensityStyles,
@@ -8,19 +7,15 @@ import {
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.compose(
-            [
-                plainTextStyles,
-                controlDensityStyles,
-            ],
-        )
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            plainTextStyles,
+            controlDensityStyles,
+        ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tab/tab.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.styles.modules.ts
@@ -1,15 +1,13 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { itemStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        itemStyles
-    ],
+export const styleModules: StyleRules = [
+    {
+        styles: itemStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tabs/tabs.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tabs/tabs.styles.modules.ts
@@ -1,15 +1,13 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { plainTextStyles } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        plainTextStyles
-    ]
+export const styleModules: StyleRules = [
+    {
+        styles: plainTextStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-area/text-area.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     densityControl,
     inputStyles,
@@ -8,33 +8,27 @@ import {
 import { TextAreaAnatomy } from "./text-area.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+        properties: {
+            gap: densityControl.verticalGap,
         },
-        Styles.compose(
-            [
-                typeRampBaseStyles,
-            ],
-            {
-                gap: densityControl.verticalGap,
-            }
-        ),
-    ],
-    [
-        {
-            part: TextAreaAnatomy.parts.label
+    },
+    {
+        target : {
+            part: TextAreaAnatomy.parts.label,
         },
-        labelTextStyles
-    ],
-    [
-        {
-            part: TextAreaAnatomy.parts.control
+        styles: labelTextStyles,
+    },
+    {
+        target : {
+            part: TextAreaAnatomy.parts.control,
         },
-        inputStyles
-    ],
+        styles: inputStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/text-field/text-field.styles.modules.ts
@@ -1,4 +1,4 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import {
     autofillInnerDensityStyles,
     densityControl,
@@ -9,39 +9,33 @@ import {
 import { TextFieldAnatomy } from "./text-field.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: typeRampBaseStyles,
+        properties: {
+            gap: densityControl.verticalGap,
+        }
+    },
+    {
+        target : {
+            part: TextFieldAnatomy.parts.label,
         },
-        Styles.compose(
-            [
-                typeRampBaseStyles,
-            ],
-            {
-                gap: densityControl.verticalGap,
-            }
-        ),
-    ],
-    [
-        {
-            part: TextFieldAnatomy.parts.label
+        styles: labelTextStyles,
+    },
+    {
+        target : {
+            part: TextFieldAnatomy.parts.root,
         },
-        labelTextStyles
-    ],
-    [
-        {
-            part: TextFieldAnatomy.parts.root
+        styles: inputAutofillStyles,
+    },
+    {
+        target : {
+            part: TextFieldAnatomy.parts.control,
         },
-        inputAutofillStyles
-    ],
-    [
-        {
-            part: TextFieldAnatomy.parts.control
-        },
-        autofillInnerDensityStyles
-    ],
+        styles: autofillInnerDensityStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/toolbar/toolbar.styles.modules.ts
@@ -1,27 +1,25 @@
-import { StyleModules, Styles } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { densityControl, neutralStrokeStrong } from "@adaptive-web/adaptive-ui/reference";
 import { ToolbarAnatomy } from "./toolbar.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-        },
-        Styles.fromProperties({
+export const styleModules: StyleRules = [
+    {
+        properties: {
             foregroundFill: neutralStrokeStrong,
             gap: densityControl.horizontalGap,
-        }),
-    ],
-    [
-        {
+        },
+    },
+    {
+        target : {
             part: ToolbarAnatomy.parts.positioningRegion,
         },
-        Styles.fromProperties({
+        properties: {
             gap: densityControl.horizontalGap,
-        }),
-    ],
+        },
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tooltip/tooltip.styles.modules.ts
@@ -1,37 +1,32 @@
 import {
     BorderFill,
-    StyleModules,
-    Styles
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import {
     controlDensityStyles,
     controlShapeStyles,
-    neutralFillSubtleRest,
-    neutralStrokeSubtleRest,
+    neutralFillSubtle,
+    neutralStrokeSubtle,
     plainTextStyles,
     shadowTooltipStyles
 } from "@adaptive-web/adaptive-ui/reference";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
+export const styleModules: StyleRules = [
+    {
+        styles: [
+            controlShapeStyles,
+            controlDensityStyles,
+            plainTextStyles,
+            shadowTooltipStyles,
+        ],
+        properties: {
+            ...BorderFill.all(neutralStrokeSubtle.rest),
+            backgroundFill: neutralFillSubtle.rest,
         },
-        Styles.compose(
-            [
-                controlShapeStyles,
-                controlDensityStyles,
-                plainTextStyles,
-                shadowTooltipStyles,
-            ],
-            {
-                ...BorderFill.all(neutralStrokeSubtleRest),
-                backgroundFill: neutralFillSubtleRest,
-            },
-        )
-    ],
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.modules.ts
@@ -1,17 +1,17 @@
-import { StyleModules } from "@adaptive-web/adaptive-ui";
+import { StyleRules } from "@adaptive-web/adaptive-ui";
 import { itemStyles } from "@adaptive-web/adaptive-ui/reference"; 
 import { TreeItemAnatomy } from "./tree-item.template.js";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
-    [
-        {
-            part: TreeItemAnatomy.parts.control
+export const styleModules: StyleRules = [
+    {
+        target : {
+            part: TreeItemAnatomy.parts.control,
         },
-        itemStyles
-    ],
+        styles: itemStyles,
+    },
 ];

--- a/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/tree-view/tree-view.styles.modules.ts
@@ -1,11 +1,11 @@
 import {
-    StyleModules,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 
 /**
- * Visual styles composed by modules.
+ * Visual styles composed by style rules.
  * 
  * @public
  */
-export const styleModules: StyleModules = [
+export const styleModules: StyleRules = [
 ];

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -10,8 +10,7 @@ import type { StaticallyComposableHTML } from "@microsoft/fast-foundation";
 import {
     type ComponentAnatomy,
     ElementStylesRenderer,
-    type StyleModuleTarget,
-    Styles,
+    StyleRule,
 } from "@adaptive-web/adaptive-ui";
 import type {
     AccordionItemStatics,
@@ -25,7 +24,7 @@ import type {
     SelectStatics,
     TreeItemStatics
 } from "./components/index.js";
-import { globalStyleModules } from './global.styles.modules.js';
+import { globalStyleRules } from './global.styles.modules.js';
 
 type ComponentStatics =
     AccordionItemStatics
@@ -148,16 +147,11 @@ export class DesignSystem {
             defaultStyles;
 
         const allStyleModules = [
-            ...globalStyleModules(anatomy),
+            ...globalStyleRules(anatomy),
             ...(options && options.styleModules ? options.styleModules : [])
         ];
 
-        for (const [target, styles] of allStyleModules) {
-            const renderedStyles = new ElementStylesRenderer(styles).render(target, anatomy?.interactivity);
-            componentStyles.push(renderedStyles);
-        }
-
-        return new ElementStyles(componentStyles);
+        return ElementStylesRenderer.renderStyleRules(componentStyles, allStyleModules, anatomy);
     }
 }
 
@@ -176,7 +170,7 @@ export const DefaultDesignSystem: DesignSystem = new DesignSystem("adaptive");
 export type ComposeOptions<TSource, TStatics extends string = any> = {
     template?: (ds: DesignSystem) => ElementViewTemplate<TSource, any>;
     styles?: ElementStyles | ElementStyles[];
-    styleModules?: Iterable<readonly [StyleModuleTarget, Styles]>;
+    styleModules?: Iterable<StyleRule>;
     shadowOptions?: Partial<ShadowRootOptions>;
     elementOptions?: ElementDefinitionOptions;
     statics?: Record<TStatics, StaticallyComposableHTML>;

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -2,9 +2,9 @@ import { CSSDesignToken } from "@microsoft/fast-foundation";
 import {
     ComponentAnatomy,
     InteractiveSet,
-    StyleModules,
-    StyleModuleTarget,
     StyleProperties,
+    StyleRule,
+    StyleRules,
     Styles,
     StyleValue
 } from "@adaptive-web/adaptive-ui";
@@ -59,19 +59,19 @@ const focusResetStyles = convertToFocusState(Styles.fromProperties({
  * 
  * @public
  */
-export const globalStyleModules = (anatomy?: ComponentAnatomy<any, any>): StyleModules => {
-    const styles = new Array<[StyleModuleTarget, Styles]>();
+export const globalStyleRules = (anatomy?: ComponentAnatomy<any, any>): StyleRules => {
+    const styles = new Array<StyleRule>();
 
     // If this component can be disabled, apply the style to all children.
     if (anatomy?.interactivity?.disabledSelector !== undefined) {
         styles.push(
-            [
-                {
+            {
+                target : {
                     hostCondition: anatomy.interactivity.disabledSelector,
                     part: "*",
                 },
-                disabledStyles,
-            ]
+                styles: disabledStyles,
+            },
         );
     }
 
@@ -79,19 +79,19 @@ export const globalStyleModules = (anatomy?: ComponentAnatomy<any, any>): StyleM
     if (anatomy?.focus) {
         if (anatomy.focus?.resetTarget) {
             styles.push(
-                [
-                    anatomy.focus?.resetTarget,
-                    focusResetStyles,
-                ],
+                {
+                    target: anatomy.focus?.resetTarget,
+                    styles: focusResetStyles,
+                }
             );
         }
 
         // Set intentional focus styles
         styles.push(
-            [
-                anatomy.focus.focusTarget,
-                focusStateStyles,
-            ]
+            {
+                target: anatomy.focus.focusTarget,
+                styles: focusStateStyles,
+            }
         );
     }
 


### PR DESCRIPTION
# Pull Request

## Description

The previous type definition for Style Modules was an array of arrays. Originally it was to separate the target (css selector) aspect from the styles. In practice, a lot of styles were composed from multiple other styles and individual properties. It seems stronger now to treat this all as a complete object definition which can also be more easily abstracted and reused.

This cleans up that typing and starts the rename from "Style Modules" to "Style Rules". The new terminology is aligned with what CSS calls the various pieces of a stylesheet.

I didn't rename the variables published from each component in this PR as we're updating the compose method and I thought it was better to handle at that time or after.

## Reviewer Notes

Curious about feedback on the ergonomics of the style authoring and type change, if any.

## Test Plan

Tested in all examples and packages.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

### Component-specific
<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Finish renaming the component `styleModules` to `styleRules`. Note the term "modules" may still come into play where CSS is generated, in the notion that there will be helpers constructing complicated CSS or patterns.