### PR TITLE
Designer: Added ability to mark a node `inline` for styling

### DIFF
--- a/change/@adaptive-web-adaptive-ui-designer-core-a1d3a17c-d392-4dd1-ba4f-07204ba4b955.json
+++ b/change/@adaptive-web-adaptive-ui-designer-core-a1d3a17c-d392-4dd1-ba4f-07204ba4b955.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Designer: Added ability to mark a node `inline` for styling",
+  "packageName": "@adaptive-web/adaptive-ui-designer-core",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-ui-designer-figma-602338ac-be9f-4281-8f99-be2dd70df37e.json
+++ b/change/@adaptive-web-adaptive-ui-designer-figma-602338ac-be9f-4281-8f99-be2dd70df37e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Designer: Added ability to mark a node `inline` for styling",
+  "packageName": "@adaptive-web/adaptive-ui-designer-figma",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-designer-core/src/index.ts
+++ b/packages/adaptive-ui-designer-core/src/index.ts
@@ -1,5 +1,6 @@
 export { Controller, PluginUIState, STYLE_REMOVE } from "./controller.js";
 export {
+    Config,
     PluginNodeData,
     AppliedStyleModules,
     AppliedStyleValues,

--- a/packages/adaptive-ui-designer-core/src/model.ts
+++ b/packages/adaptive-ui-designer-core/src/model.ts
@@ -41,6 +41,18 @@ export const AdditionalDataKeys = {
 export type AdditionalDataKeys = ValuesOf<typeof AdditionalDataKeys>;
 
 /**
+ * Configuration options for a node.
+ */
+export class Config {
+    /**
+     * Indicator to treat the node as flattened or inline with the containing hierarchy.
+     * Usable on Component nodes which exist as a construction convenience and are not
+     * actual implemented components.
+     */
+    public inline?: boolean;
+}
+
+/**
  * A design token value.
  */
 export class DesignTokenValue {
@@ -113,6 +125,11 @@ export class AdditionalData extends Map<string, string> {}
  * Defines the data stored by the plugin on a node instance.
  */
 export interface PluginNodeData {
+    /**
+     * Configuration options for a node.
+     */
+    config: Config;
+
     /**
      * Design token values set directly to the node.
      */
@@ -216,6 +233,7 @@ export const pluginNodesToUINodes = (
                 componentAppliedDesignTokens: node.componentAppliedDesignTokens,
                 effectiveAppliedStyleValues: new AppliedStyleValues(),
                 children,
+                config: node.config,
                 designTokens: node.localDesignTokens as DesignTokenValues,
                 appliedStyleModules: node.appliedStyleModules as AppliedStyleModules,
                 appliedDesignTokens: node.appliedDesignTokens as AppliedDesignTokens,

--- a/packages/adaptive-ui-designer-core/src/node.ts
+++ b/packages/adaptive-ui-designer-core/src/node.ts
@@ -7,6 +7,7 @@ import {
     AppliedDesignTokens,
     AppliedStyleModules,
     AppliedStyleValues,
+    Config,
     DesignTokenValues,
     PluginNodeData,
     ReadonlyAppliedDesignTokens,
@@ -213,6 +214,11 @@ export abstract class PluginNode {
      * Gets the style properties this node supports.
      */
     public abstract get supports(): Array<StyleProperty>;
+
+    /**
+     * Configuration options for a node.
+     */
+    public config: Config;
 
     protected deserializeLocalDesignTokens(): DesignTokenValues {
         const json = this.getPluginData("designTokens");

--- a/packages/adaptive-ui-designer-figma/src/lib/node-parser.ts
+++ b/packages/adaptive-ui-designer-figma/src/lib/node-parser.ts
@@ -5,6 +5,7 @@ import {
     AppliedDesignTokens,
     AppliedStyleModules,
     AppliedStyleValues,
+    Config,
     deserializeMap,
     DesignTokenValues,
     PluginNodeData,
@@ -38,8 +39,12 @@ export function parseNode(node: FigmaRestAPI.Node): PluginUINodeData {
         additionalData.set(AdditionalDataKeys.codeGenName, node.name);
     }
 
+    const configData = getPluginData(node, "config");
     const appliedTokensPluginData = getPluginData(node, "appliedDesignTokens");
     const appliedStylesPluginData = getPluginData(node, "appliedStyleModules");
+    const config: Config = configData
+        ? JSON.parse(configData)
+        : new Config();
     const appliedDesignTokens: AppliedDesignTokens = appliedTokensPluginData
         ? deserializeMap(appliedTokensPluginData)
         : new AppliedDesignTokens();
@@ -53,6 +58,7 @@ export function parseNode(node: FigmaRestAPI.Node): PluginUINodeData {
         type: node.type,
         supports: [],
         children: children.map(parseNode),
+        config,
         additionalData,
         appliedDesignTokens,
         appliedStyleModules,


### PR DESCRIPTION
# Pull Request

## Description

In Figma we often build components from smaller components. In some cases those are actual implemented components, like a Button, but sometimes they are just convenience for construction in Figma.

The `inline` configuration option added to a node here allows us to mark a component as a construction utility and "inline" it into the components where it's used for style processing. The concrete example of this is a Label component which has the label text node and a required indicator node. It's unlikely we will write an actual Label component, rather that this is just an attribute or slot of a handful of implemented components. We can now mark that inline and components like a Text Filed, Select, etc. will be able to process styling for the label elements.

The alternative is that the instance in Figma is an actual published component, but we don't have the ability to detect that full list, so we assume that they are as this is more common.

## Test Plan

Tested in CLI.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.