### PR TITLE
Designer: Added support for applying interactive groups

### DIFF
--- a/change/@adaptive-web-adaptive-ui-a3f2c827-911c-4906-a735-78bd8f38bd99.json
+++ b/change/@adaptive-web-adaptive-ui-a3f2c827-911c-4906-a735-78bd8f38bd99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated style properties to readonly, adjusted token group types",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-ui-designer-core-2547a09a-053d-486e-a3bf-3e015478db71.json
+++ b/change/@adaptive-web-adaptive-ui-designer-core-2547a09a-053d-486e-a3bf-3e015478db71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added support for registering interactive token groups",
+  "packageName": "@adaptive-web/adaptive-ui-designer-core",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-designer-core/src/index.ts
+++ b/packages/adaptive-ui-designer-core/src/index.ts
@@ -15,5 +15,5 @@ export {
 } from "./model.js";
 export { mapReplacer, mapReviver, deserializeMap, serializeMap } from "./serialization.js";
 export { State, StatesState, PluginNode, focusIndicatorNodeName, } from "./node.js";
-export { AdaptiveDesignToken, DesignTokenRegistry } from "./registry/design-token-registry.js";
+export { AdaptiveDesignToken, AdaptiveDesignTokenOrGroup, DesignTokenRegistry } from "./registry/design-token-registry.js";
 export { registerAppliableTokens, registerTokens } from "./registry/recipes.js";

--- a/packages/adaptive-ui-designer-core/src/registry/design-token-registry.ts
+++ b/packages/adaptive-ui-designer-core/src/registry/design-token-registry.ts
@@ -1,16 +1,18 @@
 import { CSSDesignToken, DesignToken } from "@microsoft/fast-foundation";
-import { DesignTokenMetadata, StyleProperty } from "@adaptive-web/adaptive-ui";
+import { DesignTokenMetadata, InteractiveTokenGroup, StyleProperty } from "@adaptive-web/adaptive-ui";
 
 export type AdaptiveDesignToken = (DesignToken<any> | CSSDesignToken<any>) & DesignTokenMetadata;
 
-export class DesignTokenRegistry {
-    private _entries: { [id: string]: AdaptiveDesignToken } = {};
+export type AdaptiveDesignTokenOrGroup = (DesignToken<any> | CSSDesignToken<any> | InteractiveTokenGroup<any>) & DesignTokenMetadata;
+
+export class DesignTokenRegistry<T extends { name: string } & DesignTokenMetadata> {
+    private _entries: { [id: string]: T } = {};
 
     /**
      * Registers a new design token definition.
      * @param designToken The design token definition to register.
      */
-    public register(designToken: AdaptiveDesignToken): void {
+    public register(designToken: T): void {
         const { name } = designToken;
 
         if (this.isRegistered(name)) {
@@ -34,7 +36,7 @@ export class DesignTokenRegistry {
      * Gets a design token definition by ID.
      * @param name The ID of the design token definition.
      */
-    public get(name: string): AdaptiveDesignToken | null {
+    public get(name: string): T | null {
         if (this.isRegistered(name)) {
             return this._entries[name];
         }
@@ -45,7 +47,7 @@ export class DesignTokenRegistry {
     /**
      * Gets all entries in this registry.
      */
-    public get entries(): AdaptiveDesignToken[] {
+    public get entries(): T[] {
         return Object.values(this._entries);
     }
 
@@ -61,7 +63,7 @@ export class DesignTokenRegistry {
      * Returns all entries that apply to a given style property type
      * @param target the style property type to return entries of
      */
-    public find(target: StyleProperty): AdaptiveDesignToken[] {
+    public find(target: StyleProperty): T[] {
         return Object.values(this._entries).filter(value => value.intendedFor?.includes(target));
     }
 }

--- a/packages/adaptive-ui-designer-core/src/registry/recipes.ts
+++ b/packages/adaptive-ui-designer-core/src/registry/recipes.ts
@@ -1,4 +1,4 @@
-import { densityAdjustmentUnits } from "@adaptive-web/adaptive-ui"
+import { densityAdjustmentUnits, DesignTokenMetadata } from "@adaptive-web/adaptive-ui"
 import {
     accentBaseColor,
     accentFillDiscernible,
@@ -148,12 +148,16 @@ import {
     warningStrokeSubtle,
     wcagContrastLevel,
 } from "@adaptive-web/adaptive-ui/reference";
-import { AdaptiveDesignToken, DesignTokenRegistry } from "./design-token-registry.js";
+import { AdaptiveDesignToken, AdaptiveDesignTokenOrGroup, DesignTokenRegistry } from "./design-token-registry.js";
 
 /**
  * A collection of DesignTokens for adding to a {@link DesignTokenRegistry}.
  */
-type DesignTokenStore = Array<AdaptiveDesignToken>;
+type Store<T extends { name: string } & DesignTokenMetadata> = Array<T>;
+
+type DesignTokenStore = Store<AdaptiveDesignToken>;
+
+type DesignTokenOrGroupStore = Store<AdaptiveDesignTokenOrGroup>;
 
 const designTokens: DesignTokenStore = [
     accentBaseColor,
@@ -203,7 +207,7 @@ const designTokens: DesignTokenStore = [
     strokeStrongRestDelta,
 ];
 
-const colorTokens: DesignTokenStore = [
+const colorTokens: DesignTokenOrGroupStore = [
     // Layer
     layerFillFixedMinus4,
     layerFillFixedMinus3,
@@ -214,89 +218,89 @@ const colorTokens: DesignTokenStore = [
     layerFillFixedPlus2,
     layerFillFixedPlus3,
     layerFillFixedPlus4,
-    layerFillInteractive.rest,
+    layerFillInteractive,
     // Fill
     accentBaseColor,
-    accentFillStealth.rest,
-    accentFillSubtle.rest,
-    accentFillIdeal.rest,
-    accentFillDiscernible.rest,
-    accentFillReadable.rest,
+    accentFillStealth,
+    accentFillSubtle,
+    accentFillIdeal,
+    accentFillDiscernible,
+    accentFillReadable,
     highlightBaseColor,
-    highlightFillStealth.rest,
-    highlightFillSubtle.rest,
-    highlightFillIdeal.rest,
-    highlightFillDiscernible.rest,
-    highlightFillReadable.rest,
+    highlightFillStealth,
+    highlightFillSubtle,
+    highlightFillIdeal,
+    highlightFillDiscernible,
+    highlightFillReadable,
     criticalBaseColor,
-    criticalFillStealth.rest,
-    criticalFillSubtle.rest,
-    criticalFillIdeal.rest,
-    criticalFillDiscernible.rest,
-    criticalFillReadable.rest,
+    criticalFillStealth,
+    criticalFillSubtle,
+    criticalFillIdeal,
+    criticalFillDiscernible,
+    criticalFillReadable,
     warningBaseColor,
-    warningFillStealth.rest,
-    warningFillSubtle.rest,
-    warningFillIdeal.rest,
-    warningFillDiscernible.rest,
-    warningFillReadable.rest,
+    warningFillStealth,
+    warningFillSubtle,
+    warningFillIdeal,
+    warningFillDiscernible,
+    warningFillReadable,
     successBaseColor,
-    successFillStealth.rest,
-    successFillSubtle.rest,
-    successFillIdeal.rest,
-    successFillDiscernible.rest,
-    successFillReadable.rest,
+    successFillStealth,
+    successFillSubtle,
+    successFillIdeal,
+    successFillDiscernible,
+    successFillReadable,
     infoBaseColor,
-    infoFillStealth.rest,
-    infoFillSubtle.rest,
-    infoFillIdeal.rest,
-    infoFillDiscernible.rest,
-    infoFillReadable.rest,
+    infoFillStealth,
+    infoFillSubtle,
+    infoFillIdeal,
+    infoFillDiscernible,
+    infoFillReadable,
     neutralBaseColor,
-    neutralFillStealth.rest,
-    neutralFillSubtle.rest,
-    neutralFillIdeal.rest,
-    neutralFillDiscernible.rest,
-    neutralFillReadable.rest,
+    neutralFillStealth,
+    neutralFillSubtle,
+    neutralFillIdeal,
+    neutralFillDiscernible,
+    neutralFillReadable,
     // Stroke
     focusStroke,
     focusStrokeOuter,
     focusStrokeInner,
-    accentStrokeSafety.rest,
-    accentStrokeSubtle.rest,
-    accentStrokeDiscernible.rest,
-    accentStrokeReadable.rest,
-    accentStrokeStrong.rest,
-    highlightStrokeSafety.rest,
-    highlightStrokeSubtle.rest,
-    highlightStrokeDiscernible.rest,
-    highlightStrokeReadable.rest,
-    highlightStrokeStrong.rest,
-    criticalStrokeSafety.rest,
-    criticalStrokeSubtle.rest,
-    criticalStrokeDiscernible.rest,
-    criticalStrokeReadable.rest,
-    criticalStrokeStrong.rest,
-    warningStrokeSafety.rest,
-    warningStrokeSubtle.rest,
-    warningStrokeDiscernible.rest,
-    warningStrokeReadable.rest,
-    warningStrokeStrong.rest,
-    successStrokeSafety.rest,
-    successStrokeSubtle.rest,
-    successStrokeDiscernible.rest,
-    successStrokeReadable.rest,
-    successStrokeStrong.rest,
-    infoStrokeSafety.rest,
-    infoStrokeSubtle.rest,
-    infoStrokeDiscernible.rest,
-    infoStrokeReadable.rest,
-    infoStrokeStrong.rest,
-    neutralStrokeSafety.rest,
-    neutralStrokeSubtle.rest,
-    neutralStrokeDiscernible.rest,
-    neutralStrokeReadable.rest,
-    neutralStrokeStrong.rest,
+    accentStrokeSafety,
+    accentStrokeSubtle,
+    accentStrokeDiscernible,
+    accentStrokeReadable,
+    accentStrokeStrong,
+    highlightStrokeSafety,
+    highlightStrokeSubtle,
+    highlightStrokeDiscernible,
+    highlightStrokeReadable,
+    highlightStrokeStrong,
+    criticalStrokeSafety,
+    criticalStrokeSubtle,
+    criticalStrokeDiscernible,
+    criticalStrokeReadable,
+    criticalStrokeStrong,
+    warningStrokeSafety,
+    warningStrokeSubtle,
+    warningStrokeDiscernible,
+    warningStrokeReadable,
+    warningStrokeStrong,
+    successStrokeSafety,
+    successStrokeSubtle,
+    successStrokeDiscernible,
+    successStrokeReadable,
+    successStrokeStrong,
+    infoStrokeSafety,
+    infoStrokeSubtle,
+    infoStrokeDiscernible,
+    infoStrokeReadable,
+    infoStrokeStrong,
+    neutralStrokeSafety,
+    neutralStrokeSubtle,
+    neutralStrokeDiscernible,
+    neutralStrokeReadable,
+    neutralStrokeStrong,
 ];
 
 const strokeWidthTokens: DesignTokenStore = [
@@ -369,9 +373,9 @@ const effectsTokens: DesignTokenStore = [
     elevationDialog,
 ];
 
-function registerStore(
-    store: DesignTokenStore,
-    registry: DesignTokenRegistry
+function registerStore<T extends { name: string } & DesignTokenMetadata>(
+    store: Store<T>,
+    registry: DesignTokenRegistry<T>
 ): void {
     store.forEach((token) => {
         // console.log("registerStore", token);
@@ -384,7 +388,7 @@ function registerStore(
 // interface for mapping tokens to other recipes or fixed values as well.
 // For now we've grouped the color tokens since by default those are all recipes/derived.
 
-export const registerTokens = (registry: DesignTokenRegistry) => {
+export const registerTokens = (registry: DesignTokenRegistry<AdaptiveDesignToken>) => {
     registerStore(designTokens, registry);
     // This could be optimized, but some tokens are intended to be modified as well as applied as style properties.
     registerStore(strokeWidthTokens, registry);
@@ -393,7 +397,7 @@ export const registerTokens = (registry: DesignTokenRegistry) => {
     registerStore(effectsTokens, registry);
 };
 
-export const registerAppliableTokens = (registry: DesignTokenRegistry) => {
+export const registerAppliableTokens = (registry: DesignTokenRegistry<AdaptiveDesignTokenOrGroup>) => {
     registerStore(colorTokens, registry);
     registerStore(strokeWidthTokens, registry);
     registerStore(densityTokens, registry);

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/style-token-item/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/style-token-item/index.ts
@@ -1,7 +1,7 @@
 import { attr, css, customElement, FASTElement, html, observable, ref, when } from "@microsoft/fast-element";
 import { Styles } from "@adaptive-web/adaptive-ui";
 import { cornerRadiusControl, neutralFillStealthHover, neutralStrokeStrongRest } from "@adaptive-web/adaptive-ui/reference";
-import { TokenGlyph, TokenGlyphType } from "../token-glyph/index.js";
+import { TokenGlyph, TokenGlyphValueType } from "../token-glyph/index.js";
 
 // TODO, make a button
 const template = html<StyleTokenItem>`
@@ -14,14 +14,14 @@ const template = html<StyleTokenItem>`
             ${(x) => x.title}
         </span>
         ${when(
-            (x) => x.glyphType,
+            (x) => x.glyphType || x.styles,
             html`
                 <designer-token-glyph
                     ${ref("glyph")}
                     circular
-                    value=${(x) => x.value}
+                    :value=${(x) => x.value}
                     :styles=${(x) => x.styles}
-                    type=${(x) => x.glyphType}
+                    valueType=${(x) => x.glyphType}
                 >
                 </designer-token-glyph>
             `,
@@ -49,6 +49,11 @@ const styles = css`
         padding: 8px 4px;
     }
 
+    .value {
+        /* Needs a better UI, but cap for long values like font family */
+        max-width: 50%;
+    }
+
     .content,
     .value {
         white-space: nowrap;
@@ -72,10 +77,10 @@ export class StyleTokenItem extends FASTElement {
     public title: string = "";
 
     @attr
-    public value: string = "";
+    public value: string | null = null;
 
     @attr
-    public glyphType?: TokenGlyphType;
+    public glyphType?: TokenGlyphValueType;
 
     public glyph?: TokenGlyph;
 
@@ -84,7 +89,7 @@ export class StyleTokenItem extends FASTElement {
 
     @observable
     public styles?: Styles;
-    protected stylesChanged(_: Styles, next?: Styles) {
+    protected stylesChanged() {
         this.setupGlyph();
     }
 
@@ -95,7 +100,10 @@ export class StyleTokenItem extends FASTElement {
 
     private setupGlyph() {
         if (this.glyph && this.styles) {
-            this.glyph.type = TokenGlyphType.stylesSwatch;
+            if (this.glyphType === TokenGlyphValueType.foreground) {
+                this.glyph.icon = true;
+            }
+            this.glyph.valueType = null;
             this.glyph.interactive = true;
         }
     }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/style-token-item/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/style-token-item/index.ts
@@ -1,6 +1,7 @@
-import { attr, css, customElement, FASTElement, html, when } from "@microsoft/fast-element";
+import { attr, css, customElement, FASTElement, html, observable, ref, when } from "@microsoft/fast-element";
+import { Styles } from "@adaptive-web/adaptive-ui";
 import { cornerRadiusControl, neutralFillStealthHover, neutralStrokeStrongRest } from "@adaptive-web/adaptive-ui/reference";
-import { TokenGlyphType } from "../token-glyph/index.js";
+import { TokenGlyph, TokenGlyphType } from "../token-glyph/index.js";
 
 // TODO, make a button
 const template = html<StyleTokenItem>`
@@ -8,6 +9,7 @@ const template = html<StyleTokenItem>`
         <span
             class="content"
             role=${x => (x.contentButton ? "button" : null)}
+            @click="${(x, c) => x.handleContentClick(c.event)}"
         >
             ${(x) => x.title}
         </span>
@@ -15,8 +17,10 @@ const template = html<StyleTokenItem>`
             (x) => x.glyphType,
             html`
                 <designer-token-glyph
+                    ${ref("glyph")}
                     circular
                     value=${(x) => x.value}
+                    :styles=${(x) => x.styles}
                     type=${(x) => x.glyphType}
                 >
                 </designer-token-glyph>
@@ -73,6 +77,30 @@ export class StyleTokenItem extends FASTElement {
     @attr
     public glyphType?: TokenGlyphType;
 
+    public glyph?: TokenGlyph;
+
     @attr({ attribute: "content-button", mode: "boolean" })
     public contentButton: boolean = false;
+
+    @observable
+    public styles?: Styles;
+    protected stylesChanged(_: Styles, next?: Styles) {
+        this.setupGlyph();
+    }
+
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.setupGlyph();
+    }
+
+    private setupGlyph() {
+        if (this.glyph && this.styles) {
+            this.glyph.type = TokenGlyphType.stylesSwatch;
+            this.glyph.interactive = true;
+        }
+    }
+
+    public handleContentClick(event: Event): void {
+        this.$emit("itemClick", event);
+    }
 }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/token-glyph/index.ts
@@ -1,5 +1,5 @@
 import { attr, css, customElement, ElementStyles, FASTElement, html, observable } from "@microsoft/fast-element";
-import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
+import { cornerRadiusControl, neutralStrokeStrong } from "@adaptive-web/adaptive-ui/reference";
 import { ElementStylesRenderer, Interactivity, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
 import { formatHex8, parse } from "culori/fn";
@@ -7,14 +7,14 @@ import BlobIcon from "../../assets/blob.svg";
 
 const template = html<TokenGlyph>`
     <template
-        class=${x => (x.value === "none" && x.type !== TokenGlyphType.stylesSwatch ? "none" : "")}
+        class=${x => (x.valueType !== null && x.value === null ? "none" : null)}
         tabindex=${x => (x.interactive ? "0" : null)}
         role=${x => (x.interactive ? "button" : null)}
     >
         <div
             part="swatch"
             class="swatch"
-            style=${x => (!x.value || x.value === "none" ? "" : `--swatch-value: ${x.valueColor}`)}
+            style=${x => (x.value !== null ? `--swatch-value: ${x.valueColor}` : null)}
         >
             <span class="text">Ag</span>
             <span class="icon">${staticallyCompose(BlobIcon)}</span>
@@ -24,6 +24,7 @@ const template = html<TokenGlyph>`
 
 const styles = css`
     :host {
+        position: relative;
         box-sizing: border-box;
         display: inline-flex;
         align-items: center;
@@ -39,52 +40,77 @@ const styles = css`
         width: 32px;
         height: 32px;
         border-radius: calc(${cornerRadiusControl} * 2);
-        color: transparent; /* Reset for styles which don't have a foreground color */
+        /* Resets for 'style' type, here for specificity */
+        color: transparent;
+        border: solid 6px transparent;
     }
 
-    .text,
-    .icon {
-        display: none;
+    .text {
         user-select: none;
     }
 
-    :host([type="background"]) .swatch,
-    :host([type="border"]) .swatch {
-        background-color: var(--swatch-value);
-        border: 1px solid #e8e8e8;
+    .icon {
+        display: none;
     }
 
-    :host([type="border"]) .swatch::before {
+    svg {
+        fill: currentcolor;
+    }
+
+    :host([valueType="background"]) .swatch {
+        background-color: var(--swatch-value);
+    }
+
+    :host([valueType="border"]) .swatch {
+        border-color: var(--swatch-value);
+    }
+
+    /* Pseudo border rings */
+    :host([valueType="border"]) .swatch::before,
+    :host([valueType="background"]) .swatch::after,
+    :host([valueType="border"]) .swatch::after {
         display: block;
         content: "";
         position: absolute;
-        top: 6px;
-        bottom: 6px;
-        left: 6px;
-        right: 6px;
         box-sizing: border-box;
-        background: var(--color-context);
         border: 1px solid #e8e8e8;
-        border-radius: calc(${cornerRadiusControl} * 2);
+        border-radius: inherit;
     }
 
-    :host([type="icon"]) .swatch {
+    /* Inner pseudo border ring */
+    :host([valueType="border"]) .swatch::before {
+        inset: 0;
+    }
+
+    /* Outer pseudo border ring */
+    :host([valueType="background"]) .swatch::after,
+    :host([valueType="border"]) .swatch::after {
+        inset: -8px;
+    }
+
+    :host([valueType="foreground"]) .swatch,
+    :host([icon]) .swatch {
         position: relative;
         width: 28px;
         height: 28px;
         overflow: hidden;
+    }
+
+    :host([valueType="foreground"]) .swatch {
         color: var(--swatch-value);
     }
 
-    :host([type="icon"]) .icon {
+    :host([valueType="foreground"]) .icon,
+    :host([icon]) .icon {
         display: block;
     }
 
-    :host([type="icon"]) svg {
-        fill: currentcolor;
+    :host([valueType="foreground"]) .text,
+    :host([icon]) .text {
+        display: none;
     }
 
-    :host(.none) .swatch::after {
+    :host(.none)::after {
         display: block;
         content: "";
         width: 1px;
@@ -96,12 +122,7 @@ const styles = css`
         transform: rotate(45deg);
     }
 
-    :host([type="styles"]) .text {
-        display: block;
-    }
-
-    :host([circular]) .swatch,
-    :host([circular]) .swatch::before {
+    :host([circular]) .swatch {
         border-radius: 50%;
     }
 
@@ -111,16 +132,15 @@ const styles = css`
     }
 `;
 
-export enum TokenGlyphType {
-    backgroundSwatch = "background",
-    borderSwatch = "border",
-    stylesSwatch = "styles",
-    icon = "icon",
+export enum TokenGlyphValueType {
+    background = "background",
+    foreground = "foreground",
+    border = "border",
 }
 
 const params: StyleModuleTarget = {
     ...Interactivity.always,
-    context: ":host([type='styles'])", // More specificity than the `.swatch` selector above
+    context: ":host(:not([foo]))", // More specificity than the `.swatch` selector above
     part: ".swatch",
 };
 
@@ -133,14 +153,11 @@ const PLACEHOLDER_COLOR = "#ff00ff";
 })
 export class TokenGlyph extends FASTElement {
     @attr
-    public type: TokenGlyphType = TokenGlyphType.backgroundSwatch;
-
-    @attr({ mode: "boolean" })
-    public circular: boolean = false;
+    public valueType: TokenGlyphValueType = TokenGlyphValueType.background;
 
     @attr
-    public value: string | "none" = "none";
-    protected valueChanged(prev: string, next: string) {
+    public value: string | null = null;
+    protected valueChanged(prev: string | null, next: string | null) {
         const color = parse(next);
         this.valueColor = formatHex8(color) || PLACEHOLDER_COLOR;
     }
@@ -150,15 +167,28 @@ export class TokenGlyph extends FASTElement {
 
     @observable
     public styles?: Styles;
-    protected stylesChanged(prev: Styles, next: Styles) {
+    protected stylesChanged(prev?: Styles, next?: Styles) {
         if (prev) {
             this.$fastController.removeStyles(this._addedStyles);
         }
         if (next) {
+            // There are too many combinations of needs for the preview glyph.
+            // This is a workaround for the font-only styles so they display for now.
+            if (next.effectiveProperties.has("fontFamily") && !next.effectiveProperties.has("foregroundFill")) {
+                const props = next.properties;
+                props.set("foregroundFill", neutralStrokeStrong.rest);
+                next.properties = props;
+            }
             this._addedStyles = new ElementStylesRenderer(next).render(params);
             this.$fastController.addStyles(this._addedStyles);
         }
     }
+
+    @attr({ mode: "boolean" })
+    public circular: boolean = false;
+
+    @attr({ mode: "boolean" })
+    public icon: boolean = false;
 
     @attr({ mode: "boolean" })
     public interactive: boolean = false;

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/components/token-glyph/index.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/components/token-glyph/index.ts
@@ -1,6 +1,6 @@
 import { attr, css, customElement, ElementStyles, FASTElement, html, observable } from "@microsoft/fast-element";
 import { cornerRadiusControl } from "@adaptive-web/adaptive-ui/reference";
-import { ElementStylesRenderer, Interactivity, Styles } from "@adaptive-web/adaptive-ui";
+import { ElementStylesRenderer, Interactivity, StyleModuleTarget, Styles } from "@adaptive-web/adaptive-ui";
 import { staticallyCompose } from "@microsoft/fast-foundation";
 import { formatHex8, parse } from "culori/fn";
 import BlobIcon from "../../assets/blob.svg";
@@ -39,11 +39,13 @@ const styles = css`
         width: 32px;
         height: 32px;
         border-radius: calc(${cornerRadiusControl} * 2);
+        color: transparent; /* Reset for styles which don't have a foreground color */
     }
 
     .text,
     .icon {
         display: none;
+        user-select: none;
     }
 
     :host([type="background"]) .swatch,
@@ -116,8 +118,9 @@ export enum TokenGlyphType {
     icon = "icon",
 }
 
-const params = {
+const params: StyleModuleTarget = {
     ...Interactivity.always,
+    context: ":host([type='styles'])", // More specificity than the `.swatch` selector above
     part: ".swatch",
 };
 

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
@@ -1,5 +1,5 @@
 import { customElement, FASTElement, html } from "@microsoft/fast-element";
-import type { DesignToken, StaticDesignTokenValue } from "@microsoft/fast-foundation";
+import { DesignToken, StaticDesignTokenValue } from "@microsoft/fast-foundation";
 import { Swatch } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
 import { DesignTokenValue, PluginUINodeData } from "@adaptive-web/adaptive-ui-designer-core";
@@ -130,7 +130,7 @@ export class ElementsController {
         return (value: DesignTokenValue, key: string): void => {
             const token = this.controller.designTokenRegistry.get(key);
             // console.log("      setting token", key, token, value.value);
-            if (token) {
+            if (token && token instanceof DesignToken) {
                 this.setDesignTokenForElement(
                     element,
                     token,
@@ -171,8 +171,8 @@ export class ElementsController {
         // console.log("    setting additional data");
         node.additionalData.forEach((value, key) => {
             const token = this.controller.designTokenRegistry.get(key);
-            if (token) {
-                // console.log("      setting token value on element", token, "value", value);
+            if (token && token instanceof DesignToken) {
+                // console.log("      setting token value on element", def, "value", value);
                 this.setDesignTokenForElement(nodeElement, token, value);
             }
         }, this);

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
@@ -256,7 +256,7 @@ export class UIController {
                                 console.warn("    token type not supported >", typeof token, token);
                             }
                         }
-                    } else {
+                    } else if (applied.tokenID) {
                         const tokenIDParts = applied.tokenID.split(".");
                         if (Object.keys(InteractiveState).includes(tokenIDParts[tokenIDParts.length - 1])) {
                             const groupState = tokenIDParts.pop();

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
@@ -1,10 +1,12 @@
 import { calc } from '@csstools/css-calc';
 import { FASTElement, observable } from "@microsoft/fast-element";
-import { CSSDesignToken, type ValuesOf } from "@microsoft/fast-foundation";
+import { CSSDesignToken, DesignToken, type ValuesOf } from "@microsoft/fast-foundation";
 import { Color, InteractiveState, InteractiveTokenGroup, StyleProperty, Styles, Swatch } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
 import { formatHex8 } from 'culori';
 import {
+    AdaptiveDesignToken,
+    AdaptiveDesignTokenOrGroup,
     AdditionalDataKeys,
     AppliedDesignToken,
     AppliedStyleModules,
@@ -58,7 +60,19 @@ type AppliedTokenSource = ValuesOf<typeof AppliedTokenSource>;
  * Information about an applied design token, used to evaluate and apply the value.
  */
 type AppliedStyleValueInfo = {
+    /**
+     * The name of the token, which may also be an interactive group.
+     */
+    name?: string;
+
+    /**
+     * The value when evaluated.
+     */
     value: string | CSSDesignToken<any>;
+
+    /**
+     * How the token was applied.
+     */
     source: AppliedTokenSource;
 }
 
@@ -102,8 +116,8 @@ export class UIController {
     // What was previously a "recipe" is now an "applied design token".
     // The separation is useful for now in that "setting" a token is for overriding a value at a node,
     // and "applying" a token is using it for some visual element.
-    public readonly designTokenRegistry: DesignTokenRegistry = new DesignTokenRegistry();
-    public readonly appliableDesignTokenRegistry: DesignTokenRegistry = new DesignTokenRegistry();
+    public readonly designTokenRegistry: DesignTokenRegistry<AdaptiveDesignToken> = new DesignTokenRegistry();
+    public readonly appliableDesignTokenRegistry: DesignTokenRegistry<AdaptiveDesignTokenOrGroup> = new DesignTokenRegistry();
 
     private _selectedNodes: PluginUINodeData[] = [];
 
@@ -221,10 +235,27 @@ export class UIController {
                 if (applied) {
                     const token = registry.get(applied.tokenID);
                     if (token) {
-                        allApplied.set(target, {
-                            value: token as CSSDesignToken<any>,
-                            source,
-                        });
+                        if (token instanceof DesignToken) {
+                            console.error("Token is not appliable:", applied.tokenID, node.name, node.type, node.id, applied.value);
+                        } else if (token instanceof CSSDesignToken) {
+                            allApplied.set(target, {
+                                name: token.name,
+                                value: token,
+                                source,
+                            });
+                        } else {
+                            const group = (token as InteractiveTokenGroup<any>);
+                            if (group && group[state]) {
+                                // console.log("    applying group >", state, group);
+                                allApplied.set(target, {
+                                    name: group.name,
+                                    value: group[state],
+                                    source,
+                                });
+                            } else {
+                                console.warn("    token type not supported >", typeof token, token);
+                            }
+                        }
                     } else {
                         console.error("Token not found:", applied.tokenID, node.name, node.type, node.id, applied.value);
                     }
@@ -269,6 +300,7 @@ export class UIController {
                         if (value instanceof CSSDesignToken) {
                             // console.log("    applying token >", value);
                             allApplied.set(target, {
+                                name: value.name,
                                 value,
                                 source,
                             });
@@ -283,6 +315,7 @@ export class UIController {
                             if (group && group[state]) {
                                 // console.log("    applying group >", state, group);
                                 allApplied.set(target, {
+                                    name: group.name,
                                     value: group[state],
                                     source,
                                 });
@@ -333,13 +366,7 @@ export class UIController {
             const allApplied = this.collectEffectiveAppliedStyles(node);
             allApplied.forEach((info, target) => {
                 if (info.value) {
-                    if (typeof info.value === "string") {
-                        // console.log("    evaluateEffectiveAppliedStyleValues", target, " : ", "string", " -> ", info.value, `(from ${info.source})`);
-                        const applied = new AppliedStyleValue(info.value);
-                        node.effectiveAppliedStyleValues.set(target, applied);
-                    } else {
-                        this.evaluateEffectiveAppliedDesignToken(target, info.value, node, info.source);
-                    }
+                    this.evaluateEffectiveAppliedDesignToken(target, info, node);
                 } else {
                     console.warn("Token not found in appliable tokens", info.source);
                 }
@@ -353,50 +380,57 @@ export class UIController {
         });
     }
 
-    private evaluateEffectiveAppliedDesignToken(target: StyleProperty, token: CSSDesignToken<any>, node: PluginUINodeData, source: AppliedTokenSource) {
-        const valueOriginal: any = this._elements.getDesignTokenValue(node, token);
-        let value: any = valueOriginal;
-        // let valueDebug: any;
-        if (valueOriginal instanceof Color) {
-            const swatch = valueOriginal;
-            value = formatHex8(swatch.color);
-            // valueDebug = swatch.toColorString();
-        } else if (typeof valueOriginal === "string") {
-            if (valueOriginal.startsWith("calc")) {
-                const ret = calc(valueOriginal as string);
-                // console.log(`    calc ${value} returns ${ret}`);
-                value = ret;
+    private evaluateEffectiveAppliedDesignToken(target: StyleProperty, info: AppliedStyleValueInfo, node: PluginUINodeData) {
+        if (typeof info.value === "string") {
+            // console.log("    evaluateEffectiveAppliedStyleValues", target, " : ", "string", " -> ", info.value, `(from ${info.source})`);
+            const applied = new AppliedStyleValue(info.value);
+            node.effectiveAppliedStyleValues.set(target, applied);
+        } else {
+            const token = info.value;
+            const valueOriginal: any = this._elements.getDesignTokenValue(node, token);
+            let value: any = valueOriginal;
+            // let valueDebug: any;
+            if (valueOriginal instanceof Color) {
+                const swatch = valueOriginal;
+                value = formatHex8(swatch.color);
+                // valueDebug = swatch.toColorString();
+            } else if (typeof valueOriginal === "string") {
+                if (valueOriginal.startsWith("calc")) {
+                    const ret = calc(valueOriginal as string);
+                    // console.log(`    calc ${value} returns ${ret}`);
+                    value = ret;
+                }
             }
-        }
-        // const fillColorValue = (this._elements.getDesignTokenValue(node, fillColor) as Swatch).toColorString();
-        // console.log("    evaluateEffectiveAppliedDesignToken", target, " : ", token.name, " -> ", value, valueDebug, `(from ${source})`, "fillColor", fillColorValue);
+            const fillColorValue = (this._elements.getDesignTokenValue(node, fillColor) as Swatch).toColorString();
+            // console.log("    evaluateEffectiveAppliedDesignToken", target, " : ", token.name, " -> ", value, valueDebug, `(from ${info.source})`, "fillColor", fillColorValue);
 
-        const applied = new AppliedStyleValue(value);
-        node.effectiveAppliedStyleValues.set(target, applied);
+            const applied = new AppliedStyleValue(value);
+            node.effectiveAppliedStyleValues.set(target, applied);
 
-        if (source === AppliedTokenSource.local) {
-            const appliedToken = new AppliedDesignToken(token.name, value);
-            node.appliedDesignTokens.set(target, appliedToken);
-        }
+            if (info.source === AppliedTokenSource.local) {
+                const appliedToken = new AppliedDesignToken(info.name, value);
+                node.appliedDesignTokens.set(target, appliedToken);
+            }
 
-        // This is necessary for representing nested elements in Figma, but does not realistically represent the way the tokens work.
-        // - A node will come in with the paren't fill color provided in `additionalData`. This accounts for relative color recipes,
-        //   but addressed the fact only selected nodes are processed going down the hierarchy.
-        // - If this node calculates a new background fill we need to update that value.
-        // - See `evaluateEffectiveAppliedStyleValues` where this value is set as a design token value.
-        // 
-        // This is perhaps still the most indirect interaction in Adaptive UI, where most color recipes are based on a container fill,
-        // but there's no way to resolve the _container_ color, so the color has to be on the _child_ node.
-        // This is further complicated by the fact that token values can only be set at the component level, not for a child element.
-        // This is also one of the primary motivations of the style modules and the creation of background/foreground color sets, because
-        // the foreground can be evaluated in the context of the background color, removing the reliance on the `fill-color` token.
-        if (target === StyleProperty.backgroundFill) {
-            if (node.children.length > 0) {
-                // console.log(`        Setting '${AdditionalDataKeys.toolParentFillColor}' additional data on children`, value, valueOriginal);
-                node.children.forEach(child => {
-                    // console.log("          Child", child.id, child.name);
-                    child.additionalData.set(AdditionalDataKeys.toolParentFillColor, value);
-                });
+            // This is necessary for representing nested elements in Figma, but does not realistically represent the way the tokens work.
+            // - A node will come in with the paren't fill color provided in `additionalData`. This accounts for relative color recipes,
+            //   but addressed the fact only selected nodes are processed going down the hierarchy.
+            // - If this node calculates a new background fill we need to update that value.
+            // - See `evaluateEffectiveAppliedStyleValues` where this value is set as a design token value.
+            // 
+            // This is perhaps still the most indirect interaction in Adaptive UI, where most color recipes are based on a container fill,
+            // but there's no way to resolve the _container_ color, so the color has to be on the _child_ node.
+            // This is further complicated by the fact that token values can only be set at the component level, not for a child element.
+            // This is also one of the primary motivations of the style modules and the creation of background/foreground color sets, because
+            // the foreground can be evaluated in the context of the background color, removing the reliance on the `fill-color` token.
+            if (target === StyleProperty.backgroundFill) {
+                if (node.children.length > 0) {
+                    // console.log(`        Setting '${AdditionalDataKeys.toolParentFillColor}' additional data on children`, value, valueOriginal);
+                    node.children.forEach(child => {
+                        // console.log("          Child", child.id, child.name);
+                        child.additionalData.set(AdditionalDataKeys.toolParentFillColor, value);
+                    });
+                }
             }
         }
     }

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/util.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/util.ts
@@ -1,7 +1,6 @@
 import { sentenceCase } from "change-case";
-import { DesignToken } from "@microsoft/fast-foundation";
 
-export function designTokenTitle(token?: DesignToken<any>): string {
+export function designTokenTitle(token?: { name: string }): string {
     if (token === undefined || token.name === undefined) {
         console.log(token);
         

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -251,14 +251,10 @@ export class DensityPaddingAndGapTokenGroup implements TokenGroup {
 }
 
 // @public
-export class DesignTokenMetadata {
-    // (undocumented)
-    protected init(type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]): void;
-    get intendedFor(): StyleProperty[] | undefined;
-    protected set intendedFor(value: StyleProperty[] | undefined);
-    get type(): DesignTokenType;
-    protected set type(value: DesignTokenType);
-}
+export type DesignTokenMetadata = {
+    readonly type: DesignTokenType;
+    readonly intendedFor?: StyleProperty[];
+};
 
 // @public
 export class DesignTokenMultiValue<T extends CSSDirective | string> extends Array<T> implements CSSDirective {
@@ -381,7 +377,7 @@ export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {
 export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
 
 // @public
-export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveValues<TypedCSSDesignToken<T>> {
+export interface InteractiveTokenGroup<T> extends MakePropertyRequired<TokenGroup, "type">, InteractiveValues<TypedCSSDesignToken<T>> {
 }
 
 // @public
@@ -410,6 +406,14 @@ export function isDark(color: RelativeLuminance): boolean;
 
 // @public
 export function luminanceSwatch(luminance: number): Swatch;
+
+// @public (undocumented)
+export type MakePropertyOptional<T, K extends keyof T> = Omit<T, K> & {
+    [P in K]?: T[P];
+};
+
+// @public (undocumented)
+export type MakePropertyRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 // @public
 export function makeSelector(params: StyleModuleEvaluateParameters, state: InteractiveState): string;
@@ -733,8 +737,8 @@ export class Swatch extends Color {
 export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null;
 
 // @public
-export interface TokenGroup {
-    intendedFor?: StyleProperty | StyleProperty[];
+export interface TokenGroup extends MakePropertyOptional<DesignTokenMetadata, "type"> {
+    intendedFor?: StyleProperty[];
     name: string;
     type?: DesignTokenType;
 }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -707,7 +707,7 @@ export class Styles {
     static fromDeclaration(declaration: StyleDeclaration, name?: string): Styles;
     static fromProperties(properties: StyleProperties, name?: string): Styles;
     readonly name: string | undefined;
-    get properties(): StylePropertiesMap | undefined;
+    get properties(): Readonly<StylePropertiesMap> | undefined;
     set properties(properties: StylePropertiesMap | undefined);
     // (undocumented)
     static Shared: Map<string, Styles>;

--- a/packages/adaptive-ui/src/core/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/core/adaptive-design-tokens.ts
@@ -45,7 +45,13 @@ export type DesignTokenType = ValuesOf<typeof DesignTokenType> | string;
  *
  * @public
  */
-export class DesignTokenMetadata {
+export type DesignTokenMetadata = {
+    readonly type: DesignTokenType;
+    readonly intendedFor?: StyleProperty[];
+};
+
+// A slight alteration of the mixin pattern to hide an internal function from the public type.
+class DesignTokenMetadataImpl implements DesignTokenMetadata {
     // TODO: This needs to support multiple types, tokens in Adaptive UI might represent different value
     // types, like a Swatch type commonly refers to a `color` but may also be a `gradient`. (see `create.ts`)
     private _type: DesignTokenType = "string";
@@ -74,7 +80,7 @@ export class DesignTokenMetadata {
         this._intendedFor = value;
     }
 
-    protected init(type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
+    setMetadata(type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
         this.type = type;
         if (intendedFor) {
             if (Array.isArray(intendedFor)) {
@@ -114,7 +120,7 @@ export abstract class DesignTokenRegistry {
 export class TypedDesignToken<T> extends DesignToken<T> implements DesignTokenMetadata {
     constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
         super({ name });
-        this.init(type, intendedFor);
+        (this as unknown as DesignTokenMetadataImpl).setMetadata(type, intendedFor);
     }
 
     /**
@@ -136,7 +142,7 @@ export class TypedDesignToken<T> extends DesignToken<T> implements DesignTokenMe
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface TypedDesignToken<T> extends DesignTokenMetadata {}
-applyMixins(TypedDesignToken, DesignTokenMetadata);
+applyMixins(TypedDesignToken, DesignTokenMetadataImpl);
 
 /**
  * A CSSDesignToken with value type and intended styling uses.
@@ -149,7 +155,7 @@ export class TypedCSSDesignToken<T> extends CSSDesignToken<T> implements DesignT
     constructor(name: string, type: DesignTokenType, intendedFor?: StyleProperty | StyleProperty[]) {
         const cssName = name.replace(/\./g, "-");
         super({ name, cssCustomPropertyName: cssName });
-        this.init(type, intendedFor);
+        (this as unknown as DesignTokenMetadataImpl).setMetadata(type, intendedFor);
     }
 
     /**
@@ -171,7 +177,7 @@ export class TypedCSSDesignToken<T> extends CSSDesignToken<T> implements DesignT
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface TypedCSSDesignToken<T> extends DesignTokenMetadata {}
-applyMixins(TypedCSSDesignToken, DesignTokenMetadata);
+applyMixins(TypedCSSDesignToken, DesignTokenMetadataImpl);
 
 /**
  * A design token value for css properties which can have multiple values, like `box-shadow`.

--- a/packages/adaptive-ui/src/core/modules/styles.ts
+++ b/packages/adaptive-ui/src/core/modules/styles.ts
@@ -314,7 +314,7 @@ export class Styles {
     /**
      * The local properties or composition overrides.
      */
-    public get properties(): StylePropertiesMap | undefined {
+    public get properties(): Readonly<StylePropertiesMap> | undefined {
         return this._properties;
     }
 

--- a/packages/adaptive-ui/src/core/types.ts
+++ b/packages/adaptive-ui/src/core/types.ts
@@ -1,12 +1,16 @@
-import type { DesignTokenType, TypedCSSDesignToken } from "./adaptive-design-tokens.js";
+import type { DesignTokenMetadata, DesignTokenType, TypedCSSDesignToken } from "./adaptive-design-tokens.js";
 import { StyleProperty } from "./modules/types.js";
+
+export type MakePropertyOptional<T, K extends keyof T> = Omit<T, K> & { [P in K]?: T[P] };
+
+export type MakePropertyRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 /**
  * A group of tokens.
  *
  * @public
  */
-export interface TokenGroup {
+export interface TokenGroup extends MakePropertyOptional<DesignTokenMetadata, "type"> {
     /**
      * The name of the token group. Contained tokens should extend this name like `groupName` -\> `groupName.child`.
      */
@@ -20,7 +24,7 @@ export interface TokenGroup {
     /**
      * The style properties where tokens within this group are intended to be used.
      */
-    intendedFor?: StyleProperty | StyleProperty[]
+    intendedFor?: StyleProperty[];
 }
 
 /**
@@ -69,4 +73,4 @@ export type InteractiveValues<T> = {
  *
  * @public
  */
-export interface InteractiveTokenGroup<T> extends TokenGroup, InteractiveValues<TypedCSSDesignToken<T>> {}
+export interface InteractiveTokenGroup<T> extends MakePropertyRequired<TokenGroup, "type">, InteractiveValues<TypedCSSDesignToken<T>> {}

--- a/packages/adaptive-ui/src/reference/elevation.ts
+++ b/packages/adaptive-ui/src/reference/elevation.ts
@@ -75,7 +75,7 @@ export const elevationCardDisabled = createTokenShadow("elevation.card.disabled"
 export const elevationCardInteractive: InteractiveTokenGroup<ShadowValue> = {
     name: "elevation.card",
     type: DesignTokenType.shadow,
-    intendedFor: StyleProperty.shadow,
+    intendedFor: [StyleProperty.shadow],
     rest: elevationCardRest,
     hover: elevationCardHover,
     active: elevationCardActive,


### PR DESCRIPTION
# Pull Request

## Description

### AUI
Improved support for registering Interactive Token groups for use in design token properties.
Standardized some type information for groups.

### Designer plugin
Added support for applying interactive token groups directly as properties instead of only through styles (modules) as available previously.

## Reviewer Notes

I don't love the updates to get the token glyph preview to work in the plugin. I have some ideas to clean that up by turning the basic properties into the same `styles` format to ease the logic required to figure out what type of preview to show.

## Test Plan

Tested in Figma.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.