### PR TITLE
Designer: Begin migration away from design token definition

### DIFF
--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/app.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/app.ts
@@ -17,7 +17,7 @@ import type { PluginMessage} from "../core/messages.js";
 import SubtractIcon from "./assets/subtract.svg";
 import { UIController } from "./ui-controller.js";
 import { AppliedDesignTokenItem, StyleModuleDisplay, StyleModuleDisplayList } from "./ui-controller-styles.js";
-import { DesignTokenAdd, DesignTokensForm, Drawer, StyleTokenItem, TokenGlyph, TokenGlyphType } from "./components/index.js";
+import { AddEventDetail, DesignTokenAdd, DesignTokensForm, DetachEventDetail, Drawer, StyleTokenItem, TokenChangeEventDetail, TokenGlyph, TokenGlyphType } from "./components/index.js";
 
 StyleTokenItem;
 TokenGlyph;
@@ -411,8 +411,8 @@ const template = html<App>`
                                 :designTokens=${(x) => x.controller.designTokens.availableDesignTokens}
                                 @add=${(x, c) =>
                                     x.controller.designTokens.setDesignToken(
-                                        (c.event as CustomEvent).detail.definition,
-                                        (c.event as CustomEvent).detail.value
+                                        ((c.event as CustomEvent).detail as AddEventDetail).token,
+                                        ((c.event as CustomEvent).detail as AddEventDetail).value
                                     )}
                             ></designer-design-token-add>
                             <adaptive-divider></adaptive-divider>
@@ -422,10 +422,13 @@ const template = html<App>`
                                 :designTokens=${(x) => x.controller.designTokens.designTokenValues}
                                 @tokenChange=${(x, c) =>
                                     x.controller.designTokens.setDesignToken(
-                                        (c.event as CustomEvent).detail.definition,
-                                        (c.event as CustomEvent).detail.value
+                                        ((c.event as CustomEvent).detail as TokenChangeEventDetail).token,
+                                        ((c.event as CustomEvent).detail as TokenChangeEventDetail).value
                                     )}
-                                @detach=${(x, c) => x.controller.designTokens.removeDesignToken((c.event as CustomEvent).detail)}
+                                @detach=${(x, c) =>
+                                    x.controller.designTokens.removeDesignToken(
+                                        ((c.event as CustomEvent).detail as DetachEventDetail)
+                                    )}
                             ></designer-design-tokens-form>
                         </div>
                     </div>

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-token-add/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-token-add/index.ts
@@ -8,21 +8,24 @@ import {
     ref,
     repeat,
 } from "@microsoft/fast-element";
-import { staticallyCompose } from "@microsoft/fast-foundation";
-import { DesignTokenDefinition } from "@adaptive-web/adaptive-ui-designer-core";
+import { DesignToken, staticallyCompose } from "@microsoft/fast-foundation";
 import CheckmarkIcon from "../../assets/checkmark.svg";
 import { DesignTokenField } from "../design-token-field/index.js";
+import { UIDesignTokenValue } from "../../ui-controller-tokens.js";
+import { designTokenTitle } from "../../util.js";
 
 DesignTokenField;
+
+export type AddEventDetail = UIDesignTokenValue;
 
 const template = html<DesignTokenAdd>`
     <select @change="${(x, c) => x.selectHandler(c)}" ${ref("list")}>
         <option selected value="-">Add design token override...</option>
         ${repeat(
             x => x.designTokens,
-            html<DesignTokenDefinition, DesignTokenAdd>`
-                <option value="${x => x.id}">
-                    ${x => x.title} (${x => x.groupTitle})
+            html<DesignToken<any>, DesignTokenAdd>`
+                <option value="${x => x.name}">
+                    ${x => designTokenTitle(x)}
                 </option>
             `
         )}
@@ -67,28 +70,28 @@ const styles = css`
 })
 export class DesignTokenAdd extends FASTElement {
     @observable
-    designTokens: DesignTokenDefinition[] = [];
+    designTokens: DesignToken<any>[] = [];
 
     @observable
-    selectedDesignToken?: DesignTokenDefinition;
+    selectedDesignToken?: DesignToken<any>;
 
     list?: HTMLSelectElement;
 
     field?: DesignTokenField;
 
     selectHandler(c: ExecutionContext) {
-        const selectedTokenId = (c.event.target as unknown as HTMLSelectElement).value;
+        const selectedTokenName = (c.event.target as unknown as HTMLSelectElement).value;
 
-        if (selectedTokenId !== "-") {
+        if (selectedTokenName !== "-") {
             this.selectedDesignToken = this.designTokens.find((token) => {
-                return token.id === selectedTokenId;
+                return token.name === selectedTokenName;
             });
             if (this.list) {
                 this.list.value = "-";
             }
 
             if (this.field) {
-                this.field.value = "" + this.selectedDesignToken?.token.default;
+                this.field.value = "" + this.selectedDesignToken?.default;
             }
         }
     }
@@ -96,9 +99,9 @@ export class DesignTokenAdd extends FASTElement {
     addHandler() {
         if (this.field?.value) {
             this.$emit("add", {
-                definition: this.selectedDesignToken,
+                token: this.selectedDesignToken,
                 value: this.field.value,
-            });
+            } as AddEventDetail);
 
             this.selectedDesignToken = undefined;
         }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-token-field/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-token-field/index.ts
@@ -1,6 +1,10 @@
+import { DesignToken } from "@microsoft/fast-foundation";
 import { css, customElement, FASTElement, html, observable } from "@microsoft/fast-element";
 import { twoWay } from "@microsoft/fast-element/binding/two-way.js";
-import { DesignTokenDefinition, FormControlId } from "@adaptive-web/adaptive-ui-designer-core";
+import { DesignTokenMetadata, DesignTokenType } from "@adaptive-web/adaptive-ui";
+import { designTokenTitle } from "../../util.js";
+
+export type ChangeEventDetail = string;
 
 const tokenTemplatesByType = {
     default: html<DesignTokenField>`
@@ -36,7 +40,7 @@ const tokenTemplatesByType = {
 
 const template = html<DesignTokenField>`
     <label>
-        <span>${x => x.designToken?.title}</span>
+        <span>${x => designTokenTitle(x.designToken)}</span>
         ${x => x.selectTemplate()}
     </label>
 `;
@@ -79,19 +83,19 @@ const styles = css`
 })
 export class DesignTokenField extends FASTElement {
     @observable
-    designToken?: DesignTokenDefinition;
+    designToken?: DesignToken<any> & DesignTokenMetadata;
 
     @observable
     value: string = "";
     valueChanged(prev: string, next: string) {
-        this.$emit("change", this.value);
+        this.$emit("change", this.value as ChangeEventDetail);
     }
 
     selectTemplate() {
         if (this.designToken) {
-            if (this.designToken.formControlId === FormControlId.color) {
+            if (this.designToken.type === DesignTokenType.color) {
                 return tokenTemplatesByType.color;
-            } else if (this.designToken.id === "color.layer.fill.ramp.baseLuminance") {
+            } else if (this.designToken.name === "color.layer.fill.ramp.baseLuminance") {
                 return tokenTemplatesByType.luminance;
             }
         }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-tokens-form/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/design-tokens-form/index.ts
@@ -7,12 +7,15 @@ import {
     repeat,
     when,
 } from "@microsoft/fast-element";
-import { staticallyCompose } from "@microsoft/fast-foundation";
+import { DesignToken, staticallyCompose } from "@microsoft/fast-foundation";
 import SubtractIcon from "../../assets/subtract.svg";
 import type { UIDesignTokenValue } from "../../ui-controller-tokens.js";
-import { DesignTokenField } from "../design-token-field/index.js";
+import { ChangeEventDetail, DesignTokenField } from "../design-token-field/index.js";
 
 DesignTokenField;
+
+export type TokenChangeEventDetail = UIDesignTokenValue;
+export type DetachEventDetail = DesignToken<any>;
 
 const template = html<DesignTokensForm>`
     <ul>
@@ -21,10 +24,10 @@ const template = html<DesignTokensForm>`
             html<UIDesignTokenValue, DesignTokensForm>`
                 <li>
                     <designer-design-token-field
-                        :designToken=${x => x.definition}
+                        :designToken=${x => x.token}
                         :value=${x => x.value}
                         @change="${(x, c) =>
-                            c.parent.changeHandler(x, c.event as CustomEvent)}"
+                            c.parent.changeHandler(x, (c.event as CustomEvent).detail as ChangeEventDetail)}"
                     ></designer-design-token-field>
                     <adaptive-button
                         appearance="stealth"
@@ -69,9 +72,9 @@ export class DesignTokensForm extends FASTElement {
     @observable
     designTokens: UIDesignTokenValue[] = [];
 
-    changeHandler(token: UIDesignTokenValue, e: CustomEvent) {
-        token.value = e.detail;
-        this.$emit("tokenChange", token);
+    changeHandler(token: UIDesignTokenValue, value: string) {
+        token.value = value;
+        this.$emit("tokenChange", token as TokenChangeEventDetail);
     }
 
     detachHandler(token: UIDesignTokenValue) {
@@ -83,6 +86,6 @@ export class DesignTokensForm extends FASTElement {
         });
         this.designTokens.splice(detachIndex, 1);
 
-        this.$emit("detach", token.definition);
+        this.$emit("detach", token.token as DetachEventDetail);
     }
 }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/util.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/util.ts
@@ -1,0 +1,16 @@
+import { sentenceCase } from "change-case";
+import { DesignToken } from "@microsoft/fast-foundation";
+
+export function designTokenTitle(token?: DesignToken<any>): string {
+    if (token === undefined || token.name === undefined) {
+        console.log(token);
+        
+        return "-";
+    }
+
+    // Handle legacy non-hierarchical format for `custom-recipes.ts`.
+    const name = token.name.indexOf(".") > -1 ? token.name.split(".").slice(1).join("-") : token.name;
+
+    const base = name.replace(/-/g, ' ').replace(/density_/, '');
+    return sentenceCase(base);
+}


### PR DESCRIPTION
# Pull Request

## Description

The DesignTokenDefinition and associated registry have been planned to phase out for a while. Now that all tokens are registered in AUI we no longer need it. This is not what I first set out to do, but it was a good checkpoint on the path.

## Test Plan

Tested in Figma Designer

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

Continue updates to remove references to this.