### PR TITLE
Adaptive UI: Added support for overriding interactive state selectors

### DIFF
--- a/change/@adaptive-web-adaptive-ui-e82ee743-0977-4df0-9922-cc67bae3b821.json
+++ b/change/@adaptive-web-adaptive-ui-e82ee743-0977-4df0-9922-cc67bae3b821.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Adaptive UI: Added support for overriding interactive state selectors - Naming and type cleanup around interactive states",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-0c4d7c77-d485-4550-91c3-93ac0004eb98.json
+++ b/change/@adaptive-web-adaptive-web-components-0c4d7c77-d485-4550-91c3-93ac0004eb98.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated Adaptive UI interactive state support",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -165,7 +165,7 @@ export function createTokenColorRecipeWithPalette<T>(recipeToken: TypedDesignTok
 export function createTokenColorSet(recipeToken: TypedDesignToken<InteractiveColorRecipe>): InteractiveTokenGroup<Swatch>;
 
 // @public
-export function createTokenDelta(baseName: string, state: keyof InteractiveSwatchSet, value: number | DesignToken<number>): TypedDesignToken<number>;
+export function createTokenDelta(baseName: string, state: InteractiveState, value: number | DesignToken<number>): TypedDesignToken<number>;
 
 // @public
 export function createTokenDimension(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<string>;
@@ -313,9 +313,6 @@ export interface FocusDefinition<TParts> {
 }
 
 // @public
-export type FocusSelector = "focus" | "focus-visible" | "focus-within";
-
-// @public
 export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Color, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveSwatchSet;
 
 // @public
@@ -337,38 +334,45 @@ export type InteractiveColorRecipePalette = ColorRecipePalette<InteractiveSwatch
 export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractiveSwatchSet>;
 
 // @public
-export interface InteractiveSet<T> {
-    active: T;
-    disabled: T;
-    focus: T;
-    hover: T;
-    rest: T;
+export enum InteractiveState {
+    active = "active",
+    disabled = "disabled",
+    focus = "focus",
+    hover = "hover",
+    rest = "rest"
 }
 
 // @public
-export interface InteractiveSwatchSet extends InteractiveSet<Swatch | null> {
+export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {
 }
 
 // @public
 export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
 
 // @public
-export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveSet<TypedCSSDesignToken<T>> {
+export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveValues<TypedCSSDesignToken<T>> {
 }
+
+// @public
+export type InteractiveValues<T> = {
+    [key in InteractiveState]: T;
+};
 
 // @public
 export const Interactivity: {
     readonly disabledAttribute: InteractivityDefinition;
+    readonly disabledClass: InteractivityDefinition;
     readonly hrefAttribute: InteractivityDefinition;
     readonly always: InteractivityDefinition;
     readonly never: InteractivityDefinition;
 };
 
 // @public
-export interface InteractivityDefinition {
-    disabledSelector?: string;
-    interactivitySelector?: string;
-}
+export type InteractivityDefinition = {
+    [key in InteractiveState]?: string;
+} & {
+    interactive?: string;
+};
 
 // @public
 export function isDark(color: RelativeLuminance): boolean;
@@ -377,7 +381,7 @@ export function isDark(color: RelativeLuminance): boolean;
 export function luminanceSwatch(luminance: number): Swatch;
 
 // @public
-export function makeSelector(params: StyleModuleEvaluateParameters, state?: StateSelector): string;
+export function makeSelector(params: StyleModuleEvaluateParameters, state: InteractiveState): string;
 
 // @public (undocumented)
 export const Padding: {
@@ -470,9 +474,6 @@ export class Shadow implements CSSDirective {
 export type ShadowValue = Shadow | DesignTokenMultiValue<Shadow> | string;
 
 // @public
-export type StateSelector = "hover" | "active" | FocusSelector | "disabled";
-
-// @public
 export type StyleDeclaration = {
     styles?: Styles | Iterable<Styles>;
     properties?: StyleProperties;
@@ -485,7 +486,6 @@ export type StyleModuleEvaluateParameters = StyleModuleTarget & InteractivityDef
 export interface StyleModuleTarget {
     context?: string;
     contextCondition?: string;
-    focusSelector?: FocusSelector;
     // @beta
     ignoreInteractivity?: boolean;
     part?: string;
@@ -591,7 +591,7 @@ export class Styles {
 }
 
 // @public
-export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string | number;
+export type StyleValue = CSSDesignToken<any> | InteractiveValues<any | null> | CSSDirective | string | number;
 
 // @public
 export class Swatch extends Color {

--- a/packages/adaptive-ui/src/color/recipe.ts
+++ b/packages/adaptive-ui/src/color/recipe.ts
@@ -1,5 +1,5 @@
 import { Recipe, RecipeEvaluate, RecipeEvaluateOptional, RecipeOptional } from "../recipes.js";
-import { InteractiveSet } from "../types.js";
+import { InteractiveValues } from "../types.js";
 import { Palette } from "./palette.js";
 import { Swatch } from "./swatch.js";
 
@@ -87,7 +87,7 @@ export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<I
  *
  * @public
  */
-export interface InteractiveSwatchSet extends InteractiveSet<Swatch | null> {}
+export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {}
 
 /**
  * A recipe that evaluates based on an interactive set of color values.

--- a/packages/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/adaptive-ui/src/design-tokens/color.ts
@@ -24,6 +24,7 @@ import {
 } from "../token-helpers-color.js";
 import { createNonCss, createTokenNonCss, createTokenSwatch } from "../token-helpers.js";
 import { DesignTokenType, TypedDesignToken } from "../adaptive-design-tokens.js";
+import { InteractiveState } from "../types.js";
 import { accentPalette, criticalPalette, disabledPalette, highlightPalette, infoPalette, neutralPalette, successPalette, warningPalette } from "./palette.js";
 
 /**
@@ -220,19 +221,19 @@ export const blackOrWhiteReadableRecipe = createTokenColorRecipeBySet<Interactiv
 const fillStealthName = "fill-stealth";
 
 /** @public */
-export const fillStealthRestDelta = createTokenDelta(fillStealthName, "rest", 0);
+export const fillStealthRestDelta = createTokenDelta(fillStealthName, InteractiveState.rest, 0);
 
 /** @public */
-export const fillStealthHoverDelta = createTokenDelta(fillStealthName, "hover", 3);
+export const fillStealthHoverDelta = createTokenDelta(fillStealthName, InteractiveState.hover, 3);
 
 /** @public */
-export const fillStealthActiveDelta = createTokenDelta(fillStealthName, "active", 2);
+export const fillStealthActiveDelta = createTokenDelta(fillStealthName, InteractiveState.active, 2);
 
 /** @public */
-export const fillStealthFocusDelta = createTokenDelta(fillStealthName, "focus", 0);
+export const fillStealthFocusDelta = createTokenDelta(fillStealthName, InteractiveState.focus, 0);
 
 /** @public */
-export const fillStealthDisabledDelta = createTokenDelta(fillStealthName, "disabled", 0);
+export const fillStealthDisabledDelta = createTokenDelta(fillStealthName, InteractiveState.disabled, 0);
 
 /** @public */
 export const fillStealthRecipe = createTokenColorRecipeForPalette(
@@ -256,19 +257,19 @@ export const fillStealthRecipe = createTokenColorRecipeForPalette(
 const fillSubtleName = "fill-subtle";
 
 /** @public */
-export const fillSubtleRestDelta = createTokenDelta(fillSubtleName, "rest", 2);
+export const fillSubtleRestDelta = createTokenDelta(fillSubtleName, InteractiveState.rest, 2);
 
 /** @public */
-export const fillSubtleHoverDelta = createTokenDelta(fillSubtleName, "hover", 3);
+export const fillSubtleHoverDelta = createTokenDelta(fillSubtleName, InteractiveState.hover, 3);
 
 /** @public */
-export const fillSubtleActiveDelta = createTokenDelta(fillSubtleName, "active", 1);
+export const fillSubtleActiveDelta = createTokenDelta(fillSubtleName, InteractiveState.active, 1);
 
 /** @public */
-export const fillSubtleFocusDelta = createTokenDelta(fillSubtleName, "focus", 2);
+export const fillSubtleFocusDelta = createTokenDelta(fillSubtleName, InteractiveState.focus, 2);
 
 /** @public */
-export const fillSubtleDisabledDelta = createTokenDelta(fillSubtleName, "disabled", 2);
+export const fillSubtleDisabledDelta = createTokenDelta(fillSubtleName, InteractiveState.disabled, 2);
 
 /** @public */
 export const fillSubtleRecipe = createTokenColorRecipeForPalette(
@@ -307,19 +308,19 @@ export const fillSubtleInverseRecipe = createTokenColorRecipeForPalette(
 const fillDiscernibleName = "fill-discernible";
 
 /** @public */
-export const fillDiscernibleRestDelta = createTokenDelta(fillDiscernibleName, "rest", 0);
+export const fillDiscernibleRestDelta = createTokenDelta(fillDiscernibleName, InteractiveState.rest, 0);
 
 /** @public */
-export const fillDiscernibleHoverDelta = createTokenDelta(fillDiscernibleName, "hover", 6);
+export const fillDiscernibleHoverDelta = createTokenDelta(fillDiscernibleName, InteractiveState.hover, 6);
 
 /** @public */
-export const fillDiscernibleActiveDelta = createTokenDelta(fillDiscernibleName, "active", 3);
+export const fillDiscernibleActiveDelta = createTokenDelta(fillDiscernibleName, InteractiveState.active, 3);
 
 /** @public */
-export const fillDiscernibleFocusDelta = createTokenDelta(fillDiscernibleName, "focus", 0);
+export const fillDiscernibleFocusDelta = createTokenDelta(fillDiscernibleName, InteractiveState.focus, 0);
 
 /** @public */
-export const fillDiscernibleDisabledDelta = createTokenDelta(fillDiscernibleName, "disabled", 2);
+export const fillDiscernibleDisabledDelta = createTokenDelta(fillDiscernibleName, InteractiveState.disabled, 2);
 
 /** @public */
 export const fillDiscernibleRecipe = createTokenColorRecipeForPalette(
@@ -342,19 +343,19 @@ export const fillDiscernibleRecipe = createTokenColorRecipeForPalette(
 const fillReadableName = "fill-readable";
 
 /** @public */
-export const fillReadableRestDelta = createTokenDelta(fillReadableName, "rest", 0);
+export const fillReadableRestDelta = createTokenDelta(fillReadableName, InteractiveState.rest, 0);
 
 /** @public */
-export const fillReadableHoverDelta = createTokenDelta(fillReadableName, "hover", -2);
+export const fillReadableHoverDelta = createTokenDelta(fillReadableName, InteractiveState.hover, -2);
 
 /** @public */
-export const fillReadableActiveDelta = createTokenDelta(fillReadableName, "active", 2);
+export const fillReadableActiveDelta = createTokenDelta(fillReadableName, InteractiveState.active, 2);
 
 /** @public */
-export const fillReadableFocusDelta = createTokenDelta(fillReadableName, "focus", 0);
+export const fillReadableFocusDelta = createTokenDelta(fillReadableName, InteractiveState.focus, 0);
 
 /** @public */
-export const fillReadableDisabledDelta = createTokenDelta(fillReadableName, "disabled", 2);
+export const fillReadableDisabledDelta = createTokenDelta(fillReadableName, InteractiveState.disabled, 2);
 
 /** @public */
 export const fillReadableRecipe = createTokenColorRecipeForPalette(
@@ -377,19 +378,19 @@ export const fillReadableRecipe = createTokenColorRecipeForPalette(
 const strokeSafetyName = "stroke-safety";
 
 /** @public */
-export const strokeSafetyRestDelta = createTokenDelta(strokeSafetyName, "rest", 0);
+export const strokeSafetyRestDelta = createTokenDelta(strokeSafetyName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeSafetyHoverDelta = createTokenDelta(strokeSafetyName, "hover", 6);
+export const strokeSafetyHoverDelta = createTokenDelta(strokeSafetyName, InteractiveState.hover, 6);
 
 /** @public */
-export const strokeSafetyActiveDelta = createTokenDelta(strokeSafetyName, "active", -6);
+export const strokeSafetyActiveDelta = createTokenDelta(strokeSafetyName, InteractiveState.active, -6);
 
 /** @public */
-export const strokeSafetyFocusDelta = createTokenDelta(strokeSafetyName, "focus", 0);
+export const strokeSafetyFocusDelta = createTokenDelta(strokeSafetyName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeSafetyDisabledDelta = createTokenDelta(strokeSafetyName, "disabled", 0);
+export const strokeSafetyDisabledDelta = createTokenDelta(strokeSafetyName, InteractiveState.disabled, 0);
 
 /** @public */
 export const strokeSafetyRecipe = createTokenColorRecipeForPalette(
@@ -415,19 +416,19 @@ export const strokeSafetyRecipe = createTokenColorRecipeForPalette(
 const strokeStealthName = "stroke-stealth";
 
 /** @public */
-export const strokeStealthRestDelta = createTokenDelta(strokeStealthName, "rest", 0);
+export const strokeStealthRestDelta = createTokenDelta(strokeStealthName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeStealthHoverDelta = createTokenDelta(strokeStealthName, "hover", 6);
+export const strokeStealthHoverDelta = createTokenDelta(strokeStealthName, InteractiveState.hover, 6);
 
 /** @public */
-export const strokeStealthActiveDelta = createTokenDelta(strokeStealthName, "active", -6);
+export const strokeStealthActiveDelta = createTokenDelta(strokeStealthName, InteractiveState.active, -6);
 
 /** @public */
-export const strokeStealthFocusDelta = createTokenDelta(strokeStealthName, "focus", 0);
+export const strokeStealthFocusDelta = createTokenDelta(strokeStealthName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeStealthDisabledDelta = createTokenDelta(strokeStealthName, "disabled", 0);
+export const strokeStealthDisabledDelta = createTokenDelta(strokeStealthName, InteractiveState.disabled, 0);
 
 /** @public */
 export const strokeStealthRecipe = createTokenColorRecipeForPalette(
@@ -452,19 +453,19 @@ export const strokeStealthRecipe = createTokenColorRecipeForPalette(
 const strokeSubtleName = "stroke-subtle";
 
 /** @public */
-export const strokeSubtleRestDelta = createTokenDelta(strokeSubtleName, "rest", 0);
+export const strokeSubtleRestDelta = createTokenDelta(strokeSubtleName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeSubtleHoverDelta = createTokenDelta(strokeSubtleName, "hover", 4);
+export const strokeSubtleHoverDelta = createTokenDelta(strokeSubtleName, InteractiveState.hover, 4);
 
 /** @public */
-export const strokeSubtleActiveDelta = createTokenDelta(strokeSubtleName, "active", -2);
+export const strokeSubtleActiveDelta = createTokenDelta(strokeSubtleName, InteractiveState.active, -2);
 
 /** @public */
-export const strokeSubtleFocusDelta = createTokenDelta(strokeSubtleName, "focus", 0);
+export const strokeSubtleFocusDelta = createTokenDelta(strokeSubtleName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeSubtleDisabledDelta = createTokenDelta(strokeSubtleName, "disabled", 8);
+export const strokeSubtleDisabledDelta = createTokenDelta(strokeSubtleName, InteractiveState.disabled, 8);
 
 /** @public */
 export const strokeSubtleRecipe = createTokenColorRecipeForPalette(
@@ -487,19 +488,19 @@ export const strokeSubtleRecipe = createTokenColorRecipeForPalette(
 const strokeDiscernibleName = "stroke-discernible";
 
 /** @public */
-export const strokeDiscernibleRestDelta = createTokenDelta(strokeDiscernibleName, "rest", 0);
+export const strokeDiscernibleRestDelta = createTokenDelta(strokeDiscernibleName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeDiscernibleHoverDelta = createTokenDelta(strokeDiscernibleName, "hover", 8);
+export const strokeDiscernibleHoverDelta = createTokenDelta(strokeDiscernibleName, InteractiveState.hover, 8);
 
 /** @public */
-export const strokeDiscernibleActiveDelta = createTokenDelta(strokeDiscernibleName, "active", -4);
+export const strokeDiscernibleActiveDelta = createTokenDelta(strokeDiscernibleName, InteractiveState.active, -4);
 
 /** @public */
-export const strokeDiscernibleFocusDelta = createTokenDelta(strokeDiscernibleName, "focus", 0);
+export const strokeDiscernibleFocusDelta = createTokenDelta(strokeDiscernibleName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeDiscernibleDisabledDelta = createTokenDelta(strokeDiscernibleName, "disabled", 8);
+export const strokeDiscernibleDisabledDelta = createTokenDelta(strokeDiscernibleName, InteractiveState.disabled, 8);
 
 /** @public */
 export const strokeDiscernibleRecipe = createTokenColorRecipeForPalette(
@@ -522,19 +523,19 @@ export const strokeDiscernibleRecipe = createTokenColorRecipeForPalette(
 const strokeReadableName = "stroke-readable";
 
 /** @public */
-export const strokeReadableRestDelta = createTokenDelta(strokeReadableName, "rest", 0);
+export const strokeReadableRestDelta = createTokenDelta(strokeReadableName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeReadableHoverDelta = createTokenDelta(strokeReadableName, "hover", 6);
+export const strokeReadableHoverDelta = createTokenDelta(strokeReadableName, InteractiveState.hover, 6);
 
 /** @public */
-export const strokeReadableActiveDelta = createTokenDelta(strokeReadableName, "active", -6);
+export const strokeReadableActiveDelta = createTokenDelta(strokeReadableName, InteractiveState.active, -6);
 
 /** @public */
-export const strokeReadableFocusDelta = createTokenDelta(strokeReadableName, "focus", 0);
+export const strokeReadableFocusDelta = createTokenDelta(strokeReadableName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeReadableDisabledDelta = createTokenDelta(strokeReadableName, "disabled", 8);
+export const strokeReadableDisabledDelta = createTokenDelta(strokeReadableName, InteractiveState.disabled, 8);
 
 /** @public */
 export const strokeReadableRecipe = createTokenColorRecipeForPalette(
@@ -560,19 +561,19 @@ const strokeStrongName = "stroke-strong";
 export const strokeStrongMinContrast = createTokenMinContrast(strokeStrongName, 12);
 
 /** @public */
-export const strokeStrongRestDelta = createTokenDelta(strokeStrongName, "rest", 0);
+export const strokeStrongRestDelta = createTokenDelta(strokeStrongName, InteractiveState.rest, 0);
 
 /** @public */
-export const strokeStrongHoverDelta = createTokenDelta(strokeStrongName, "hover", 10);
+export const strokeStrongHoverDelta = createTokenDelta(strokeStrongName, InteractiveState.hover, 10);
 
 /** @public */
-export const strokeStrongActiveDelta = createTokenDelta(strokeStrongName, "active", -10);
+export const strokeStrongActiveDelta = createTokenDelta(strokeStrongName, InteractiveState.active, -10);
 
 /** @public */
-export const strokeStrongFocusDelta = createTokenDelta(strokeStrongName, "focus", 0);
+export const strokeStrongFocusDelta = createTokenDelta(strokeStrongName, InteractiveState.focus, 0);
 
 /** @public */
-export const strokeStrongDisabledDelta = createTokenDelta(strokeStrongName, "disabled", 8);
+export const strokeStrongDisabledDelta = createTokenDelta(strokeStrongName, InteractiveState.disabled, 8);
 
 /** @public */
 export const strokeStrongRecipe = createTokenColorRecipeForPalette(

--- a/packages/adaptive-ui/src/design-tokens/layer.ts
+++ b/packages/adaptive-ui/src/design-tokens/layer.ts
@@ -8,6 +8,7 @@ import { luminanceSwatch } from "../color/utilities/luminance-swatch.js";
 import { StyleProperty } from "../modules/types.js";
 import { createTokenNonCss, createTokenRecipe, createTokenSwatch } from "../token-helpers.js";
 import { createTokenColorRecipe, createTokenColorSet, createTokenDelta } from "../token-helpers-color.js";
+import { InteractiveState } from "../types.js";
 import { fillColor } from "./color.js";
 import { neutralPalette } from "./palette.js";
 
@@ -55,7 +56,7 @@ export const layerFillBaseLuminance = createTokenNonCss<number>(`${layerFillName
  *
  * @public
  */
-export const layerFillRestDelta = createTokenDelta(layerFillName, "rest", -2);
+export const layerFillRestDelta = createTokenDelta(layerFillName, InteractiveState.rest, -2);
 
 /**
  * @public
@@ -68,28 +69,28 @@ export const layerFillDelta = layerFillRestDelta;
  *
  * @public
  */
-export const layerFillHoverDelta = createTokenDelta(layerFillName, "hover", -3);
+export const layerFillHoverDelta = createTokenDelta(layerFillName, InteractiveState.hover, -3);
 
 /**
  * The offset from the container for "Interactive" active state, {@link layerFillInteractiveActive}.
  *
  * @public
  */
-export const layerFillActiveDelta = createTokenDelta(layerFillName, "active", -1);
+export const layerFillActiveDelta = createTokenDelta(layerFillName, InteractiveState.active, -1);
 
 /**
  * The offset from the container for "Interactive" focus state, {@link layerFillInteractiveFocus}.
  *
  * @public
  */
-export const layerFillFocusDelta = createTokenDelta(layerFillName, "focus", -3);
+export const layerFillFocusDelta = createTokenDelta(layerFillName, InteractiveState.focus, -3);
 
 /**
  * The offset from the container for "Interactive" disabled state, {@link layerFillInteractiveDisabled}.
  *
  * @public
  */
-export const layerFillDisabledDelta = createTokenDelta(layerFillName, "disabled", -1);
+export const layerFillDisabledDelta = createTokenDelta(layerFillName, InteractiveState.disabled, -1);
 
 const layerFillFixedName = `${layerFillName}-fixed`;
 

--- a/packages/adaptive-ui/src/migration/color.ts
+++ b/packages/adaptive-ui/src/migration/color.ts
@@ -84,6 +84,7 @@ import {
     strokeSubtleRestDelta
 } from "../design-tokens/color.js";
 import { neutralPalette } from "../design-tokens/palette.js";
+import { InteractiveState } from "../types.js";
 
 /**
  * Convenience values for WCAG contrast requirements.
@@ -143,30 +144,30 @@ export const foregroundOnAccentFillReadableFocus = foregroundOnAccentFillReadabl
 const accentFillReadableName = "accent-fill-readable";
 
 /** @public @deprecated Use `fillReadableRestDelta` instead. */
-export const accentFillReadableRestDelta = createTokenDelta(accentFillReadableName, "rest", fillReadableRestDelta);
+export const accentFillReadableRestDelta = createTokenDelta(accentFillReadableName, InteractiveState.rest, fillReadableRestDelta);
 
 /** @public @deprecated Use `fillReadableHoverDelta` instead. */
-export const accentFillReadableHoverDelta = createTokenDelta(accentFillReadableName, "hover", fillReadableHoverDelta);
+export const accentFillReadableHoverDelta = createTokenDelta(accentFillReadableName, InteractiveState.hover, fillReadableHoverDelta);
 
 /** @public @deprecated Use `fillReadableActiveDelta` instead. */
-export const accentFillReadableActiveDelta = createTokenDelta(accentFillReadableName, "active", fillReadableActiveDelta);
+export const accentFillReadableActiveDelta = createTokenDelta(accentFillReadableName, InteractiveState.active, fillReadableActiveDelta);
 
 /** @public @deprecated Use `fillReadableFocusDelta` instead. */
-export const accentFillReadableFocusDelta = createTokenDelta(accentFillReadableName, "focus", fillReadableFocusDelta);
+export const accentFillReadableFocusDelta = createTokenDelta(accentFillReadableName, InteractiveState.focus, fillReadableFocusDelta);
 
 const accentStrokeReadableName = "accent-stroke-readable";
 
 /** @public @deprecated Use `strokeReadableRestDelta` instead. */
-export const accentStrokeReadableRestDelta = createTokenDelta(accentStrokeReadableName, "rest", strokeReadableRestDelta);
+export const accentStrokeReadableRestDelta = createTokenDelta(accentStrokeReadableName, InteractiveState.rest, strokeReadableRestDelta);
 
 /** @public @deprecated Use `strokeReadableHoverDelta` instead. */
-export const accentStrokeReadableHoverDelta = createTokenDelta(accentStrokeReadableName, "hover", strokeReadableHoverDelta);
+export const accentStrokeReadableHoverDelta = createTokenDelta(accentStrokeReadableName, InteractiveState.hover, strokeReadableHoverDelta);
 
 /** @public @deprecated Use `strokeReadableActiveDelta` instead. */
-export const accentStrokeReadableActiveDelta = createTokenDelta(accentStrokeReadableName, "active", strokeReadableActiveDelta);
+export const accentStrokeReadableActiveDelta = createTokenDelta(accentStrokeReadableName, InteractiveState.active, strokeReadableActiveDelta);
 
 /** @public @deprecated Use `strokeReadableFocusDelta` instead. */
-export const accentStrokeReadableFocusDelta = createTokenDelta(accentStrokeReadableName, "focus", strokeReadableFocusDelta);
+export const accentStrokeReadableFocusDelta = createTokenDelta(accentStrokeReadableName, InteractiveState.focus, strokeReadableFocusDelta);
 
 /** @public @deprecated use "Readable" instead */
 export const accentFillRestDelta = accentFillReadableRestDelta;
@@ -240,86 +241,86 @@ export const accentForegroundFocus = accentStrokeReadableFocus;
 const neutralFillStealthName = "neutral-fill-stealth";
 
 /** @public @deprecated Use `fillStealthRestDelta` instead. */
-export const neutralFillStealthRestDelta = createTokenDelta(neutralFillStealthName, "rest", fillStealthRestDelta);
+export const neutralFillStealthRestDelta = createTokenDelta(neutralFillStealthName, InteractiveState.rest, fillStealthRestDelta);
 
 /** @public @deprecated Use `fillStealthRestDelta` instead. */
-export const neutralFillStealthHoverDelta = createTokenDelta(neutralFillStealthName, "hover", fillStealthHoverDelta);
+export const neutralFillStealthHoverDelta = createTokenDelta(neutralFillStealthName, InteractiveState.hover, fillStealthHoverDelta);
 
 /** @public @deprecated Use `fillStealthRestDelta` instead. */
-export const neutralFillStealthActiveDelta = createTokenDelta(neutralFillStealthName, "active", fillStealthActiveDelta);
+export const neutralFillStealthActiveDelta = createTokenDelta(neutralFillStealthName, InteractiveState.active, fillStealthActiveDelta);
 
 /** @public @deprecated Use `fillStealthRestDelta` instead. */
-export const neutralFillStealthFocusDelta = createTokenDelta(neutralFillStealthName, "focus", fillStealthFocusDelta);
+export const neutralFillStealthFocusDelta = createTokenDelta(neutralFillStealthName, InteractiveState.focus, fillStealthFocusDelta);
 
 const neutralFillSubtleName = "neutral-fill-subtle";
 
 /** @public @deprecated Use `fillSubtleRestDelta` instead. */
-export const neutralFillSubtleRestDelta = createTokenDelta(neutralFillSubtleName, "rest", fillSubtleRestDelta);
+export const neutralFillSubtleRestDelta = createTokenDelta(neutralFillSubtleName, InteractiveState.rest, fillSubtleRestDelta);
 
 /** @public @deprecated Use `fillSubtleHoverDelta` instead. */
-export const neutralFillSubtleHoverDelta = createTokenDelta(neutralFillSubtleName, "hover", fillSubtleHoverDelta);
+export const neutralFillSubtleHoverDelta = createTokenDelta(neutralFillSubtleName, InteractiveState.hover, fillSubtleHoverDelta);
 
 /** @public @deprecated Use `fillSubtleActiveDelta` instead. */
-export const neutralFillSubtleActiveDelta = createTokenDelta(neutralFillSubtleName, "active", fillSubtleActiveDelta);
+export const neutralFillSubtleActiveDelta = createTokenDelta(neutralFillSubtleName, InteractiveState.active, fillSubtleActiveDelta);
 
 /** @public @deprecated Use `fillSubtleFocusDelta` instead. */
-export const neutralFillSubtleFocusDelta = createTokenDelta(neutralFillSubtleName, "focus", fillSubtleFocusDelta);
+export const neutralFillSubtleFocusDelta = createTokenDelta(neutralFillSubtleName, InteractiveState.focus, fillSubtleFocusDelta);
 
 const neutralFillDiscernibleName = "neutral-fill-discernible";
 
 /** @public @deprecated Use `fillDiscernibleRestDelta` instead. */
-export const neutralFillDiscernibleRestDelta = createTokenDelta(neutralFillDiscernibleName, "rest", fillDiscernibleRestDelta);
+export const neutralFillDiscernibleRestDelta = createTokenDelta(neutralFillDiscernibleName, InteractiveState.rest, fillDiscernibleRestDelta);
 
 /** @public @deprecated Use `fillDiscernibleRestDelta` instead. */
-export const neutralFillDiscernibleHoverDelta = createTokenDelta(neutralFillDiscernibleName, "rest", fillDiscernibleHoverDelta);
+export const neutralFillDiscernibleHoverDelta = createTokenDelta(neutralFillDiscernibleName, InteractiveState.rest, fillDiscernibleHoverDelta);
 
 /** @public @deprecated Use `fillDiscernibleRestDelta` instead. */
-export const neutralFillDiscernibleActiveDelta = createTokenDelta(neutralFillDiscernibleName, "rest", fillDiscernibleActiveDelta);
+export const neutralFillDiscernibleActiveDelta = createTokenDelta(neutralFillDiscernibleName, InteractiveState.rest, fillDiscernibleActiveDelta);
 
 /** @public @deprecated Use `fillDiscernibleRestDelta` instead. */
-export const neutralFillDiscernibleFocusDelta = createTokenDelta(neutralFillDiscernibleName, "rest", fillDiscernibleFocusDelta);
+export const neutralFillDiscernibleFocusDelta = createTokenDelta(neutralFillDiscernibleName, InteractiveState.rest, fillDiscernibleFocusDelta);
 
 const neutralStrokeSubtleName = "neutral-stroke-subtle";
 
 /** @public @deprecated Use `strokeSubtleRestDelta` instead. */
-export const neutralStrokeSubtleRestDelta = createTokenDelta(neutralStrokeSubtleName, "rest", strokeSubtleRestDelta);
+export const neutralStrokeSubtleRestDelta = createTokenDelta(neutralStrokeSubtleName, InteractiveState.rest, strokeSubtleRestDelta);
 
 /** @public @deprecated Use `strokeSubtleHoverDelta` instead. */
-export const neutralStrokeSubtleHoverDelta = createTokenDelta(neutralStrokeSubtleName, "hover", strokeSubtleHoverDelta);
+export const neutralStrokeSubtleHoverDelta = createTokenDelta(neutralStrokeSubtleName, InteractiveState.hover, strokeSubtleHoverDelta);
 
 /** @public @deprecated Use `strokeSubtleActiveDelta` instead. */
-export const neutralStrokeSubtleActiveDelta = createTokenDelta(neutralStrokeSubtleName, "active", strokeSubtleActiveDelta);
+export const neutralStrokeSubtleActiveDelta = createTokenDelta(neutralStrokeSubtleName, InteractiveState.active, strokeSubtleActiveDelta);
 
 /** @public @deprecated Use `strokeSubtleFocusDelta` instead. */
-export const neutralStrokeSubtleFocusDelta = createTokenDelta(neutralStrokeSubtleName, "focus", strokeSubtleFocusDelta);
+export const neutralStrokeSubtleFocusDelta = createTokenDelta(neutralStrokeSubtleName, InteractiveState.focus, strokeSubtleFocusDelta);
 
 const neutralStrokeDiscernibleName = "neutral-stroke-discernible";
 
 /** @public @deprecated Use `strokeDiscernibleRestDelta` instead. */
-export const neutralStrokeDiscernibleRestDelta = createTokenDelta(neutralStrokeDiscernibleName, "rest", strokeDiscernibleRestDelta);
+export const neutralStrokeDiscernibleRestDelta = createTokenDelta(neutralStrokeDiscernibleName, InteractiveState.rest, strokeDiscernibleRestDelta);
 
 /** @public @deprecated Use `strokeDiscernibleHoverDelta` instead. */
-export const neutralStrokeDiscernibleHoverDelta = createTokenDelta(neutralStrokeDiscernibleName, "hover", strokeDiscernibleHoverDelta);
+export const neutralStrokeDiscernibleHoverDelta = createTokenDelta(neutralStrokeDiscernibleName, InteractiveState.hover, strokeDiscernibleHoverDelta);
 
 /** @public @deprecated Use `strokeDiscernibleActiveDelta` instead. */
-export const neutralStrokeDiscernibleActiveDelta = createTokenDelta(neutralStrokeDiscernibleName, "active", strokeDiscernibleActiveDelta);
+export const neutralStrokeDiscernibleActiveDelta = createTokenDelta(neutralStrokeDiscernibleName, InteractiveState.active, strokeDiscernibleActiveDelta);
 
 /** @public @deprecated Use `strokeDiscernibleFocusDelta` instead. */
-export const neutralStrokeDiscernibleFocusDelta = createTokenDelta(neutralStrokeDiscernibleName, "focus", strokeDiscernibleFocusDelta);
+export const neutralStrokeDiscernibleFocusDelta = createTokenDelta(neutralStrokeDiscernibleName, InteractiveState.focus, strokeDiscernibleFocusDelta);
 
 const neutralStrokeReadableName = "neutral-stroke-readable";
 
 /** @public @deprecated Use `strokeReadableRestDelta` instead. */
-export const neutralStrokeReadableRestDelta = createTokenDelta(neutralStrokeReadableName, "rest", strokeReadableRestDelta);
+export const neutralStrokeReadableRestDelta = createTokenDelta(neutralStrokeReadableName, InteractiveState.rest, strokeReadableRestDelta);
 
 /** @public @deprecated Use `strokeReadableHoverDelta` instead. */
-export const neutralStrokeReadableHoverDelta = createTokenDelta(neutralStrokeReadableName, "hover", strokeReadableHoverDelta);
+export const neutralStrokeReadableHoverDelta = createTokenDelta(neutralStrokeReadableName, InteractiveState.hover, strokeReadableHoverDelta);
 
 /** @public @deprecated Use `strokeReadableActiveDelta` instead. */
-export const neutralStrokeReadableActiveDelta = createTokenDelta(neutralStrokeReadableName, "active", strokeReadableActiveDelta);
+export const neutralStrokeReadableActiveDelta = createTokenDelta(neutralStrokeReadableName, InteractiveState.active, strokeReadableActiveDelta);
 
 /** @public @deprecated Use `strokeReadableFocusDelta` instead. */
-export const neutralStrokeReadableFocusDelta = createTokenDelta(neutralStrokeReadableName, "focus", strokeReadableFocusDelta);
+export const neutralStrokeReadableFocusDelta = createTokenDelta(neutralStrokeReadableName, InteractiveState.focus, strokeReadableFocusDelta);
 
 const neutralStrokeStrongName = "neutral-stroke-strong";
 
@@ -327,16 +328,16 @@ const neutralStrokeStrongName = "neutral-stroke-strong";
 export const neutralStrokeStrongMinContrast = createTokenMinContrast(neutralStrokeStrongName, strokeStrongMinContrast);
 
 /** @public @deprecated Use `strokeStrongRestDelta` instead. */
-export const neutralStrokeStrongRestDelta = createTokenDelta(neutralStrokeStrongName, "rest", strokeStrongRestDelta);
+export const neutralStrokeStrongRestDelta = createTokenDelta(neutralStrokeStrongName, InteractiveState.rest, strokeStrongRestDelta);
 
 /** @public @deprecated Use `strokeStrongHoverDelta` instead. */
-export const neutralStrokeStrongHoverDelta = createTokenDelta(neutralStrokeStrongName, "hover", strokeStrongHoverDelta);
+export const neutralStrokeStrongHoverDelta = createTokenDelta(neutralStrokeStrongName, InteractiveState.hover, strokeStrongHoverDelta);
 
 /** @public @deprecated Use `strokeStrongActiveDelta` instead. */
-export const neutralStrokeStrongActiveDelta = createTokenDelta(neutralStrokeStrongName, "active", strokeStrongActiveDelta);
+export const neutralStrokeStrongActiveDelta = createTokenDelta(neutralStrokeStrongName, InteractiveState.active, strokeStrongActiveDelta);
 
 /** @public @deprecated Use `strokeStrongFocusDelta` instead. */
-export const neutralStrokeStrongFocusDelta = createTokenDelta(neutralStrokeStrongName, "focus", strokeStrongFocusDelta);
+export const neutralStrokeStrongFocusDelta = createTokenDelta(neutralStrokeStrongName, InteractiveState.focus, strokeStrongFocusDelta);
 
 /** @public @deprecated Use "Stroke Readable" instead */
 export const neutralForegroundHintRecipe = strokeReadableRecipe;
@@ -406,16 +407,16 @@ export const neutralFillFocus = neutralFillSubtleFocus;
 const neutralFillInputName = "neutral-fill-input";
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralFillInputRestDelta = createTokenDelta(neutralFillInputName, "rest", -1);
+export const neutralFillInputRestDelta = createTokenDelta(neutralFillInputName, InteractiveState.rest, -1);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralFillInputHoverDelta = createTokenDelta(neutralFillInputName, "hover", 1);
+export const neutralFillInputHoverDelta = createTokenDelta(neutralFillInputName, InteractiveState.hover, 1);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralFillInputActiveDelta = createTokenDelta(neutralFillInputName, "active", -2);
+export const neutralFillInputActiveDelta = createTokenDelta(neutralFillInputName, InteractiveState.active, -2);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralFillInputFocusDelta = createTokenDelta(neutralFillInputName, "focus", -2);
+export const neutralFillInputFocusDelta = createTokenDelta(neutralFillInputName, InteractiveState.focus, -2);
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralFillInputRecipe = createTokenColorRecipe(
@@ -457,16 +458,16 @@ export const neutralFillInputFocus = neutralFillInput.focus;
 const neutralFillSecondaryName = "neutral-fill-secondary";
 
 /** @public @deprecated Use "Subtle" or "Discernible" instead */
-export const neutralFillSecondaryRestDelta = createTokenDelta(neutralFillSecondaryName, "rest", 3);
+export const neutralFillSecondaryRestDelta = createTokenDelta(neutralFillSecondaryName, InteractiveState.rest, 3);
 
 /** @public @deprecated Use "Subtle" or "Discernible" instead */
-export const neutralFillSecondaryHoverDelta = createTokenDelta(neutralFillSecondaryName, "hover", 2);
+export const neutralFillSecondaryHoverDelta = createTokenDelta(neutralFillSecondaryName, InteractiveState.hover, 2);
 
 /** @public @deprecated Use "Subtle" or "Discernible" instead */
-export const neutralFillSecondaryActiveDelta = createTokenDelta(neutralFillSecondaryName, "active", 1);
+export const neutralFillSecondaryActiveDelta = createTokenDelta(neutralFillSecondaryName, InteractiveState.active, 1);
 
 /** @public @deprecated Use "Subtle" or "Discernible" instead */
-export const neutralFillSecondaryFocusDelta = createTokenDelta(neutralFillSecondaryName, "focus", 3);
+export const neutralFillSecondaryFocusDelta = createTokenDelta(neutralFillSecondaryName, InteractiveState.focus, 3);
 
 /** @public @deprecated Use "Subtle" or "Discernible" instead */
 export const neutralFillSecondaryRecipe = createTokenColorRecipe(
@@ -562,7 +563,7 @@ export const neutralStrokeFocus = neutralStrokeSubtleFocus;
 const neutralStrokeDividerName = "neutral-stroke-divider";
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralStrokeDividerRestDelta = createTokenDelta(neutralStrokeDividerName, "rest", 4);
+export const neutralStrokeDividerRestDelta = createTokenDelta(neutralStrokeDividerName, InteractiveState.rest, 4);
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeDividerRecipe = createTokenColorRecipe(
@@ -588,16 +589,16 @@ export const neutralStrokeDividerRest = createTokenColorRecipeValue(neutralStrok
 const neutralStrokeInputName = "neutral-stroke-input";
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralStrokeInputRestDelta = createTokenDelta(neutralStrokeInputName, "rest", 3);
+export const neutralStrokeInputRestDelta = createTokenDelta(neutralStrokeInputName, InteractiveState.rest, 3);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralStrokeInputHoverDelta = createTokenDelta(neutralStrokeInputName, "hover", 5);
+export const neutralStrokeInputHoverDelta = createTokenDelta(neutralStrokeInputName, InteractiveState.hover, 5);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralStrokeInputActiveDelta = createTokenDelta(neutralStrokeInputName, "active", 5);
+export const neutralStrokeInputActiveDelta = createTokenDelta(neutralStrokeInputName, InteractiveState.active, 5);
 
 /** @public @deprecated Use "Subtle" instead */
-export const neutralStrokeInputFocusDelta = createTokenDelta(neutralStrokeInputName, "focus", 5);
+export const neutralStrokeInputFocusDelta = createTokenDelta(neutralStrokeInputName, InteractiveState.focus, 5);
 
 /** @public @deprecated Use "Subtle" instead */
 export const neutralStrokeInputRecipe = createTokenColorRecipe(

--- a/packages/adaptive-ui/src/modules/styles.ts
+++ b/packages/adaptive-ui/src/modules/styles.ts
@@ -3,7 +3,7 @@ import type { CSSDesignToken } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet } from "../color/recipe.js";
 import { Swatch } from "../color/swatch.js";
 import { TypedCSSDesignToken, TypedDesignToken } from "../adaptive-design-tokens.js";
-import { InteractiveSet, InteractiveTokenGroup } from "../types.js";
+import { InteractiveTokenGroup, InteractiveValues } from "../types.js";
 import { createForegroundSet, createForegroundSetBySet } from "../token-helpers-color.js";
 import { StyleModuleTarget, StyleProperty, StylePropertyCss } from "./types.js";
 
@@ -12,7 +12,7 @@ import { StyleModuleTarget, StyleProperty, StylePropertyCss } from "./types.js";
  *
  * @public
  */
-export type StyleValue = CSSDesignToken<any> | InteractiveSet<any | null> | CSSDirective | string | number;
+export type StyleValue = CSSDesignToken<any> | InteractiveValues<any | null> | CSSDirective | string | number;
 
 /**
  * An object of style definitions, where the key is the {@link (StylePropertyCss:type)} and the value is the token or final value.

--- a/packages/adaptive-ui/src/token-helpers-color.ts
+++ b/packages/adaptive-ui/src/token-helpers-color.ts
@@ -18,7 +18,7 @@ import { StyleProperty } from "./modules/types.js";
 import { DesignTokenType, TypedCSSDesignToken, TypedDesignToken } from "./adaptive-design-tokens.js";
 import { Recipe, RecipeOptional } from "./recipes.js";
 import { createTokenNonCss, createTokenSwatch } from "./token-helpers.js";
-import type { InteractiveSet, InteractiveTokenGroup } from "./types.js";
+import { InteractiveState, InteractiveTokenGroup } from "./types.js";
 
 /**
  * Creates a DesignToken that can be used for interactive color recipe deltas.
@@ -31,7 +31,7 @@ import type { InteractiveSet, InteractiveTokenGroup } from "./types.js";
  */
 export function createTokenDelta(
     baseName: string,
-    state: keyof InteractiveSwatchSet,
+    state: InteractiveState,
     value: number | DesignToken<number>
 ): TypedDesignToken<number> {
     return createTokenNonCss<number>(`${baseName}-${state}-delta`, DesignTokenType.number).withDefault(value);
@@ -134,7 +134,7 @@ export function createTokenColorRecipeWithPalette<T>(
 
 function createTokenColorSetState(
     valueToken: TypedDesignToken<InteractiveSwatchSet>,
-    state: keyof InteractiveSwatchSet,
+    state: InteractiveState,
 ): TypedCSSDesignToken<Swatch> {
     return createTokenSwatch(`${valueToken.name.replace("-value", "")}-${state}`, valueToken.intendedFor).withDefault(
         (resolve: DesignTokenResolver) =>
@@ -161,11 +161,11 @@ export function createTokenColorSet(
         name,
         type: DesignTokenType.color,
         intendedFor: valueToken.intendedFor,
-        rest: createTokenColorSetState(valueToken, "rest"),
-        hover: createTokenColorSetState(valueToken, "hover"),
-        active: createTokenColorSetState(valueToken, "active"),
-        focus: createTokenColorSetState(valueToken, "focus"),
-        disabled: createTokenColorSetState(valueToken, "disabled"),
+        rest: createTokenColorSetState(valueToken, InteractiveState.rest),
+        hover: createTokenColorSetState(valueToken, InteractiveState.hover),
+        active: createTokenColorSetState(valueToken, InteractiveState.active),
+        focus: createTokenColorSetState(valueToken, InteractiveState.focus),
+        disabled: createTokenColorSetState(valueToken, InteractiveState.disabled),
     };
 }
 
@@ -202,8 +202,8 @@ export function createForegroundSet(
     const setName = `${foregroundBaseName}-on-${background.name}`;
 
     function createState(
-        foregroundState: keyof InteractiveSet<any>,
-        state: keyof InteractiveSet<any>,
+        foregroundState: InteractiveState,
+        state: InteractiveState,
     ): TypedCSSDesignToken<Swatch> {
         return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
@@ -217,11 +217,11 @@ export function createForegroundSet(
         name: setName,
         type: DesignTokenType.color,
         intendedFor: foregroundRecipe.intendedFor,
-        rest: createState("rest", "rest"),
-        hover: createState("rest", "hover"),
-        active: createState("rest", "active"),
-        focus: createState("rest", "focus"),
-        disabled: createState("disabled", "disabled"),
+        rest: createState(InteractiveState.rest, InteractiveState.rest),
+        hover: createState(InteractiveState.rest, InteractiveState.hover),
+        active: createState(InteractiveState.rest, InteractiveState.active),
+        focus: createState(InteractiveState.rest, InteractiveState.focus),
+        disabled: createState(InteractiveState.disabled, InteractiveState.disabled),
     };
 }
 
@@ -255,7 +255,7 @@ export function createForegroundSetBySet(
     );
 
     function createState(
-        state: keyof InteractiveSet<any>,
+        state: InteractiveState,
     ): TypedCSSDesignToken<Swatch> {
         return createTokenSwatch(`${setName}-${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
@@ -267,10 +267,10 @@ export function createForegroundSetBySet(
         name: setName,
         intendedFor: foregroundRecipe.intendedFor,
         type: DesignTokenType.color,
-        rest: createState("rest"),
-        hover: createState("hover"),
-        active: createState("active"),
-        focus: createState("focus"),
-        disabled: createState("disabled"),
+        rest: createState(InteractiveState.rest),
+        hover: createState(InteractiveState.hover),
+        active: createState(InteractiveState.active),
+        focus: createState(InteractiveState.focus),
+        disabled: createState(InteractiveState.disabled),
     };
 }

--- a/packages/adaptive-ui/src/types.ts
+++ b/packages/adaptive-ui/src/types.ts
@@ -24,35 +24,44 @@ export interface TokenGroup {
 }
 
 /**
- * A set for an interactive element's states.
+ * An interactive element's states.
  *
  * @public
  */
-export interface InteractiveSet<T> {
+export enum InteractiveState {
     /**
-     * The value to apply to the rest state.
+     * The rest state.
      */
-    rest: T;
+    rest = "rest",
 
     /**
-     * The value to apply to the hover state.
+     * The hover state.
      */
-    hover: T;
+    hover = "hover",
 
     /**
-     * The value to apply to the active state.
+     * The active state.
      */
-    active: T;
+    active = "active",
 
     /**
-     * The value to apply to the focus state.
+     * The focus state.
      */
-    focus: T;
+    focus = "focus",
 
     /**
-     * The value to apply to the disabled state.
+     * The disabled state.
      */
-    disabled: T;
+    disabled = "disabled",
+}
+
+/**
+ * Values for an interactive element's states.
+ *
+ * @public
+ */
+export type InteractiveValues<T> = {
+    [key in InteractiveState]: T;
 }
 
 /**
@@ -60,4 +69,4 @@ export interface InteractiveSet<T> {
  *
  * @public
  */
-export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveSet<TypedCSSDesignToken<T>> {}
+export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveValues<TypedCSSDesignToken<T>> {}

--- a/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
+++ b/packages/adaptive-web-components/src/components/breadcrumb-item/breadcrumb-item.styles.modules.ts
@@ -37,7 +37,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactive,
             part: BreadcrumbItemAnatomy.parts.control,
             partCondition: BreadcrumbItemAnatomy.conditions.current,
         },
@@ -45,7 +45,7 @@ export const styleModules: StyleRules = [
     },
     {
         target : {
-            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactivitySelector,
+            contextCondition: BreadcrumbItemAnatomy.interactivity?.interactive,
             part: BreadcrumbItemAnatomy.parts.control,
         },
         styles: accentForegroundReadableControlStyles,

--- a/packages/adaptive-web-components/src/global.styles.modules.ts
+++ b/packages/adaptive-web-components/src/global.styles.modules.ts
@@ -1,7 +1,7 @@
 import { CSSDesignToken } from "@microsoft/fast-foundation";
 import {
     ComponentAnatomy,
-    InteractiveSet,
+    InteractiveValues,
     StyleProperties,
     StyleRule,
     StyleRules,
@@ -26,7 +26,7 @@ const convertToFocusState = (styles: Styles) => {
         } else if (value && typeof (value as any).createCSS === "function") {
             focusValue = value;
         } else {
-            focusValue = (value as InteractiveSet<any>).focus;
+            focusValue = (value as InteractiveValues<any>).focus;
         }
 
         if (focusValue) {
@@ -63,11 +63,11 @@ export const globalStyleRules = (anatomy?: ComponentAnatomy<any, any>): StyleRul
     const styles = new Array<StyleRule>();
 
     // If this component can be disabled, apply the style to all children.
-    if (anatomy?.interactivity?.disabledSelector !== undefined) {
+    if (anatomy?.interactivity?.disabled !== undefined) {
         styles.push(
             {
                 target : {
-                    contextCondition: anatomy.interactivity.disabledSelector,
+                    contextCondition: anatomy.interactivity.disabled,
                     part: "*",
                 },
                 styles: disabledStyles,


### PR DESCRIPTION
# Pull Request

## Description

Added support for overriding interactive state selectors in Adaptive UI
- Naming and type cleanup around interactive states

## Reviewer Notes

I dusted off the TypeScript manual for this one, but I think the type updates here are beneficial around the consolidation of what "interactive" means and the consistency of the handling of the states. Would love any feedback about any potential issues or alternatives.

## Test Plan

Tested in AWC, including ad-hoc updates to validate style output with state overrides. I plan to add automated testing around this feature, but want to get the initial update pushed first.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Add automated testing around this area of the package.