### PR TITLE
AUI: Remove assumption on `part` selector

### DIFF
--- a/change/@adaptive-web-adaptive-ui-3ee37aaf-126b-435c-8f21-6b3e41ecc67b.json
+++ b/change/@adaptive-web-adaptive-ui-3ee37aaf-126b-435c-8f21-6b3e41ecc67b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Remove assumption on `part` selector",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-773cc7f3-c184-4004-935e-2efb19eea303.json
+++ b/change/@adaptive-web-adaptive-web-components-773cc7f3-c184-4004-935e-2efb19eea303.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Remove assumption on `part` selector",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -581,7 +581,7 @@ export type StyleRule = {
 } & StyleDeclaration;
 
 // @public
-export type StyleRules = Iterable<StyleRule>;
+export type StyleRules = Array<StyleRule>;
 
 // @public
 export class Styles {

--- a/packages/adaptive-ui/src/core/modules/selector.ts
+++ b/packages/adaptive-ui/src/core/modules/selector.ts
@@ -32,7 +32,7 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state: Inter
     const disabled = state === InteractiveState.disabled;
 
     const stateSelector = disabled ? "" : params[state] || DefaultInteractiveSelectors[state];
-    const context = params.context && params.context !== defaultContext ? `.${params.context}` : defaultContext;
+    const context = params.context && params.context !== defaultContext ? `${params.context}` : defaultContext;
 
     if (params.contextCondition ||
         (!rest && !disabled && params.interactive !== undefined) ||
@@ -69,8 +69,7 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state: Inter
         if (params.part === "*") {
             selectors.push("*");
         } else {
-            // Using class selector notation for now.
-            selectors.push(`.${params.part}${params.partCondition || ""}${params.stateOnContext !== true ? stateSelector : ""}`);
+            selectors.push(`${params.part}${params.partCondition || ""}${params.stateOnContext !== true ? stateSelector : ""}`);
         }
     }
 

--- a/packages/adaptive-ui/src/core/modules/types.ts
+++ b/packages/adaptive-ui/src/core/modules/types.ts
@@ -420,4 +420,4 @@ export const stylePropertyPaddingAll = [
  *
  * @public
  */
-export type StyleRules = Iterable<StyleRule>;
+export type StyleRules = Array<StyleRule>;

--- a/packages/adaptive-web-components/docs/api-report.md
+++ b/packages/adaptive-web-components/docs/api-report.md
@@ -63,7 +63,6 @@ import { FASTTreeView } from '@microsoft/fast-foundation';
 import { HorizontalScrollView } from '@microsoft/fast-foundation';
 import { ShadowRootOptions } from '@microsoft/fast-element';
 import type { StaticallyComposableHTML } from '@microsoft/fast-foundation';
-import { StyleRule } from '@adaptive-web/adaptive-ui';
 import { StyleRules } from '@adaptive-web/adaptive-ui';
 import type { ValuesOf } from '@microsoft/fast-foundation';
 

--- a/packages/adaptive-web-components/src/design-system.ts
+++ b/packages/adaptive-web-components/src/design-system.ts
@@ -11,6 +11,7 @@ import {
     type ComponentAnatomy,
     ElementStylesRenderer,
     StyleRule,
+    StyleRules,
 } from "@adaptive-web/adaptive-ui";
 import type {
     AccordionItemStatics,
@@ -130,6 +131,23 @@ export class DesignSystem {
     }
 
     /**
+     * Checks a StyleRule for a target `part` and turns it into a class name.
+     *
+     * @remarks
+     * This Design System is local to AWC and all templates and anatomy are structured this way.
+     * The opinion of using class names used to exist in AUI, but AUI is now non-opinionated in this regard.
+     *
+     * @param styleRule - The StyleRule to check and update
+     * @returns The updated StyleRule.
+     */
+    private static updateStyleRulesParts(styleRule: StyleRule): StyleRule {
+        if (styleRule.target?.part && !styleRule.target?.part.startsWith(".")) {
+            styleRule.target.part = "." + styleRule.target.part;
+        }
+        return styleRule;
+    }
+
+    /**
      * Assembles the collection of intended styles, evaluating and injecting modular styling if provided.
      *
      * @param defaultStyles - The default collection of styles to use if not overridden by `options.styles`.
@@ -148,7 +166,7 @@ export class DesignSystem {
 
         const allStyleModules = [
             ...globalStyleRules(anatomy),
-            ...(options && options.styleModules ? options.styleModules : [])
+            ...(options && options.styleModules ? options.styleModules.map(DesignSystem.updateStyleRulesParts) : [])
         ];
 
         return ElementStylesRenderer.renderStyleRules(componentStyles, allStyleModules, anatomy);
@@ -170,7 +188,7 @@ export const DefaultDesignSystem: DesignSystem = new DesignSystem("adaptive");
 export type ComposeOptions<TSource, TStatics extends string = any> = {
     template?: (ds: DesignSystem) => ElementViewTemplate<TSource, any>;
     styles?: ElementStyles | ElementStyles[];
-    styleModules?: Iterable<StyleRule>;
+    styleModules?: StyleRules;
     shadowOptions?: Partial<ShadowRootOptions>;
     elementOptions?: ElementDefinitionOptions;
     statics?: Record<TStatics, StaticallyComposableHTML>;


### PR DESCRIPTION
# Pull Request

## Description

AUI included an opinion/optimization that all `part` selectors were actually class names. This originated from that convention on the FAST Foundation template implementation. In expanding AUI capabilities to support other frameworks, this assumption is detrimental.

This PR removes the assumption from the underlying AUI code, but at least for the time being leaves it in AWC. We have other updates planned around the component Anatomy structure, including a naming strategy, so this capability will further improve, but since all AWC components are based on FAST Foundation now, it keeps the opinion and centralizes the necessary update.

## Reviewer Notes

The intent here was a least-touch PR that maintains existing opinions and functionality. As mentioned, we're planning to refactor this soon anyway,

## Test Plan

Tested in Storybook.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

This will be further addressed when the component anatomy is refactored.