### PR TITLE
Added subtle inverse color recipes

### DIFF
--- a/change/@adaptive-web-adaptive-ui-af78f269-705d-4753-a2cf-fa5d40c26969.json
+++ b/change/@adaptive-web-adaptive-ui-af78f269-705d-4753-a2cf-fa5d40c26969.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added subtle inverse color recipes",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -4,6 +4,7 @@ import {
     accentFillReadableControlStyles,
     accentFillStealthControlStyles,
     accentFillSubtleControlStyles,
+    accentFillSubtleInverseControlStyles,
     accentForegroundReadableControlStyles,
     accentOutlineDiscernibleControlStyles,
     fillColor,
@@ -11,6 +12,7 @@ import {
     highlightFillReadableControlStyles,
     highlightFillStealthControlStyles,
     highlightFillSubtleControlStyles,
+    highlightFillSubtleInverseControlStyles,
     highlightForegroundReadableControlStyles,
     highlightOutlineDiscernibleControlStyles,
     neutralDividerDiscernibleElementStyles,
@@ -19,10 +21,11 @@ import {
     neutralFillReadableControlStyles,
     neutralFillStealthControlStyles,
     neutralFillSubtleControlStyles,
+    neutralFillSubtleInverseControlStyles,
     neutralForegroundReadableElementStyles,
     neutralForegroundStrongElementStyles,
     neutralOutlineDiscernibleControlStyles,
-    neutralStrokeReadableRest
+    neutralStrokeReadable,
 } from '@adaptive-web/adaptive-ui/reference';
 import { componentBaseStyles } from "@adaptive-web/adaptive-web-components";
 import {
@@ -58,6 +61,10 @@ const backplateComponents = html<ColorBlock>`
         Accent subtle
     </app-style-example>
 
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => accentFillSubtleInverseControlStyles}">
+        Accent subtle inverse
+    </app-style-example>
+
     <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillReadableControlStyles}">
         Neutral readable
     </app-style-example>
@@ -70,6 +77,10 @@ const backplateComponents = html<ColorBlock>`
         Neutral subtle
     </app-style-example>
 
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => neutralFillSubtleInverseControlStyles}">
+        Neutral subtle inverse
+    </app-style-example>
+
     <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillReadableControlStyles}">
         Highlight readable
     </app-style-example>
@@ -80,6 +91,10 @@ const backplateComponents = html<ColorBlock>`
 
     <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillSubtleControlStyles}">
         Highlight subtle
+    </app-style-example>
+
+    <app-style-example :disabledState=${x => x.disabledState} :styles="${x => highlightFillSubtleInverseControlStyles}">
+        Highlight subtle inverse
     </app-style-example>
 `;
 
@@ -166,7 +181,7 @@ const styles = css`
         padding: 36px;
         gap: 24px;
         background-color: ${fillColor};
-        color: ${neutralStrokeReadableRest};
+        color: ${neutralStrokeReadable.rest};
     }
 
     .title {

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -287,6 +287,23 @@ export const fillSubtleRecipe = createTokenColorRecipeForPalette(
         )
 );
 
+/** @public */
+export const fillSubtleInverseRecipe = createTokenColorRecipeForPalette(
+    `${fillSubtleName}-inverse`,
+    StyleProperty.backgroundFill,
+    (resolve: DesignTokenResolver, params: ColorRecipePaletteParams) =>
+        deltaSwatchSet(
+            params.palette,
+            params.reference || resolve(fillColor),
+            resolve(fillSubtleRestDelta) * -1,
+            resolve(fillSubtleHoverDelta) * -1,
+            resolve(fillSubtleActiveDelta) * -1,
+            resolve(fillSubtleFocusDelta) * -1,
+            resolve(fillSubtleDisabledDelta) * -1,
+            resolve(disabledPalette),
+        )
+);
+
 const fillDiscernibleName = "fill-discernible";
 
 /** @public */
@@ -615,6 +632,14 @@ export const accentFillSubtleActive = accentFillSubtle.active;
 /** @public @deprecated Use baseColorSet.state format instead */
 export const accentFillSubtleFocus = accentFillSubtle.focus;
 
+// Accent Fill Subtle Inverse
+
+/** @public */
+export const accentFillSubtleInverseRecipe = createTokenColorRecipeAccent(fillSubtleInverseRecipe);
+
+/** @public */
+export const accentFillSubtleInverse = createTokenColorSet(accentFillSubtleInverseRecipe);
+
 // Accent Fill Discernible
 
 /** @public */
@@ -814,6 +839,14 @@ export const highlightFillSubtleActive = highlightFillSubtle.active;
 
 /** @public @deprecated Use baseColorSet.state format instead */
 export const highlightFillSubtleFocus = highlightFillSubtle.focus;
+
+// Highlight Fill Subtle Inverse
+
+/** @public */
+export const highlightFillSubtleInverseRecipe = createTokenColorRecipeHighlight(fillSubtleInverseRecipe);
+
+/** @public */
+export const highlightFillSubtleInverse = createTokenColorSet(highlightFillSubtleInverseRecipe);
 
 // Highlight Fill Discernible
 
@@ -1015,6 +1048,14 @@ export const criticalFillSubtleActive = criticalFillSubtle.active;
 /** @public @deprecated Use baseColorSet.state format instead */
 export const criticalFillSubtleFocus = criticalFillSubtle.focus;
 
+// Critical Fill Subtle Inverse
+
+/** @public */
+export const criticalFillSubtleInverseRecipe = createTokenColorRecipeCritical(fillSubtleInverseRecipe);
+
+/** @public */
+export const criticalFillSubtleInverse = createTokenColorSet(criticalFillSubtleInverseRecipe);
+
 // Critical Fill Discernible
 
 /** @public */
@@ -1190,6 +1231,12 @@ export const warningFillSubtleRecipe = createTokenColorRecipeWarning(fillSubtleR
 export const warningFillSubtle = createTokenColorSet(warningFillSubtleRecipe);
 
 /** @public */
+export const warningFillSubtleInverseRecipe = createTokenColorRecipeWarning(fillSubtleInverseRecipe);
+
+/** @public */
+export const warningFillSubtleInverse = createTokenColorSet(warningFillSubtleInverseRecipe);
+
+/** @public */
 export const warningFillDiscernibleRecipe = createTokenColorRecipeWarning(fillDiscernibleRecipe);
 
 /** @public */
@@ -1252,6 +1299,12 @@ export const successFillSubtleRecipe = createTokenColorRecipeSuccess(fillSubtleR
 export const successFillSubtle = createTokenColorSet(successFillSubtleRecipe);
 
 /** @public */
+export const successFillSubtleInverseRecipe = createTokenColorRecipeSuccess(fillSubtleInverseRecipe);
+
+/** @public */
+export const successFillSubtleInverse = createTokenColorSet(successFillSubtleInverseRecipe);
+
+/** @public */
 export const successFillDiscernibleRecipe = createTokenColorRecipeSuccess(fillDiscernibleRecipe);
 
 /** @public */
@@ -1312,6 +1365,12 @@ export const infoFillSubtleRecipe = createTokenColorRecipeInfo(fillSubtleRecipe)
 
 /** @public */
 export const infoFillSubtle = createTokenColorSet(infoFillSubtleRecipe);
+
+/** @public */
+export const infoFillSubtleInverseRecipe = createTokenColorRecipeInfo(fillSubtleInverseRecipe);
+
+/** @public */
+export const infoFillSubtleInverse = createTokenColorSet(infoFillSubtleInverseRecipe);
 
 /** @public */
 export const infoFillDiscernibleRecipe = createTokenColorRecipeInfo(fillDiscernibleRecipe);
@@ -1400,6 +1459,14 @@ export const neutralFillSubtleActive = neutralFillSubtle.active;
 
 /** @public @deprecated Use baseColorSet.state format instead */
 export const neutralFillSubtleFocus = neutralFillSubtle.focus;
+
+// Neutral Fill Subtle Inverse
+
+/** @public */
+export const neutralFillSubtleInverseRecipe = createTokenColorRecipeNeutral(fillSubtleInverseRecipe);
+
+/** @public */
+export const neutralFillSubtleInverse = createTokenColorSet(neutralFillSubtleInverseRecipe);
 
 // Neutral Fill Discernible (previously "Strong")
 

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -5,6 +5,7 @@ import {
     accentFillReadable,
     accentFillStealth,
     accentFillSubtle,
+    accentFillSubtleInverse,
     accentStrokeDiscernible,
     accentStrokeReadable,
     accentStrokeReadableRecipe,
@@ -15,6 +16,7 @@ import {
     criticalFillReadable,
     criticalFillStealth,
     criticalFillSubtle,
+    criticalFillSubtleInverse,
     criticalStrokeDiscernible,
     criticalStrokeReadable,
     criticalStrokeReadableRecipe,
@@ -25,6 +27,7 @@ import {
     highlightFillReadable,
     highlightFillStealth,
     highlightFillSubtle,
+    highlightFillSubtleInverse,
     highlightStrokeDiscernible,
     highlightStrokeReadable,
     highlightStrokeReadableRecipe,
@@ -33,6 +36,7 @@ import {
     infoFillReadable,
     infoFillStealth,
     infoFillSubtle,
+    infoFillSubtleInverse,
     infoStrokeDiscernible,
     infoStrokeReadable,
     infoStrokeReadableRecipe,
@@ -41,6 +45,7 @@ import {
     neutralFillReadable,
     neutralFillStealth,
     neutralFillSubtle,
+    neutralFillSubtleInverse,
     neutralStrokeDiscernible,
     neutralStrokeReadable,
     neutralStrokeSafety,
@@ -51,6 +56,7 @@ import {
     successFillReadable,
     successFillStealth,
     successFillSubtle,
+    successFillSubtleInverse,
     successStrokeDiscernible,
     successStrokeReadable,
     successStrokeReadableRecipe,
@@ -59,6 +65,7 @@ import {
     warningFillReadable,
     warningFillStealth,
     warningFillSubtle,
+    warningFillSubtleInverse,
     warningStrokeDiscernible,
     warningStrokeReadable,
     warningStrokeReadableRecipe,
@@ -298,6 +305,24 @@ export const accentFillSubtleControlStyles: Styles = Styles.fromProperties(
 );
 
 /**
+ * Convenience style module for an accent-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - accent subtle inverse background
+ * - accent readable foreground (a11y)
+ * - accent safety border
+ *
+ * @public
+ */
+export const accentFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(accentFillSubtleInverse, accentStrokeReadableRecipe),
+        ...densityBorderStyles(accentStrokeSafety),
+    },
+    "color.accent-fill-subtle-inverse-control",
+);
+
+/**
  * Convenience style module for an accent-filled discernible control (interactive).
  *
  * By default, the background meets accessibility for non-text elements, useful for a checked checkbox:
@@ -403,6 +428,24 @@ export const highlightFillSubtleControlStyles: Styles = Styles.fromProperties(
         ...densityBorderStyles(highlightStrokeSafety),
     },
     "color.highlight-fill-subtle-control",
+);
+
+/**
+ * Convenience style module for an highlight-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - highlight subtle inverse background
+ * - highlight readable foreground (a11y)
+ * - highlight safety border
+ *
+ * @public
+ */
+export const highlightFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(highlightFillSubtleInverse, highlightStrokeReadableRecipe),
+        ...densityBorderStyles(highlightStrokeSafety),
+    },
+    "color.highlight-fill-subtle-inverse-control",
 );
 
 /**
@@ -514,6 +557,24 @@ export const infoFillSubtleControlStyles: Styles = Styles.fromProperties(
 );
 
 /**
+ * Convenience style module for an info-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - info subtle inverse background
+ * - info readable foreground (a11y)
+ * - info safety border
+ *
+ * @public
+ */
+export const infoFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(infoFillSubtleInverse, infoStrokeReadableRecipe),
+        ...densityBorderStyles(infoStrokeSafety),
+    },
+    "color.info-fill-subtle-inverse-control",
+);
+
+/**
  * Convenience style module for an info-filled discernible control (interactive).
  *
  * By default, the background meets accessibility for non-text elements, useful for a checked checkbox:
@@ -619,6 +680,24 @@ export const successFillSubtleControlStyles: Styles = Styles.fromProperties(
         ...densityBorderStyles(successStrokeSafety),
     },
     "color.success-fill-subtle-control",
+);
+
+/**
+ * Convenience style module for an success-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - success subtle inverse background
+ * - success readable foreground (a11y)
+ * - success safety border
+ *
+ * @public
+ */
+export const successFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(successFillSubtleInverse, successStrokeReadableRecipe),
+        ...densityBorderStyles(successStrokeSafety),
+    },
+    "color.success-fill-subtle-inverse-control",
 );
 
 /**
@@ -728,6 +807,25 @@ export const warningFillSubtleControlStyles: Styles = Styles.fromProperties(
     },
     "color.warning-fill-subtle-control",
 );
+
+/**
+ * Convenience style module for an warning-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - warning subtle inverse background
+ * - warning readable foreground (a11y)
+ * - warning safety border
+ *
+ * @public
+ */
+export const warningFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(warningFillSubtleInverse, warningStrokeReadableRecipe),
+        ...densityBorderStyles(warningStrokeSafety),
+    },
+    "color.warning-fill-subtle-inverse-control",
+);
+
 /**
  * Convenience style module for an warning-filled discernible control (interactive).
  *
@@ -837,6 +935,24 @@ export const criticalFillSubtleControlStyles: Styles = Styles.fromProperties(
 );
 
 /**
+ * Convenience style module for an critical-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - critical subtle inverse background
+ * - critical readable foreground (a11y)
+ * - critical safety border
+ *
+ * @public
+ */
+export const criticalFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(criticalFillSubtleInverse, criticalStrokeReadableRecipe),
+        ...densityBorderStyles(criticalStrokeSafety),
+    },
+    "color.critical-fill-subtle-inverse-control",
+);
+
+/**
  * Convenience style module for an critical-filled discernible control (interactive).
  *
  * By default, the background meets accessibility for non-text elements, useful for a checked checkbox:
@@ -942,6 +1058,24 @@ export const neutralFillSubtleControlStyles: Styles = Styles.fromProperties(
         ...densityBorderStyles(neutralStrokeSafety),
     },
     "color.neutral-fill-subtle-control",
+);
+
+/**
+ * Convenience style module for a neutral-filled subtle inverse control (interactive).
+ *
+ * By default, only the foreground color meets accessibility, useful for a button or similar:
+ * - neutral subtle inverse background
+ * - neutral strong foreground (a11y)
+ * - neutral safety border
+ *
+ * @public
+ */
+export const neutralFillSubtleInverseControlStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundAndForeground(neutralFillSubtleInverse, neutralStrokeStrongRecipe),
+        ...densityBorderStyles(neutralStrokeSafety),
+    },
+    "color.neutral-fill-subtle-inverse-control",
 );
 
 /**
@@ -1277,30 +1411,26 @@ export const actionStyles: Styles = Styles.compose(
     "styles.action-control",
 );
 
-const inputCommonStyles = [
-    controlShapeStyles,
-    typeRampBaseStyles,
-    Styles.compose([
-        neutralOutlineDiscernibleControlStyles
-    ], {
-        backgroundFill: {
-            name: "color.input-common-background",
-            rest: fillColor,
-            hover: fillColor,
-            active: fillColor,
-            focus: fillColor,
-            disabled: neutralFillSubtle.disabled,
-        }
-    })
-    ,
-];
+/**
+ * @public
+ */
+export const inputBaseStyles = Styles.compose(
+    [
+        controlShapeStyles,
+        typeRampBaseStyles,
+        neutralFillSubtleInverseControlStyles,
+        neutralOutlineDiscernibleControlStyles,
+    ],
+    undefined,
+    "styles.input-base",
+);
 
 /**
  * @public
  */
 export const inputStyles: Styles = Styles.compose(
     [
-        ...inputCommonStyles,
+        inputBaseStyles,
         controlDensityStyles,
     ],
     undefined,
@@ -1312,7 +1442,7 @@ export const inputStyles: Styles = Styles.compose(
  */
 export const inputAutofillStyles: Styles = Styles.compose(
     [
-        ...inputCommonStyles,
+        inputBaseStyles,
         autofillOuterDensityStyles,
     ],
     undefined,

--- a/packages/adaptive-ui/src/design-tokens/modules.ts
+++ b/packages/adaptive-ui/src/design-tokens/modules.ts
@@ -1419,9 +1419,10 @@ export const inputBaseStyles = Styles.compose(
         controlShapeStyles,
         typeRampBaseStyles,
         neutralFillSubtleInverseControlStyles,
-        neutralOutlineDiscernibleControlStyles,
     ],
-    undefined,
+    {
+        ...densityBorderStyles(neutralStrokeDiscernible),
+    },
     "styles.input-base",
 );
 


### PR DESCRIPTION
# Pull Request

## Description

Added color recipes which apply the `subtle` delta values, but in inverse to the context color. One common example of this usage is where action components like Button appear as a subtle fill darker than the container, and input components like Text Field appear lighter.

Also applied to the default input treatment and separated the base input style rules out to allow for overriding.

## Reviewer Notes

Additive color recipes.

## Test Plan

Tested in Adaptive UI Explorer

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.