### PR TITLE
AUI: Added parts support to anatomy import

### DIFF
--- a/change/@adaptive-web-adaptive-ui-f7e55679-55b0-455f-ab1e-a7febe87e42e.json
+++ b/change/@adaptive-web-adaptive-ui-f7e55679-55b0-455f-ab1e-a7febe87e42e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Added parts support to anatomy import",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui/src/bin/aui.ts
+++ b/packages/adaptive-ui/src/bin/aui.ts
@@ -97,11 +97,18 @@ program.command("compile-json-anatomy <anatomyPath>")
                 const impWithExt = imp.toLowerCase().endsWith(".json") ? imp : `${imp}.json`;
                 const impFilePath = path.format({ ...path.parse(path.join(path.parse(jsonPath).dir, impWithExt)) });
                 const impData = (await fsp.readFile(impFilePath)).toString();
-                const impJsonData = JSON.parse(impData);
-                // If `parts` are in the import, they are for validation/consistency of that file, but we want to use the parts
-                // list from the main anatomy definition.
-                // Consider extending this so imports can add their own known parts.
-                delete impJsonData.parts;
+                const impJsonData = JSON.parse(impData) as SerializableAnatomy;
+
+                // If `parts` are in the import, they are either for validation/consistency of that file
+                // or additive to the main anatomy definition.
+                // If the part selector is empty, remove it an use the value from the main anatomy definition.
+                for (const part in impJsonData.parts) {
+                    if (impJsonData.parts.hasOwnProperty(part)) {
+                        if (impJsonData.parts[part] === "") {
+                            delete impJsonData.parts[part];
+                        }
+                    }
+                }
 
                 jsonData = deepmerge(jsonData, impJsonData);
             }


### PR DESCRIPTION
# Pull Request

## Description

Adds support for adding `parts` definitions in imported anatomy files

## Test Plan

Tested in style generation pipeline

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.