### PR TITLE
AUI: Update CLI from `tokens` to align with existing `properties`

### DIFF
--- a/change/@adaptive-web-adaptive-ui-9a1613c3-c2e2-44c5-9a42-4cb2b5216378.json
+++ b/change/@adaptive-web-adaptive-ui-9a1613c3-c2e2-44c5-9a42-4cb2b5216378.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Update CLI from `tokens` to align with existing `properties`",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-ui-designer-figma-44d25ed7-78a9-46a7-8518-788cb1ac9ca3.json
+++ b/change/@adaptive-web-adaptive-ui-designer-figma-44d25ed7-78a9-46a7-8518-788cb1ac9ca3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Update CLI from `tokens` to align with existing `properties`",
+  "packageName": "@adaptive-web/adaptive-ui-designer-figma",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-designer-figma-plugin/src/core/code-gen.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/core/code-gen.ts
@@ -85,10 +85,10 @@ export class CodeGen {
                 const varName = StyleNameMapping[style as keyof typeof StyleNameMapping];
                 accumulated.push(varName);
             });
-            current.tokens.forEach(token => {
-                const varName = this.tokenIDMap(token.tokenID);
+            for (const token of current.properties.entries()) {
+                const varName = CodeGen.tokenIDMap(token[1]);
                 accumulated.push(varName);
-            });
+            }
             return accumulated;
         }, new Array<string>());
         const importBase = `import { StyleRules } from "@adaptive-web/adaptive-ui";\n`;
@@ -117,16 +117,16 @@ export class CodeGen {
         }
 
         let propertiesOut = "";
-        if (styleRule.tokens.size > 0) {
+        if (styleRule.properties.size > 0) {
             // TODO Need to map tokens better
-            const tokens = new Array(...styleRule.tokens).map(token => `${token.target}: ${this.tokenIDMap(token.tokenID)}`);
+            const tokens = new Array(...styleRule.properties).map(token => `${token[0]}: ${CodeGen.tokenIDMap(token[1])}`);
             propertiesOut = `        properties: {\n            ${tokens.join(",\n            ")},\n        },\n`;
         }
 
         return `    {\n${targetOut}${stylesOut}${propertiesOut}    },`;
     }
 
-    private tokenIDMap(tokenID: string): string {
+    private static tokenIDMap(tokenID: string): string {
         let adjustedID = tokenID;
 
         // TODO: Clean up naming and grouping

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -510,17 +510,9 @@ export interface SerializableStyleRule {
     // (undocumented)
     part?: string;
     // (undocumented)
+    properties?: Record<string, string>;
+    // (undocumented)
     styles?: string[];
-    // (undocumented)
-    tokens?: SerializableToken[];
-}
-
-// @beta (undocumented)
-export interface SerializableToken {
-    // (undocumented)
-    target: string;
-    // (undocumented)
-    tokenID: string;
 }
 
 // @public

--- a/packages/adaptive-ui/src/bin/aui.ts
+++ b/packages/adaptive-ui/src/bin/aui.ts
@@ -5,6 +5,7 @@ import fsp from "fs/promises";
 import { matcher } from "matcher"
 import * as prettier from "prettier";
 import { ComposableStyles, ElementStyles } from '@microsoft/fast-element';
+import { CSSDesignToken } from "@microsoft/fast-foundation";
 import { Command } from 'commander';
 import { glob } from "glob";
 import postcss, { type Processor} from "postcss";
@@ -28,7 +29,6 @@ import {
     StyleProperties,
     StyleRule,
     Styles,
-    TypedCSSDesignToken
 } from "../core/index.js";
 import { disabledStyles, focusIndicatorStyles, focusResetStyles } from "../reference/index.js";
 
@@ -253,10 +253,15 @@ function jsonToAUIStyleSheet(obj: SerializableAnatomy): AUIStyleSheet {
                 return Styles.Shared.get(name)!;
             });
 
-            const properties = style.tokens?.reduce((prev, current) => {
-                prev[current.target] = DesignTokenRegistry.Shared.get(current.tokenID) as TypedCSSDesignToken<any>
-                return prev;
-            }, {} as StyleProperties);
+            const properties: StyleProperties = {};
+            if (style.properties) {
+                Object.entries(style.properties).map(entry => {
+                    const target = entry[0];
+                    const value = entry[1];
+                    const token = DesignTokenRegistry.Shared.get(value);
+                    properties[target] = token ? token as CSSDesignToken<any> : value;
+                });
+            }
 
             const target: StyleModuleTarget = {
                 context: obj.context,

--- a/packages/adaptive-ui/src/core/modules/types.ts
+++ b/packages/adaptive-ui/src/core/modules/types.ts
@@ -445,19 +445,11 @@ export type SerializableCondition = SerializableBooleanCondition | SerializableS
 /**
  * @beta
  */
-export interface SerializableToken {
-    target: string,
-    tokenID: string
-}
-
-/**
- * @beta
- */
 export interface SerializableStyleRule {
     contextCondition?: Record<string, string | boolean>;
     part?: string,
     styles?: string[],
-    tokens?: SerializableToken[];
+    properties?: Record<string, string>,
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Description

Aligning the naming and of the properties associated with a style rule. Originally in AUI these were "properties" but in the json anatomy we initially only supported token values so we called them "tokens". As we continue to reconcile the models it's better to call them the same thing.

## Test Plan

Tested in AUI CLI.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.