### PR TITLE
Expand styling capabilities to not assume `:host` container

### DIFF
--- a/change/@adaptive-web-adaptive-ui-3ea279c0-91e4-47db-8015-8b43925b9c60.json
+++ b/change/@adaptive-web-adaptive-ui-3ea279c0-91e4-47db-8015-8b43925b9c60.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Expand styling capabilities to not assume `:host` container",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-fee5fd32-8612-44e2-9b82-07a9b21b20e4.json
+++ b/change/@adaptive-web-adaptive-web-components-fee5fd32-8612-44e2-9b82-07a9b21b20e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Expand styling capabilities to not assume `:host` container",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/customize-component/src/index.ts
+++ b/examples/customize-component/src/index.ts
@@ -63,7 +63,7 @@ const myCheckboxDefinition = composeCheckbox(
             },
             {
                 target: {
-                    hostCondition: CheckboxAnatomy.conditions.checked,
+                    contextCondition: CheckboxAnatomy.conditions.checked,
                     part: CheckboxAnatomy.parts.control,
                 },
                 styles: accentFillReadableControlStyles,

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -101,6 +101,7 @@ export type ColorRecipeParams = {
 // @public
 export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
     conditions: TConditions;
+    context?: string;
     focus?: FocusDefinition<TParts>;
     interactivity?: InteractivityDefinition;
     parts: TParts;
@@ -299,8 +300,8 @@ export const Fill: {
 
 // @public
 export const Focus: {
-    readonly hostFocused: () => FocusDefinition<any>;
-    readonly hostChildFocused: <TParts>(indicatorPart: keyof TParts & string) => FocusDefinition<TParts>;
+    readonly contextFocused: () => FocusDefinition<any>;
+    readonly contextChildFocused: <TParts>(indicatorPart: keyof TParts & string) => FocusDefinition<TParts>;
     readonly partFocused: <TParts_1>(part: keyof TParts_1 & string) => FocusDefinition<TParts_1>;
     readonly partWithin: <TParts_2>(indicatorPart: keyof TParts_2 & string, focusablePart: keyof TParts_2 & string) => FocusDefinition<TParts_2>;
 };
@@ -482,13 +483,14 @@ export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDef
 
 // @public
 export interface StyleModuleTarget {
+    context?: string;
+    contextCondition?: string;
     focusSelector?: FocusSelector;
-    hostCondition?: string;
     // @beta
     ignoreInteractivity?: boolean;
     part?: string;
     partCondition?: string;
-    stateOnHost?: boolean;
+    stateOnContext?: boolean;
 }
 
 // @public

--- a/packages/adaptive-ui/src/modules/element-styles-renderer.ts
+++ b/packages/adaptive-ui/src/modules/element-styles-renderer.ts
@@ -185,7 +185,17 @@ export class ElementStylesRenderer {
     public static renderStyleRules(baseStyles: ComposableStyles[] = [], styleRules: StyleRules, anatomy?: ComponentAnatomy<any, any>) {
         for (const rule of styleRules) {
             const styles = Styles.fromDeclaration(rule);
-            const renderedStyles = new ElementStylesRenderer(styles).render(rule.target || {}, anatomy?.interactivity);
+
+            // Transform the target selector if necessary
+            const target = rule.target || {};
+            if (anatomy?.context && target.context === undefined) {
+                target.context = anatomy.context;
+                if (anatomy.context === target.part) {
+                    target.part = undefined;
+                }
+            }
+
+            const renderedStyles = new ElementStylesRenderer(styles).render(target, anatomy?.interactivity);
             baseStyles.push(renderedStyles);
         }
 

--- a/packages/adaptive-ui/src/modules/types.ts
+++ b/packages/adaptive-ui/src/modules/types.ts
@@ -36,6 +36,11 @@ export type ComponentParts = Record<string, string>;
  */
 export interface ComponentAnatomy<TConditions extends ComponentConditions, TParts extends ComponentParts> {
     /**
+     * The context element selector. Implementation defaults to `:host` if not provided.
+     */
+    context?: string;
+
+    /**
      * Description of the conditions for when the component is interactive or not.
      */
     interactivity?: InteractivityDefinition;
@@ -63,15 +68,20 @@ export interface ComponentAnatomy<TConditions extends ComponentConditions, TPart
  */
 export interface StyleModuleTarget {
     /**
-     * The condition to match at the host element level.
+     * The selector for the context element. Implementation defaults to `:host` if not provided.
      */
-    hostCondition?: string;
+    context?: string;
 
     /**
-     * Normally the state applies to the host, or if specified, the part. This option forces the state to the
-     * apply to the host, useful for styling the host state in only a portion of the child elements.
+     * The condition to match on the context element.
      */
-    stateOnHost?: boolean;
+    contextCondition?: string;
+
+    /**
+     * Normally the state applies to the context element, or if specified, the part. This option forces the state to the
+     * apply to the context element, useful for styling the context element state in only a portion of the child elements.
+     */
+    stateOnContext?: boolean;
 
     /**
      * The component part name to apply this style module.
@@ -79,7 +89,7 @@ export interface StyleModuleTarget {
     part?: string;
 
     /**
-     * The condition to match at the part element level.
+     * The condition to match on the part element.
      */
     partCondition?: string;
 
@@ -190,9 +200,9 @@ export interface FocusDefinition<TParts> {
  */
 export const Focus = {
     /**
-     * The simple case of the host element accepting and indicating focus.
+     * The simple case of the context element accepting and indicating focus.
      */
-    hostFocused: () => {
+    contextFocused: () => {
         return {
             focusTarget: {
                 ignoreInteractivity: true,
@@ -201,14 +211,14 @@ export const Focus = {
     },
 
     /**
-     * The host has focus, but a child element is the indicator.
+     * The context element has focus, but a child element is the indicator.
      *
      * @param indicatorPart - The part name of where to indicate focus.
      */
-    hostChildFocused: <TParts>(indicatorPart: keyof TParts & string) => {
+    contextChildFocused: <TParts>(indicatorPart: keyof TParts & string) => {
         return {
             focusTarget: {
-                stateOnHost: true,
+                stateOnContext: true,
                 part: indicatorPart,
                 ignoreInteractivity: true,
             },

--- a/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/anchor/anchor.styles.modules.ts
@@ -29,7 +29,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: AnchorAnatomy.conditions.noHref,
+            contextCondition: AnchorAnatomy.conditions.noHref,
             part: AnchorAnatomy.parts.control,
         },
         styles: neutralForegroundStrongElementStyles,

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -30,14 +30,14 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: BreadcrumbItemAnatomy.conditions.noHref,
+            contextCondition: BreadcrumbItemAnatomy.conditions.noHref,
             part: BreadcrumbItemAnatomy.parts.control,
         },
         styles: neutralForegroundStrongElementStyles,
     },
     {
         target : {
-            hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
             part: BreadcrumbItemAnatomy.parts.control,
             partCondition: BreadcrumbItemAnatomy.conditions.current,
         },
@@ -45,7 +45,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
             part: BreadcrumbItemAnatomy.parts.control,
         },
         styles: accentForegroundReadableControlStyles,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.styles.modules.ts
@@ -32,7 +32,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: CheckboxAnatomy.conditions.checked,
+            contextCondition: CheckboxAnatomy.conditions.checked,
             part: CheckboxAnatomy.parts.control,
         },
         styles: selectableSelectedStyles,

--- a/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
+++ b/packages/adaptive-web-components/src/components/checkbox/checkbox.template.ts
@@ -42,7 +42,7 @@ export const CheckboxAnatomy: ComponentAnatomy<typeof CheckboxConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: CheckboxConditions,
     parts: CheckboxParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.styles.modules.ts
@@ -24,13 +24,13 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: DataGridCellAnatomy.conditions.cellTypeColumnHeader,
+            contextCondition: DataGridCellAnatomy.conditions.cellTypeColumnHeader,
         },
         styles: labelTextStyles,
     },
     {
         target : {
-            hostCondition: DataGridCellAnatomy.conditions.cellTypeRowHeader,
+            contextCondition: DataGridCellAnatomy.conditions.cellTypeRowHeader,
         },
         styles: labelTextStyles,
     },

--- a/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
+++ b/packages/adaptive-web-components/src/components/data-grid-cell/data-grid-cell.template.ts
@@ -25,7 +25,7 @@ export const DataGridCellAnatomy: ComponentAnatomy<typeof DataGridCellConditions
     interactivity: Interactivity.never,
     conditions: DataGridCellConditions,
     parts: DataGridCellParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/divider/divider.styles.modules.ts
@@ -10,7 +10,7 @@ import { DividerAnatomy } from "./divider.template.js";
 export const styleModules: StyleRules = [
     {
         target : {
-            hostCondition: DividerAnatomy.conditions.horizontal,
+            contextCondition: DividerAnatomy.conditions.horizontal,
         },
         properties: {
             borderFillTop: neutralStrokeSubtle.rest,
@@ -20,7 +20,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: DividerAnatomy.conditions.vertical,
+            contextCondition: DividerAnatomy.conditions.vertical,
         },
         properties: {
             borderFillLeft: neutralStrokeSubtle.rest,

--- a/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
+++ b/packages/adaptive-web-components/src/components/flipper/flipper.template.ts
@@ -42,7 +42,7 @@ export const FlipperAnatomy: ComponentAnatomy<typeof FlipperConditions, typeof F
     interactivity: Interactivity.disabledAttribute,
     conditions: FlipperConditions,
     parts: FlipperParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/listbox-option/listbox-option.styles.modules.ts
@@ -18,7 +18,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: ListboxOptionAnatomy.conditions.selected,
+            contextCondition: ListboxOptionAnatomy.conditions.selected,
         },
         styles: selectableSelectedStyles,
     },

--- a/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
+++ b/packages/adaptive-web-components/src/components/listbox/listbox.template.ts
@@ -22,7 +22,7 @@ export const ListboxAnatomy: ComponentAnatomy<typeof ListboxConditions, typeof L
     interactivity: Interactivity.disabledAttribute,
     conditions: ListboxConditions,
     parts: ListboxParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
+++ b/packages/adaptive-web-components/src/components/menu-item/menu-item.template.ts
@@ -49,7 +49,7 @@ export const MenuItemAnatomy: ComponentAnatomy<typeof MenuItemConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: MenuItemConditions,
     parts: MenuItemParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
+++ b/packages/adaptive-web-components/src/components/picker-list-item/picker-list-item.template.ts
@@ -22,7 +22,7 @@ export const PickerListItemAnatomy: ComponentAnatomy<typeof PickerListItemCondit
     interactivity: Interactivity.always,
     conditions: PickerListItemConditions,
     parts: PickerListItemParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/picker-menu-option/picker-menu-option.styles.modules.ts
@@ -13,7 +13,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: PickerMenuOptionAnatomy.conditions.selected,
+            contextCondition: PickerMenuOptionAnatomy.conditions.selected,
         },
         styles: highlightFillReadableControlStyles,
     },

--- a/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.styles.modules.ts
@@ -36,7 +36,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: RadioAnatomy.conditions.checked,
+            contextCondition: RadioAnatomy.conditions.checked,
             part: RadioAnatomy.parts.control,
         },
         styles: [

--- a/packages/adaptive-web-components/src/components/radio/radio.template.ts
+++ b/packages/adaptive-web-components/src/components/radio/radio.template.ts
@@ -40,7 +40,7 @@ export const RadioAnatomy: ComponentAnatomy<typeof RadioConditions, typeof Radio
     interactivity: Interactivity.disabledAttribute,
     conditions: RadioConditions,
     parts: RadioParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/select/select.styles.modules.ts
@@ -30,7 +30,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: SelectAnatomy.conditions.isListbox,
+            contextCondition: SelectAnatomy.conditions.isListbox,
             part: SelectAnatomy.parts.listbox,
         },
         styles: [
@@ -40,7 +40,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: SelectAnatomy.conditions.isDropdown,
+            contextCondition: SelectAnatomy.conditions.isDropdown,
             part: SelectAnatomy.parts.listbox,
         },
         styles: flyoutStyles,

--- a/packages/adaptive-web-components/src/components/select/select.template.ts
+++ b/packages/adaptive-web-components/src/components/select/select.template.ts
@@ -43,7 +43,7 @@ export const SelectAnatomy: ComponentAnatomy<typeof SelectConditions, typeof Sel
     interactivity: Interactivity.disabledAttribute,
     conditions: SelectConditions,
     parts: SelectParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/skeleton/skeleton.styles.modules.ts
@@ -15,14 +15,14 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: SkeletonAnatomy.conditions.rectangle,
+            contextCondition: SkeletonAnatomy.conditions.rectangle,
         },
         styles: controlShapeStyles,
     },
     
     {
         target : {
-            hostCondition: SkeletonAnatomy.conditions.circle,
+            contextCondition: SkeletonAnatomy.conditions.circle,
         },
         styles: roundShapeStyles,
     },

--- a/packages/adaptive-web-components/src/components/slider/slider.template.ts
+++ b/packages/adaptive-web-components/src/components/slider/slider.template.ts
@@ -30,7 +30,7 @@ export const SliderAnatomy: ComponentAnatomy<typeof SliderConditions, typeof Sli
     interactivity: Interactivity.never,
     conditions: SliderConditions,
     parts: SliderParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.styles.modules.ts
@@ -36,7 +36,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            hostCondition: SwitchAnatomy.conditions.checked,
+            contextCondition: SwitchAnatomy.conditions.checked,
             part: SwitchAnatomy.parts.switch,
         },
         styles: [

--- a/packages/adaptive-web-components/src/components/switch/switch.template.ts
+++ b/packages/adaptive-web-components/src/components/switch/switch.template.ts
@@ -26,7 +26,7 @@ export const SwitchAnatomy: ComponentAnatomy<typeof SwitchConditions, typeof Swi
     interactivity: Interactivity.disabledAttribute,
     conditions: SwitchConditions,
     parts: SwitchParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/tab/tab.template.ts
+++ b/packages/adaptive-web-components/src/components/tab/tab.template.ts
@@ -22,7 +22,7 @@ export const TabAnatomy: ComponentAnatomy<typeof TabConditions, typeof TabParts>
     interactivity: Interactivity.disabledAttribute,
     conditions: TabConditions,
     parts: TabParts,
-    focus: Focus.hostFocused(),
+    focus: Focus.contextFocused(),
 };
 
 /**

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.template.ts
@@ -42,7 +42,7 @@ export const TreeItemAnatomy: ComponentAnatomy<typeof TreeItemConditions, typeof
     interactivity: Interactivity.disabledAttribute,
     conditions: TreeItemConditions,
     parts: TreeItemParts,
-    focus: Focus.hostChildFocused("control"),
+    focus: Focus.contextChildFocused("control"),
 };
 
 // TODO: Temporary copy of template until https://github.com/microsoft/fast/pull/6286/

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -67,7 +67,7 @@ export const globalStyleRules = (anatomy?: ComponentAnatomy<any, any>): StyleRul
         styles.push(
             {
                 target : {
-                    hostCondition: anatomy.interactivity.disabledSelector,
+                    contextCondition: anatomy.interactivity.disabledSelector,
                     part: "*",
                 },
                 styles: disabledStyles,


### PR DESCRIPTION
# Pull Request

## Description

Much of the styling generation logic assumes the styles are in the context of a custom element. The Adaptive UI styling generation also works really well for other component frameworks and plain html if unique class names are used.

This PR removes the assumption that the containing element is `:host` and better enables other scenarios.

### Issues

Related to #83

## Reviewer Notes

Renamed a few occurrences of `host` to `context`. I was specifically avoiding words with meaning in css like `root`, `host`, and `scope`.

## Test Plan

Tested in Storybook

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.