### PR TITLE
Designer: Fix parent fill color handling

### DIFF
--- a/change/@adaptive-web-adaptive-ui-designer-core-f48fe501-e71a-48f5-9eea-a0e138300aee.json
+++ b/change/@adaptive-web-adaptive-ui-designer-core-f48fe501-e71a-48f5-9eea-a0e138300aee.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Designer: Fix parent fill color handling",
+  "packageName": "@adaptive-web/adaptive-ui-designer-core",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-designer-core/src/node.ts
+++ b/packages/adaptive-ui-designer-core/src/node.ts
@@ -211,6 +211,11 @@ export abstract class PluginNode {
     public abstract get parent(): PluginNode | null;
 
     /**
+     * Gets the effective fill color of this node, either locally applied or from an ancestor.
+     */
+    public abstract get effectiveFillColor(): Color | null;
+
+    /**
      * Gets the style properties this node supports.
      */
     public abstract get supports(): Array<StyleProperty>;
@@ -332,9 +337,9 @@ export abstract class PluginNode {
             this._additionalData.set(AdditionalDataKeys.codeGenName, this.codeGenName);
         }
 
-        if (!this._additionalData.has(AdditionalDataKeys.toolParentFillColor) && this.parent?.fillColor) {
-            // console.log("PluginNode.get_additionalData - adding:", AdditionalDataKeys.toolParentFillColor, this.debugInfo, formatHex8(this.parent?.fillColor));
-            this._additionalData.set(AdditionalDataKeys.toolParentFillColor, formatHex8(this.parent.fillColor));
+        if (!this._additionalData.has(AdditionalDataKeys.toolParentFillColor) && this.parent?.effectiveFillColor) {
+            // console.log("PluginNode.get_additionalData - adding:", AdditionalDataKeys.toolParentFillColor, this.debugInfo, formatHex8(this.parent?.effectiveFillColor));
+            this._additionalData.set(AdditionalDataKeys.toolParentFillColor, formatHex8(this.parent.effectiveFillColor));
         }
 
         return this._additionalData;

--- a/packages/adaptive-ui-designer-figma-plugin/src/figma/node.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/figma/node.ts
@@ -749,7 +749,7 @@ export class FigmaPluginNode extends PluginNode {
             return null;
         }
 
-        // console.log("    get parent");
+        // console.log("    get parent", this.debugInfo);
         return FigmaPluginNode.get(parent, false);
     }
 
@@ -776,6 +776,16 @@ export class FigmaPluginNode extends PluginNode {
         return null;
     }
 
+    public get effectiveFillColor(): Color | null {
+        if (this.fillColor) {
+            return this.fillColor;
+        }
+        if (this.parent) {
+            return this.parent.fillColor;
+        }
+        return null;
+    }
+
     private darkTarget: number = (-0.1 + Math.sqrt(0.21)) / 2;
 
     public handleManualDarkMode(): boolean {
@@ -783,7 +793,7 @@ export class FigmaPluginNode extends PluginNode {
             if (this._node.variantProperties) {
                 const currentDarkMode = this._node.variantProperties["Dark mode"];
                 if (currentDarkMode) {
-                    const color = this.parent?.fillColor;
+                    const color = this.parent?.effectiveFillColor;
                     if (color) {
                         const containerIsDark = wcagLuminance(color) <= this.darkTarget;
                         // eslint-disable-next-line max-len

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
@@ -39,7 +39,7 @@ export class ElementsController {
             this.rootElement.removeChild(child)
         );
 
-        this.resetFillColor(this.rootElement);
+        this.resetFillColor();
 
         this.controller.selectedNodes.forEach(node => this.setupDesignTokenElement(this.rootElement, node));
     }
@@ -182,13 +182,15 @@ export class ElementsController {
 
     /**
      * Resets the `fill-color` token value on the full element tree.
-     *
-     * @param element - The top element, recursive
      */
-    public resetFillColor(element: FASTElement) {
+    public resetFillColor() {
+        this.resetFillColorForElement(this.rootElement);
+    }
+
+    private resetFillColorForElement(element: FASTElement) {
         this.setDesignTokenForElement(element, fillColor, null);
         element.childNodes.forEach(child =>
-            this.resetFillColor(child as unknown as FASTElement)
+            this.resetFillColorForElement(child as unknown as FASTElement)
         );
     }
 }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
@@ -168,6 +168,8 @@ export class UIController {
      */
     public refreshSelectedNodes(reason: string = "refreshSelectedNodes"): void {
         // console.log("  Evaluating all design tokens for all selected nodes");
+        this._elements.resetFillColor();
+
         this.evaluateEffectiveAppliedStyleValues(this._selectedNodes);
 
         const message: PluginMessage = {
@@ -358,7 +360,7 @@ export class UIController {
         if (valueOriginal instanceof Color) {
             const swatch = valueOriginal;
             value = formatHex8(swatch.color);
-            // valueDebug = swatch;
+            // valueDebug = swatch.toColorString();
         } else if (typeof valueOriginal === "string") {
             if (valueOriginal.startsWith("calc")) {
                 const ret = calc(valueOriginal as string);
@@ -366,7 +368,7 @@ export class UIController {
                 value = ret;
             }
         }
-        // const fillColorValue = this._elements.getDesignTokenValue(node, fillColor);
+        // const fillColorValue = (this._elements.getDesignTokenValue(node, fillColor) as Swatch).toColorString();
         // console.log("    evaluateEffectiveAppliedDesignToken", target, " : ", token.name, " -> ", value, valueDebug, `(from ${source})`, "fillColor", fillColorValue);
 
         const applied = new AppliedStyleValue(value);


### PR DESCRIPTION
# Pull Request

## Description

I think I've finally resolved the issue where colors were being calculated incorrectly until you unselected and reselected a layer.
Cleaned up the handling of the effective fill color when you might have layers without a fill.
The key fix is in clearing the design token values in the shadow hierarchy at the right place so it's not latching old colors.

## Test Plan

Tested in Figma Designer.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.