### PR TITLE
AUI: Add import capability to component anatomy definitions

### DIFF
--- a/change/@adaptive-web-adaptive-ui-4e314a96-e352-46f2-b2ab-cfd816afe5fe.json
+++ b/change/@adaptive-web-adaptive-ui-4e314a96-e352-46f2-b2ab-cfd816afe5fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Add import capability to component anatomy definitions",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17978,6 +17978,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/deepmerge-ts": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.3.tgz",
+            "integrity": "sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ==",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/default-browser-id": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-1.0.4.tgz",
@@ -33059,6 +33067,7 @@
                 "@microsoft/fast-foundation": "3.0.0-alpha.31",
                 "commander": "^12.0.0",
                 "culori": "^3.2.0",
+                "deepmerge-ts": "^7.1.3",
                 "glob": "^10.3.10",
                 "matcher": "^5.0.0",
                 "postcss": "^8.4.39",
@@ -34857,6 +34866,7 @@
                 "chai": "^4.3.7",
                 "commander": "^12.0.0",
                 "culori": "^3.2.0",
+                "deepmerge-ts": "^7.1.3",
                 "glob": "^10.3.10",
                 "jsdom": "^16.2.2",
                 "jsdom-global": "3.0.2",
@@ -48925,6 +48935,11 @@
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
+        },
+        "deepmerge-ts": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.3.tgz",
+            "integrity": "sha512-qCSH6I0INPxd9Y1VtAiLpnYvz5O//6rCfJXKk0z66Up9/VOSr+1yS8XSKA5IWRxjocFGlzPyaZYe+jxq7OOLtQ=="
         },
         "default-browser-id": {
             "version": "1.0.4",

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -510,6 +510,12 @@ export interface SerializableAnatomy {
 }
 
 // @beta (undocumented)
+export interface SerializableAnatomyWithImports extends SerializableAnatomy {
+    // (undocumented)
+    imports?: string[];
+}
+
+// @beta (undocumented)
 export type SerializableBooleanCondition = string;
 
 // @beta (undocumented)

--- a/packages/adaptive-ui/package.json
+++ b/packages/adaptive-ui/package.json
@@ -42,6 +42,7 @@
     "@microsoft/fast-foundation": "3.0.0-alpha.31",
     "commander": "^12.0.0",
     "culori": "^3.2.0",
+    "deepmerge-ts": "^7.1.3",
     "glob": "^10.3.10",
     "matcher": "^5.0.0",
     "postcss": "^8.4.39",

--- a/packages/adaptive-ui/src/core/modules/types.ts
+++ b/packages/adaptive-ui/src/core/modules/types.ts
@@ -7,7 +7,7 @@ import { StyleRule } from "./styles.js";
  *
  * @public
  */
-export type BooleanCondition = string; 
+export type BooleanCondition = string;
 
 /**
  * The state and selector for a multiple value condition.
@@ -152,7 +152,7 @@ export const Interactivity = {
      *
      * For instance, a form control.
      */
-    disabledAttribute: { 
+    disabledAttribute: {
         interactive: ":not([disabled])",
         disabled: "[disabled]",
     } as InteractivityDefinition,
@@ -162,7 +162,7 @@ export const Interactivity = {
      *
      * For instance, a form control.
      */
-    disabledClass: { 
+    disabledClass: {
         interactive: ":not(.disabled)",
         disabled: ".disabled",
     } as InteractivityDefinition,
@@ -172,7 +172,7 @@ export const Interactivity = {
      *
      * For instance, an `<a>` should style as plain text when it doesn't have an `href` attribute.
      */
-    hrefAttribute:  { 
+    hrefAttribute: {
         interactive: "[href]",
     } as InteractivityDefinition,
 
@@ -181,7 +181,7 @@ export const Interactivity = {
      *
      * For instance, cards or list items that are not able to be disabled.
      */
-    always: { 
+    always: {
         interactive: "",
     } as InteractivityDefinition,
 
@@ -193,7 +193,7 @@ export const Interactivity = {
      * @remarks
      * This is an explicit value representing the default case.
      */
-    never: { 
+    never: {
     } as InteractivityDefinition,
 } as const;
 
@@ -481,7 +481,7 @@ export type StyleRules = Array<StyleRule>;
 /**
  * @beta
  */
-export type SerializableBooleanCondition = string; 
+export type SerializableBooleanCondition = string;
 
 /**
  * @beta
@@ -506,7 +506,7 @@ export interface SerializableStyleRule {
 /**
  * @beta
  */
-export interface SerializableAnatomy{
+export interface SerializableAnatomy {
     name: string,
     context: string,
     conditions: Record<string, SerializableCondition>,
@@ -514,4 +514,11 @@ export interface SerializableAnatomy{
     interactivity?: InteractivityDefinition,
     focus?: FocusDefinition<any>,
     styleRules: SerializableStyleRule[]
+}
+
+/**
+ * @beta
+ */
+export interface SerializableAnatomyWithImports extends SerializableAnatomy {
+    imports?: string[]
 }


### PR DESCRIPTION
# Pull Request

## Description

Allows extracting common definitions shared across multiple components.

Initial example is adding success/error validation across all inputs.
- Can define those styles in one definition file
- Import that file in all input components

## Reviewer Notes

The deepmerge package seemed to be the most efficient way to merge the json docs, but open to suggestions.

## Test Plan

Tested in AUI pipeline.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.