### PR TITLE
AUI: Added support for pseudo selectors in part conditions

### DIFF
--- a/change/@adaptive-web-adaptive-ui-e52e477e-a9f7-4340-9a72-a1d7ee8c16c5.json
+++ b/change/@adaptive-web-adaptive-ui-e52e477e-a9f7-4340-9a72-a1d7ee8c16c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "AUI: Added support for pseudo selectors in part conditions",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/src/core/modules/selector.ts
+++ b/packages/adaptive-ui/src/core/modules/selector.ts
@@ -71,11 +71,13 @@ export function makeSelector(params: StyleModuleEvaluateParameters, state: Inter
     // Add the part selector
     if (params.part) {
         if (params.part === "*") {
-            selectors.push("*");
+            selectors.push(" *");
+        } else if (params.part.startsWith("::")) {
+            selectors.push(params.part);
         } else {
-            selectors.push(`${params.part}${params.partCondition || ""}${params.stateOnContext !== true ? stateSelector : ""}`);
+            selectors.push(` ${params.part}${params.partCondition || ""}${params.stateOnContext !== true ? stateSelector : ""}`);
         }
     }
 
-    return selectors.join(" ");
+    return selectors.join("");
 }


### PR DESCRIPTION
# Pull Request

## Description

A simple quick fix to allow pseudo element selectors as part of the anatomy description.

## Reviewer Notes

This PR just moves the "space" added between selector portions so a pseudo-element can _not_ have a space before it.

## Test Plan

Tested by generating output with and without a pseudo element.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.