### PR TITLE
AUI: Refactored Swatch to Color

### DIFF
--- a/change/@adaptive-web-adaptive-ui-65457e29-816e-41a0-b84d-d5eb76b92e78.json
+++ b/change/@adaptive-web-adaptive-ui-65457e29-816e-41a0-b84d-d5eb76b92e78.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Refactored Swatch to Color",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-web-components-f26fdf42-e841-46c7-bcf2-927d4a453ab2.json
+++ b/change/@adaptive-web-adaptive-web-components-f26fdf42-e841-46c7-bcf2-927d4a453ab2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "AUI: Refactored Swatch to Color",
+  "packageName": "@adaptive-web/adaptive-web-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/adaptive-ui-designer-figma-plugin/src/figma/utility.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/figma/utility.ts
@@ -46,3 +46,7 @@ export const colorToRgba = (color: Rgb): RGBA => {
         a: color.alpha || 1,
     };
 }
+
+export const roundToDecimals = (num: number, dec: number): number => {
+    return parseFloat(num.toFixed(dec));
+}

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
@@ -1,6 +1,6 @@
 import { customElement, FASTElement, html } from "@microsoft/fast-element";
 import { DesignToken, StaticDesignTokenValue } from "@microsoft/fast-foundation";
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { Color } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
 import { DesignTokenValue, PluginUINodeData } from "@adaptive-web/adaptive-ui-designer-core";
 import { UIController } from "./ui-controller.js";
@@ -55,7 +55,13 @@ export class ElementsController {
         try {
             if (value) {
                 // TODO figure out a better way to handle storage data types
-                const color = Swatch.parse((value as unknown) as string);
+
+                let color: Color | null = null;
+                if (value instanceof Color) {
+                    color = value;
+                } else {
+                    color = Color.parse((value as unknown) as string);
+                }
                 if (color) {
                     // TODO fix this logic
                     // console.log("        setting DesignToken value (color)", token.name, value);

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-tokens.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-tokens.ts
@@ -2,7 +2,6 @@ import { calc } from '@csstools/css-calc';
 import { observable } from "@microsoft/fast-element";
 import { DesignToken } from "@microsoft/fast-foundation";
 import { Color } from "@adaptive-web/adaptive-ui";
-import { formatHex8 } from 'culori';
 import { DesignTokenValue, PluginUINodeData } from "@adaptive-web/adaptive-ui-designer-core";
 import { UIController } from "./ui-controller.js";
 import { ElementsController } from "./ui-controller-elements.js";
@@ -110,7 +109,7 @@ export class DesignTokenController {
         // TODO figure out a better way to handle storage data types
         // Reconcile with similar block in evaluateEffectiveAppliedDesignToken
         if (value instanceof Color) {
-            return formatHex8(value.color);
+            return value.toString();
         } else if (typeof value === "string") {
             if (value.startsWith("calc")) {
                 return calc(value);

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
@@ -1,7 +1,7 @@
 import { calc } from '@csstools/css-calc';
 import { FASTElement, observable } from "@microsoft/fast-element";
 import { CSSDesignToken, DesignToken, type ValuesOf } from "@microsoft/fast-foundation";
-import { Color, InteractiveState, InteractiveTokenGroup, StyleProperty, Styles, Swatch } from "@adaptive-web/adaptive-ui";
+import { Color, InteractiveState, InteractiveTokenGroup, StyleProperty, Styles } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
 import { formatHex8 } from 'culori';
 import {
@@ -382,7 +382,7 @@ export class UIController {
             if (colorHex) {
                 const parentElement = this._elements.getElementForNode(node).parentElement as FASTElement;
                 // console.log("    setting fill color token on parent element", colorHex, parentElement.id, parentElement.title);
-                this._elements.setDesignTokenForElement(parentElement, fillColor, Swatch.parse(colorHex));
+                this._elements.setDesignTokenForElement(parentElement, fillColor, Color.parse(colorHex));
             }
 
             const allApplied = this.collectEffectiveAppliedStyles(node);
@@ -413,8 +413,8 @@ export class UIController {
             let value: any = valueOriginal;
             // let valueDebug: any;
             if (valueOriginal instanceof Color) {
-                const swatch = valueOriginal;
-                value = formatHex8(swatch.color);
+                const color = valueOriginal;
+                value = formatHex8(color.color);
                 // valueDebug = swatch.toColorString();
             } else if (typeof valueOriginal === "string") {
                 if (valueOriginal.startsWith("calc")) {
@@ -423,7 +423,7 @@ export class UIController {
                     value = ret;
                 }
             }
-            const fillColorValue = (this._elements.getDesignTokenValue(node, fillColor) as Swatch).toColorString();
+            // const fillColorValue = (this._elements.getDesignTokenValue(node, fillColor) as Color).toColorString();
             // console.log("    evaluateEffectiveAppliedDesignToken", target, " : ", token.name, " -> ", value, valueDebug, `(from ${info.source})`, "fillColor", fillColorValue);
 
             const applied = new AppliedStyleValue(value);

--- a/packages/adaptive-ui-explorer/src/app.ts
+++ b/packages/adaptive-ui-explorer/src/app.ts
@@ -1,6 +1,6 @@
 import {
+    Color,
     Palette,
-    Swatch,
 } from "@adaptive-web/adaptive-ui";
 import {
     accentBaseColor,
@@ -289,7 +289,7 @@ export class App extends FASTElement {
               });
     }
 
-    private layerTokens: Array<[DesignToken<Swatch>, string]> = [
+    private layerTokens: Array<[DesignToken<Color>, string]> = [
         [layerFillFixedPlus1, "+1"],
         [layerFillFixedBase, "Base"],
         [layerFillFixedMinus1, "-1"],
@@ -303,7 +303,7 @@ export class App extends FASTElement {
             layerFillBaseLuminance.setValueFor(ds, luminance);
 
             return this.layerTokens
-                .map((conf: [DesignToken<Swatch>, string]): SwatchInfo => {
+                .map((conf: [DesignToken<Color>, string]): SwatchInfo => {
                     const color = conf[0].getValueFor(ds).toColorString();
                     return {
                         index: this.neutralColors.indexOf(color),

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -1,4 +1,4 @@
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { Color } from "@adaptive-web/adaptive-ui";
 import {
     accentFillDiscernibleControlStyles,
     accentFillIdealControlStyles,
@@ -261,9 +261,9 @@ export class ColorBlock extends FASTElement {
 
     private updateColor(): void {
         if (this.color && this.$fastController.isConnected) {
-            const swatch =Swatch.parse(this.color)
-            if (swatch) {
-                fillColor.setValueFor(this, swatch);
+            const color = Color.parse(this.color)
+            if (color) {
+                fillColor.setValueFor(this, color);
             }
         }
     }

--- a/packages/adaptive-ui-explorer/src/components/layer-background/index.ts
+++ b/packages/adaptive-ui-explorer/src/components/layer-background/index.ts
@@ -1,4 +1,4 @@
-import { Swatch } from '@adaptive-web/adaptive-ui';
+import { Color } from '@adaptive-web/adaptive-ui';
 import {
     fillColor,
     layerFillBaseLuminance,
@@ -61,7 +61,7 @@ export class LayerBackground extends FASTElement {
         }
 
         if (this.backgroundLayerRecipe !== undefined) {
-            let swatch: Swatch | null = null;
+            let swatch: Color | null = null;
             switch (this.backgroundLayerRecipe) {
                 case "-1":
                     swatch = layerFillFixedMinus1.getValueFor(this);

--- a/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.template.ts
+++ b/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.template.ts
@@ -1,16 +1,16 @@
 import { html, repeat } from "@microsoft/fast-element";
-import { Color, isDark, Swatch } from "@adaptive-web/adaptive-ui";
+import { Color, isDark } from "@adaptive-web/adaptive-ui";
 import { PaletteGradient } from "./palette-gradient.js";
 
-function getClass(swatch: Swatch, source?: Color, closestSource?: Swatch) {
-    return swatch.toColorString() === source?.toColorString()
+function getClass(color: Color, source?: Color, closestSource?: Color) {
+    return color.toString() === source?.toString()
         ? "source"
-        : swatch.toColorString() === closestSource?.toColorString()
+        : color.toString() === closestSource?.toString()
         ? "source closest"
         : "";
 }
 
-function getColor(background: Swatch) {
+function getColor(background: Color) {
     const darkMode = isDark(background);
     return darkMode ? "white" : "black";
 }
@@ -18,11 +18,11 @@ function getColor(background: Swatch) {
 export const paletteGradientTemplate = html<PaletteGradient>`
     ${repeat(
         (x) => x.palette?.swatches || [],
-        html<Swatch, PaletteGradient>`
+        html<Color, PaletteGradient>`
             <a
                 class="${(x, c) => getClass(x, c.parent.palette?.source, c.parent.closestSource)}"
-                style="background: ${(x) => x.toColorString()}; color: ${(x) => getColor(x)}"
-                title="${(x, c) => c.index.toString().concat(": ", x.toColorString().toUpperCase())}"
+                style="background: ${(x) => x.toString()}; color: ${(x) => getColor(x)}"
+                title="${(x, c) => c.index.toString().concat(": ", x.toString().toUpperCase())}"
             ></a>
         `,
         { positioning: true }

--- a/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.ts
+++ b/packages/adaptive-ui-explorer/src/components/palette-gradient/palette-gradient.ts
@@ -1,4 +1,4 @@
-import { Palette, Swatch } from "@adaptive-web/adaptive-ui";
+import { Color, Palette } from "@adaptive-web/adaptive-ui";
 import { customElement, FASTElement, observable } from "@microsoft/fast-element";
 import { paletteGradientStyles as styles } from "./palette-gradient.styles.js";
 import { paletteGradientTemplate as template } from "./palette-gradient.template.js";
@@ -9,7 +9,7 @@ import { paletteGradientTemplate as template } from "./palette-gradient.template
     styles,
 })
 export class PaletteGradient extends FASTElement {
-    public closestSource?: Swatch;
+    public closestSource?: Color;
 
     @observable
     public palette?: Palette;

--- a/packages/adaptive-ui-explorer/src/components/style-example.ts
+++ b/packages/adaptive-ui-explorer/src/components/style-example.ts
@@ -1,4 +1,4 @@
-import { InteractiveTokenGroup, StyleProperty, Styles, Swatch, TypedCSSDesignToken } from "@adaptive-web/adaptive-ui";
+import { Color, InteractiveTokenGroup, StyleProperty, Styles, TypedCSSDesignToken } from "@adaptive-web/adaptive-ui";
 import { densityControl, fillColor } from '@adaptive-web/adaptive-ui/reference';
 import { componentBaseStyles } from "@adaptive-web/adaptive-web-components";
 import { css, customElement, FASTElement, html, observable, repeat, volatile, when } from "@microsoft/fast-element";
@@ -52,9 +52,9 @@ const styles = css`
 interface StyleValue {
     type: SwatchType;
     tokenName: string;
-    foregroundRecipe?: TypedCSSDesignToken<Swatch>;
-    fillRecipe?: TypedCSSDesignToken<Swatch>;
-    outlineRecipe?: TypedCSSDesignToken<Swatch>;
+    foregroundRecipe?: TypedCSSDesignToken<Color>;
+    fillRecipe?: TypedCSSDesignToken<Color>;
+    outlineRecipe?: TypedCSSDesignToken<Color>;
 }
 
 @customElement({

--- a/packages/adaptive-ui-explorer/src/components/swatch.ts
+++ b/packages/adaptive-ui-explorer/src/components/swatch.ts
@@ -1,4 +1,4 @@
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { Color } from "@adaptive-web/adaptive-ui";
 import { densityControl, fillColor, neutralStrokeReadableRest, typeRampMinus1FontSize } from "@adaptive-web/adaptive-ui/reference";
 import { componentBaseStyles } from "@adaptive-web/adaptive-web-components";
 import {
@@ -86,19 +86,19 @@ export class AppSwatch extends FASTElement {
     public recipeName?: string;
 
     @observable
-    public foregroundRecipe?: DesignToken<Swatch>;
+    public foregroundRecipe?: DesignToken<Color>;
     protected foregroundRecipeChanged() {
         this.updateObservables();
     }
 
     @observable
-    public fillRecipe?: DesignToken<Swatch>;
+    public fillRecipe?: DesignToken<Color>;
     protected fillRecipeChanged() {
         this.updateObservables();
     }
 
     @observable
-    public outlineRecipe?: DesignToken<Swatch>;
+    public outlineRecipe?: DesignToken<Color>;
     protected outlineRecipeChanged() {
         this.updateObservables();
     }
@@ -136,13 +136,13 @@ export class AppSwatch extends FASTElement {
         this.updateColorValue();
     }
 
-    private tokenCSS(token?: DesignToken<Swatch>): string {
+    private tokenCSS(token?: DesignToken<Color>): string {
         return token && typeof (token as any).createCSS === "function"
             ? (token as any).createCSS()
             : "";
     }
 
-    private evaluateToken(token?: DesignToken<Swatch>): string {
+    private evaluateToken(token?: DesignToken<Color>): string {
         return token?.getValueFor(this).toColorString() || "";
     }
 
@@ -156,7 +156,7 @@ export class AppSwatch extends FASTElement {
                 : background;
     }
 
-    private formatContrast(a?: DesignToken<Swatch>, b?: DesignToken<Swatch>): string {
+    private formatContrast(a?: DesignToken<Color>, b?: DesignToken<Color>): string {
         return a && b
             ? wcagContrast(
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -168,8 +168,8 @@ export class AppSwatch extends FASTElement {
     }
 
     private formatContrastMessage(
-        a?: DesignToken<Swatch>,
-        b?: DesignToken<Swatch>
+        a?: DesignToken<Color>,
+        b?: DesignToken<Color>
     ): string {
         return `Contrast: ${this.formatContrast(a, b)} : 1`;
     }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AddBehavior } from '@microsoft/fast-element';
 import { Color as Color_2 } from 'culori/fn';
 import { ComposableStyles } from '@microsoft/fast-element';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
@@ -11,11 +12,12 @@ import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
 import { DesignTokenResolver } from '@microsoft/fast-foundation';
 import { ElementStyles } from '@microsoft/fast-element';
+import { Rgb } from 'culori/fn';
 import { TypedCSSDesignToken as TypedCSSDesignToken_2 } from '../adaptive-design-tokens.js';
 import { ValuesOf } from '@microsoft/fast-foundation';
 
 // @public
-export class BasePalette<T extends Swatch> implements Palette<T> {
+export class BasePalette<T extends Color = Color> implements Palette<T> {
     constructor(source: Color, swatches: ReadonlyArray<T>);
     readonly closestIndexCache: Map<number, number>;
     closestIndexOf(reference: RelativeLuminance): number;
@@ -29,13 +31,13 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
 }
 
 // @internal
-export const _black: Swatch;
+export const _black: Color;
 
 // @public
-export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
+export function blackOrWhiteByContrast(reference: Paint, minContrast: number, defaultBlack: boolean): Color;
 
 // @public
-export function blackOrWhiteByContrastSet(set: InteractiveSwatchSet, minContrast: number, defaultBlack: boolean): InteractiveSwatchSet;
+export function blackOrWhiteByContrastSet(set: InteractivePaintSet, minContrast: number, defaultBlack: boolean): InteractiveColorSet;
 
 // @public
 export type BooleanCondition = string;
@@ -56,10 +58,13 @@ export const BorderThickness: {
 };
 
 // @public
-export class Color implements RelativeLuminance, CSSDirective {
-    constructor(color: Color_2);
+export function calculateOverlayColor(match: Color_2, background: Color_2): Rgb;
+
+// @public
+export class Color extends Paint {
+    constructor(color: Color_2, intendedColor?: Color);
+    static asOverlay(intendedColor: Color, reference: Color): Color;
     readonly color: Color_2;
-    contrast: (b: RelativeLuminance) => number;
     createCSS: () => string;
     static from(obj: {
         r: number;
@@ -68,29 +73,31 @@ export class Color implements RelativeLuminance, CSSDirective {
         alpha?: number;
     }): Color;
     static fromRgb(r: number, g: number, b: number, alpha?: number): Color;
+    protected readonly _intendedColor?: Color;
     static parse(color: string): Color | undefined;
-    get relativeLuminance(): number;
-    toColorString(): string;
-    toString: () => string;
+    // @deprecated
+    toColorString: () => string;
+    toString(): string;
+    static unsafeOpacity(color: Color, alpha: number): Color;
 }
 
 // @public
-export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
+export type ColorRecipe<T = Color> = RecipeOptional<ColorRecipeParams, T>;
 
 // @public
-export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
+export type ColorRecipeBySet<T = Color> = Recipe<InteractivePaintSet, T>;
 
 // @public
-export type ColorRecipeBySetEvaluate<T = Swatch> = RecipeEvaluate<InteractiveSwatchSet, T>;
+export type ColorRecipeBySetEvaluate<T = Color> = RecipeEvaluate<InteractivePaintSet, T>;
 
 // @public
-export type ColorRecipeEvaluate<T = Swatch> = RecipeEvaluateOptional<ColorRecipeParams, T>;
+export type ColorRecipeEvaluate<T = Color> = RecipeEvaluateOptional<ColorRecipeParams, T>;
 
 // @public
-export type ColorRecipePalette<T = Swatch> = Recipe<ColorRecipePaletteParams, T>;
+export type ColorRecipePalette<T = Color> = Recipe<ColorRecipePaletteParams, T>;
 
 // @public
-export type ColorRecipePaletteEvaluate<T = Swatch> = RecipeEvaluate<ColorRecipePaletteParams, T>;
+export type ColorRecipePaletteEvaluate<T = Color> = RecipeEvaluate<ColorRecipePaletteParams, T>;
 
 // @public
 export type ColorRecipePaletteParams = ColorRecipeParams & {
@@ -99,7 +106,7 @@ export type ColorRecipePaletteParams = ColorRecipeParams & {
 
 // @public
 export type ColorRecipeParams = {
-    reference: Swatch | null;
+    reference: Paint | null;
 };
 
 // @public
@@ -125,10 +132,10 @@ export type Condition = BooleanCondition | StringCondition;
 export function contrast(a: RelativeLuminance, b: RelativeLuminance): number;
 
 // @public
-export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
+export function contrastAndDeltaSwatchSet(palette: Palette, reference: Paint, minContrast: number, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveColorSet;
 
 // @public
-export function contrastSwatch(palette: Palette, reference: Swatch, minContrast: number, direction?: PaletteDirection): Swatch;
+export function contrastSwatch(palette: Palette, reference: Paint, minContrast: number, direction?: PaletteDirection): Color;
 
 // @public
 export const convertStylesToFocusState: (styles: Styles) => Styles;
@@ -144,10 +151,10 @@ export const CornerRadius: {
 export const create: typeof DesignToken.create;
 
 // @public
-export function createForegroundSet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
+export function createForegroundSet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>, background: InteractiveTokenGroup<Paint>): InteractiveTokenGroup<Paint>;
 
 // @public
-export function createForegroundSetBySet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>, background: InteractiveTokenGroup<Swatch>): InteractiveTokenGroup<Swatch>;
+export function createForegroundSetBySet(foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>, background: InteractiveTokenGroup<Paint>): InteractiveTokenGroup<Paint>;
 
 // Warning: (ae-internal-missing-underscore) The name "createNonCss" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -158,22 +165,22 @@ export function createNonCss<T>(name: string): DesignToken<T>;
 export function createTokenColor(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Color>;
 
 // @public
-export function createTokenColorRecipe<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeEvaluate<T>): TypedDesignToken<ColorRecipe<T>>;
+export function createTokenColorRecipe<T = Paint>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeEvaluate<T>): TypedDesignToken<ColorRecipe<T>>;
 
 // @public
-export function createTokenColorRecipeBySet<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeBySetEvaluate<T>): TypedDesignToken<ColorRecipeBySet<T>>;
+export function createTokenColorRecipeBySet<T = Paint>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipeBySetEvaluate<T>): TypedDesignToken<ColorRecipeBySet<T>>;
 
 // @public
-export function createTokenColorRecipeForPalette<T = Swatch>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipePaletteEvaluate<T>): TypedDesignToken<ColorRecipePalette<T>>;
+export function createTokenColorRecipeForPalette<T = Paint>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: ColorRecipePaletteEvaluate<T>): TypedDesignToken<ColorRecipePalette<T>>;
 
 // @public
-export function createTokenColorRecipeValue(recipeToken: TypedDesignToken<ColorRecipe<Swatch>>): TypedCSSDesignToken<Swatch>;
+export function createTokenColorRecipeValue(recipeToken: TypedDesignToken<ColorRecipe<Paint>>): TypedCSSDesignToken<Paint>;
 
 // @public
-export function createTokenColorRecipeWithPalette<T>(recipeToken: TypedDesignToken<Recipe<ColorRecipePaletteParams, T>>, paletteToken: DesignToken<Palette>): TypedDesignToken<RecipeOptional<ColorRecipeParams, T>>;
+export function createTokenColorRecipeWithPalette<T = Paint>(recipeToken: TypedDesignToken<Recipe<ColorRecipePaletteParams, T>>, paletteToken: DesignToken<Palette>): TypedDesignToken<RecipeOptional<ColorRecipeParams, T>>;
 
 // @public
-export function createTokenColorSet(recipeToken: TypedDesignToken<InteractiveColorRecipe>): InteractiveTokenGroup<Swatch>;
+export function createTokenColorSet(recipeToken: TypedDesignToken<InteractiveColorRecipe>): InteractiveTokenGroup<Paint>;
 
 // @public
 export function createTokenDelta(baseName: string, state: InteractiveState | string, value: number | DesignToken<number>): TypedDesignToken<number>;
@@ -212,22 +219,25 @@ export function createTokenNumber(name: string, intendedFor?: StyleProperty | St
 export function createTokenNumberNonStyling(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedDesignToken<number>;
 
 // @public
+export function createTokenPaint(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Paint>;
+
+// @public
 export function createTokenRecipe<TParam, TResult>(baseName: string, intendedFor: StyleProperty | StyleProperty[], evaluate: RecipeEvaluate<TParam, TResult>): TypedDesignToken<Recipe<TParam, TResult>>;
 
 // @public
 export const createTokenShadow: (name: string) => TypedCSSDesignToken_2<ShadowValue>;
 
-// @public
+// @public @deprecated
 export function createTokenSwatch(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch>;
 
 // @public
 export const createTyped: typeof TypedCSSDesignToken.createTyped;
 
 // @public
-export function deltaSwatch(palette: Palette, reference: Swatch, delta: number, direction?: PaletteDirection): Swatch;
+export function deltaSwatch(palette: Palette, reference: Paint, delta: number, direction?: PaletteDirection): Color;
 
 // @public
-export function deltaSwatchSet(palette: Palette, reference: Swatch, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta?: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveSwatchSet;
+export function deltaSwatchSet(palette: Palette, reference: Paint, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta?: number, disabledPalette?: Palette, direction?: PaletteDirection, zeroAsTransparent?: boolean): InteractiveColorSet;
 
 // @public
 export const densityAdjustmentUnits: TypedDesignToken<number>;
@@ -288,6 +298,7 @@ export const DesignTokenType: {
     readonly fontVariations: "fontVariations";
     readonly palette: "palette";
     readonly recipe: "recipe";
+    readonly paint: "paint";
     readonly string: "string";
 };
 
@@ -320,9 +331,9 @@ export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;
 
 // @public (undocumented)
 export const Fill: {
-    backgroundAndForeground: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>) => StyleProperties;
-    backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Swatch>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
-    foregroundNonInteractiveWithDisabled: (foreground: TypedCSSDesignToken<Swatch>, disabled: TypedCSSDesignToken<Swatch>) => StyleProperties;
+    backgroundAndForeground: (background: InteractiveTokenGroup<Paint>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>) => StyleProperties;
+    backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Paint>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
+    foregroundNonInteractiveWithDisabled: (foreground: TypedCSSDesignToken<Paint>, disabled: TypedCSSDesignToken<Paint>) => StyleProperties;
 };
 
 // @public
@@ -340,25 +351,33 @@ export interface FocusDefinition<TParts> {
 }
 
 // @public
-export function idealColorDeltaSwatchSet(palette: Palette, reference: Swatch, minContrast: number, idealColor: Color, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveSwatchSet;
+export function idealColorDeltaSwatchSet(palette: Palette, reference: Paint, minContrast: number, idealColor: Color, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveColorSet;
 
 // @public
-export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
+export type InteractiveColorRecipe = ColorRecipe<InteractivePaintSet>;
 
 // @public
-export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;
+export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractivePaintSet>;
 
 // @public
-export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractivePaintSet>;
 
 // @public
-export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractivePaintSet>;
 
 // @public
-export type InteractiveColorRecipePalette = ColorRecipePalette<InteractiveSwatchSet>;
+export type InteractiveColorRecipePalette = ColorRecipePalette<InteractivePaintSet>;
 
 // @public
-export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractivePaintSet>;
+
+// @public
+export interface InteractiveColorSet extends InteractiveValues<Color | null> {
+}
+
+// @public
+export interface InteractivePaintSet extends InteractiveValues<Paint | null> {
+}
 
 // @public
 export enum InteractiveState {
@@ -370,11 +389,7 @@ export enum InteractiveState {
 }
 
 // @public
-export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {
-}
-
-// @public
-export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
+export function interactiveSwatchSetAsOverlay(set: InteractiveColorSet, reference: Color, asOverlay: boolean): InteractiveColorSet;
 
 // @public
 export interface InteractiveTokenGroup<T> extends MakePropertyRequired<TokenGroup, "type">, InteractiveValues<TypedCSSDesignToken<T>> {
@@ -405,7 +420,7 @@ export type InteractivityDefinition = {
 export function isDark(color: RelativeLuminance): boolean;
 
 // @public
-export function luminanceSwatch(luminance: number): Swatch;
+export function luminanceSwatch(luminance: number): Color;
 
 // @public (undocumented)
 export type MakePropertyOptional<T, K extends keyof T> = Omit<T, K> & {
@@ -425,7 +440,16 @@ export const Padding: {
 };
 
 // @public
-export interface Palette<T extends Swatch = Swatch> {
+export abstract class Paint implements RelativeLuminance, CSSDirective {
+    protected constructor(relativeLuminance: number);
+    // (undocumented)
+    contrast(b: RelativeLuminance): number;
+    createCSS(add: AddBehavior): ComposableStyles;
+    get relativeLuminance(): number;
+}
+
+// @public
+export interface Palette<T extends Color = Color> {
     closestIndexOf(reference: RelativeLuminance): number;
     colorContrast(reference: RelativeLuminance, minContrast: number, initialIndex?: number, direction?: PaletteDirection): T;
     delta(reference: RelativeLuminance, delta: number, direction: PaletteDirection): T;
@@ -447,7 +471,7 @@ export const PaletteDirectionValue: Readonly<{
 export type PaletteDirectionValue = typeof PaletteDirectionValue[keyof typeof PaletteDirectionValue];
 
 // @public
-export class PaletteOkhsl extends BasePalette<Swatch> {
+export class PaletteOkhsl extends BasePalette {
     // (undocumented)
     static from(source: Color | string, options?: Partial<PaletteOkhslOptions>): PaletteOkhsl;
 }
@@ -460,8 +484,8 @@ export interface PaletteOkhslOptions {
 }
 
 // @public
-export class PaletteRGB extends BasePalette<Swatch> {
-    static from(source: Swatch | string, options?: Partial<PaletteRGBOptions>): PaletteRGB;
+export class PaletteRGB extends BasePalette {
+    static from(source: Color | string, options?: Partial<PaletteRGBOptions>): PaletteRGB;
 }
 
 // @public
@@ -489,6 +513,7 @@ export interface RecipeOptional<TParam, TResult> {
 
 // @public
 export interface RelativeLuminance {
+    contrast: (a: RelativeLuminance) => number;
     readonly relativeLuminance: number;
 }
 
@@ -542,11 +567,11 @@ export interface SerializableStyleRule {
 
 // @public
 export class Shadow implements CSSDirective {
-    constructor(color: Swatch, xOffset: number, yOffset: number, blurRadius?: number | undefined, spread?: number | undefined);
+    constructor(color: Color, xOffset: number, yOffset: number, blurRadius?: number | undefined, spread?: number | undefined);
     // (undocumented)
     blurRadius?: number | undefined;
     // (undocumented)
-    color: Swatch;
+    color: Color;
     // (undocumented)
     createCSS(): string;
     // (undocumented)
@@ -716,9 +741,8 @@ export class Styles {
 // @public
 export type StyleValue = CSSDesignToken<any> | InteractiveValues<any | null> | CSSDirective | string | number;
 
-// @public
+// @public @deprecated
 export class Swatch extends Color {
-    protected constructor(color: Color_2, intendedColor?: Swatch);
     static asOverlay(intendedColor: Swatch, reference: Swatch): Swatch;
     static from(obj: {
         r: number;
@@ -729,12 +753,12 @@ export class Swatch extends Color {
     static fromColor(color: Color): Swatch;
     static fromRgb(r: number, g: number, b: number, alpha?: number): Swatch;
     static parse(color: string): Swatch | undefined;
-    get relativeLuminance(): number;
+    // @deprecated
     toTransparent(alpha?: number): Swatch;
 }
 
 // @public
-export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null;
+export function swatchAsOverlay(color: Color | null, reference: Color, asOverlay: boolean): Color | null;
 
 // @public
 export interface TokenGroup extends MakePropertyOptional<DesignTokenMetadata, "type"> {
@@ -770,7 +794,7 @@ export interface TypedDesignToken<T> extends DesignTokenMetadata {
 }
 
 // @internal
-export const _white: Swatch;
+export const _white: Color;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/adaptive-ui/src/core/adaptive-design-tokens.ts
+++ b/packages/adaptive-ui/src/core/adaptive-design-tokens.ts
@@ -30,6 +30,7 @@ export const DesignTokenType = {
     fontVariations: "fontVariations",
     palette: "palette",
     recipe: "recipe",
+    paint: "paint", // `color` or `gradient`
     string: "string",
 } as const;
 
@@ -53,7 +54,7 @@ export type DesignTokenMetadata = {
 // A slight alteration of the mixin pattern to hide an internal function from the public type.
 class DesignTokenMetadataImpl implements DesignTokenMetadata {
     // TODO: This needs to support multiple types, tokens in Adaptive UI might represent different value
-    // types, like a Swatch type commonly refers to a `color` but may also be a `gradient`. (see `create.ts`)
+    // types, like a `paint` type commonly refers to a `color` but may also be a `gradient`. (see `create.ts`)
     private _type: DesignTokenType = "string";
 
     /**

--- a/packages/adaptive-ui/src/core/color/README.md
+++ b/packages/adaptive-ui/src/core/color/README.md
@@ -2,27 +2,27 @@
 
 Color recipes are algorithmic patterns that produce individual or sets of colors from a variety of inputs. Components can apply these recipes to achieve expressive theming options while maintaining color accessability targets.
 
+## Paint
+A `Paint` is a representation of a color that has a `relativeLuminance` value and a method to convert to a color string. It is the base type for color design tokens.
+
 ## Color
-A Swatch is a representation of a color that has a `relativeLuminance` value and a method to convert the swatch to a color string. It is the base type for color design tokens.
+A `Color` is an extension of `Paint` for use in a recipe. It adds support for calculating a color as an overlay or transparency
+over another `Color`.
 
-## Swatch
-A Swatch is an extension of a Color for use in a recipe. It adds support for calculating a color as an overlay or transparency
-over another Swatch.
-
-**Example: Creating a Swatch**
+**Example: Creating a Color**
 ```ts
-import { Swatch } from "@adaptive-web/adaptive-ui";
+import { Color } from "@adaptive-web/adaptive-ui";
 
-const red = Swatch.fromRgb(1, 0, 0);
+const red = Color.fromRgb(1, 0, 0);
 ```
 
 ## Palette
-A palette is a collection `Swatch` instances, ordered by relative luminance, and provides mechanisms to safely retrieve swatches by index and by target contrast ratios. It also contains a `source` color, which is the color from which the palette is derived.
+A palette is a collection `Color` instances, ordered by relative luminance, and provides mechanisms to safely retrieve swatches by index and by target contrast ratios. It also contains a `source` color, which is the color from which the palette is derived.
 
 ### PaletteRGB
-An implementation of `Palette` of `Swatch` instances with RGB colors.
+An implementation of `Palette` of `Color` instances with RGB colors.
 
 ```ts
-// Create a PaletteRGB from a Swatch
+// Create a PaletteRGB from a Color
 const redPalette = PaletteRGB.from(red):
 ```

--- a/packages/adaptive-ui/src/core/color/index.ts
+++ b/packages/adaptive-ui/src/core/color/index.ts
@@ -1,6 +1,7 @@
 export * from "./recipes/index.js";
 export * from "./utilities/index.js";
 export * from "./color.js";
+export * from "./paint.js";
 export * from "./palette-base.js";
 export * from "./palette-okhsl.js";
 export * from "./palette-rgb.js";

--- a/packages/adaptive-ui/src/core/color/paint.ts
+++ b/packages/adaptive-ui/src/core/color/paint.ts
@@ -1,0 +1,42 @@
+import { AddBehavior, ComposableStyles, CSSDirective } from "@microsoft/fast-element";
+import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
+
+/**
+ * Abstract representation of a value which can be used to paint a style like a fill or border.
+ *
+ * See {@link Color} for concrete implementation.
+ *
+ * @public
+ */
+export abstract class Paint implements RelativeLuminance, CSSDirective {
+    readonly #relativeLuminance: number;
+
+    /**
+     * Creates a new Color.
+     *
+     * @param color - The underlying Color value
+     */
+    protected constructor(relativeLuminance: number) {
+        this.#relativeLuminance = relativeLuminance;
+    }
+
+    /**
+     * Creates a CSS fragment to interpolate into the CSS document.
+     *
+     * @returns - the string to interpolate into CSS
+     */
+    createCSS(add: AddBehavior): ComposableStyles {
+        throw new Error("Method not implemented.");
+    }
+
+    /**
+     * {@inheritdoc RelativeLuminance.relativeLuminance}
+     */
+    public get relativeLuminance(): number {
+        return this.#relativeLuminance;
+    }
+
+    public contrast(b: RelativeLuminance): number {
+        return contrast(this, b);
+    }
+}

--- a/packages/adaptive-ui/src/core/color/palette-base.ts
+++ b/packages/adaptive-ui/src/core/color/palette-base.ts
@@ -1,17 +1,16 @@
 import { Color } from "./color.js";
 import { Palette, PaletteDirection, PaletteDirectionValue, resolvePaletteDirection } from "./palette.js";
-import { Swatch } from "./swatch.js";
 import { binarySearch } from "./utilities/binary-search.js";
 import { directionByIsDark } from "./utilities/direction-by-is-dark.js";
 import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
 
 /**
  * A base {@link Palette} with a common implementation of the interface. Use PaletteRGB for an implementation
- * of a palette generation algorithm that is ready to be used directly, or extend this class to generate custom Swatches.
+ * of a palette generation algorithm that is ready to be used directly, or extend this class to generate custom swatches.
  *
  * @public
  */
-export class BasePalette<T extends Swatch> implements Palette<T> {
+export class BasePalette<T extends Color = Color> implements Palette<T> {
     /**
      * {@inheritdoc Palette.source}
      */
@@ -28,12 +27,12 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
     readonly lastIndex: number;
 
     /**
-     * A copy of the `Swatch`es in reverse order, used for optimized searching.
+     * A copy of the swatches in reverse order, used for optimized searching.
      */
     readonly reversedSwatches: ReadonlyArray<T>;
 
     /**
-     * Cache from `relativeLuminance` to `Swatch` index in the `Palette`.
+     * Cache from `relativeLuminance` to swatch index in the `Palette`.
      */
     readonly closestIndexCache = new Map<number, number>();
 
@@ -41,7 +40,7 @@ export class BasePalette<T extends Swatch> implements Palette<T> {
      * Creates a new Palette.
      *
      * @param source - The source color for the Palette
-     * @param swatches - All Swatches in the Palette
+     * @param swatches - All swatches in the Palette
      */
     constructor(source: Color, swatches: ReadonlyArray<T>) {
         this.source = source;

--- a/packages/adaptive-ui/src/core/color/palette-okhsl.ts
+++ b/packages/adaptive-ui/src/core/color/palette-okhsl.ts
@@ -1,7 +1,6 @@
 import { clampChroma, interpolate, modeOkhsl, modeRgb, samples, useMode } from "culori/fn";
 import { Color } from "./color.js";
 import { BasePalette } from "./palette-base.js";
-import { Swatch } from "./swatch.js";
 import { _black, _white } from "./utilities/color-constants.js";
 
 const okhsl = useMode(modeOkhsl);
@@ -51,7 +50,7 @@ const defaultPaletteOkhslOptions: PaletteOkhslOptions = {
  *
  * @public
  */
-export class PaletteOkhsl extends BasePalette<Swatch> {
+export class PaletteOkhsl extends BasePalette {
     public static from(source: Color | string, options?: Partial<PaletteOkhslOptions>): PaletteOkhsl {
         const color = source instanceof Color ? source : Color.parse(source);
         if (!color) {
@@ -87,7 +86,7 @@ export class PaletteOkhsl extends BasePalette<Swatch> {
 
         const ramp = [...samplesLeft, ...samplesRight.slice(1)];
         const rampSwatches = ramp.map((value) =>
-            Swatch.from(rgb(clampChroma(value, "okhsl")))
+            Color.from(rgb(clampChroma(value, "okhsl")))
         );
 
         // It's important that the ends are full white and black.

--- a/packages/adaptive-ui/src/core/color/palette-rgb.spec.ts
+++ b/packages/adaptive-ui/src/core/color/palette-rgb.spec.ts
@@ -1,18 +1,18 @@
 import chai from "chai";
+import { Color } from "./color.js";
 import { PaletteRGB, PaletteRGBOptions } from "./palette-rgb.js";
-import { Swatch } from "./swatch.js";
 import { contrast } from "./utilities/relative-luminance.js";
 
 const { expect } = chai;
 
 const greyHex = "#808080";
-const greySwatch = Swatch.parse(greyHex)!;
+const greyColor = Color.parse(greyHex)!;
 
 describe("PaletteRGB.from", () => {
-    it("should create a palette from the provided swatch", () => {
-        const palette = PaletteRGB.from(greySwatch);
+    it("should create a palette from the provided Color", () => {
+        const palette = PaletteRGB.from(greyColor);
 
-        expect(palette.source).to.equal(greySwatch);
+        expect(palette.source).to.equal(greyColor);
     });
 
     it("should create a palette from the provided hex color", () => {
@@ -26,7 +26,7 @@ describe("PaletteRGB.from", () => {
             stepContrast: 1.07,
             stepContrastRamp: 0,
         };
-        const palette = PaletteRGB.from(greySwatch, options);
+        const palette = PaletteRGB.from(greyColor, options);
 
         expect(contrast(palette.swatches[0], palette.swatches[1]), "at least 1.07:1 between 0 and 1").to.be.gte(1.07);
         expect(contrast(palette.swatches[20], palette.swatches[21]), "at least 1.07:1 between 20 and 21").to.be.gte(

--- a/packages/adaptive-ui/src/core/color/palette.ts
+++ b/packages/adaptive-ui/src/core/color/palette.ts
@@ -1,9 +1,8 @@
 import { Color } from "./color.js";
-import { Swatch } from "./swatch.js";
 import { RelativeLuminance } from "./utilities/relative-luminance.js";
 
 /**
- * Directional values for navigating {@link Swatch}es in {@link Palette}.
+ * Directional values for navigating swatches in {@link Palette}.
  *
  * @public
  */
@@ -20,7 +19,7 @@ export const PaletteDirectionValue = Object.freeze({
 } as const);
 
 /**
- * Directional values for navigating {@link Swatch}es in {@link Palette}.
+ * Directional values for navigating swatches in {@link Palette}.
  *
  * @public
  */
@@ -50,30 +49,30 @@ export function resolvePaletteDirection(direction: PaletteDirection): PaletteDir
 }
 
 /**
- * A collection of {@link Swatch}es that form a luminance gradient from light (index 0) to dark.
+ * A collection of {@link Color}s that form a luminance gradient from light (index 0) to dark.
  *
  * @public
  */
-export interface Palette<T extends Swatch = Swatch> {
+export interface Palette<T extends Color = Color> {
     /**
-     * The Swatch used to create the full palette.
+     * The Color used to create the full palette.
      */
     readonly source: Color;
 
     /**
-     * The array of all Swatches from light to dark.
+     * The array of all Colors from light to dark.
      */
     readonly swatches: ReadonlyArray<T>;
 
     /**
-     * Returns a Swatch from the Palette that most closely meets
+     * Returns a Color from the Palette that most closely meets
      * the `minContrast` ratio for to the `reference`.
      *
      * @param reference - The relative luminance of the reference
      * @param minContrast - The minimum amount of contrast from the `reference`
      * @param initialIndex - Optional starting point for the search
      * @param direction - Optional control for the direction of the search
-     * @returns The Swatch that meets the provided contrast
+     * @returns The Color that meets the provided contrast
      */
     colorContrast(
         reference: RelativeLuminance,
@@ -83,10 +82,10 @@ export interface Palette<T extends Swatch = Swatch> {
     ): T;
 
     /**
-     * Returns a Swatch from the Palette that's the specified position and direction away from the `reference`.
+     * Returns a Color from the Palette that's the specified position and direction away from the `reference`.
      *
      * @param reference - The relative luminance of the reference
-     * @param delta - The number of Swatches away from `reference`
+     * @param delta - The number of swatches away from `reference`
      * @param direction - The direction to go from `reference`, 1 goes darker, -1 goes lighter
      */
     delta(reference: RelativeLuminance, delta: number, direction: PaletteDirection): T;
@@ -101,11 +100,11 @@ export interface Palette<T extends Swatch = Swatch> {
     closestIndexOf(reference: RelativeLuminance): number;
 
     /**
-     * Gets a Swatch by index. Index is clamped to the limits
-     * of the Palette so a Swatch will always be returned.
+     * Gets a Color by index. Index is clamped to the limits
+     * of the Palette so a Color will always be returned.
      *
      * @param index - The index
-     * @returns The Swatch
+     * @returns The Color
      */
     get(index: number): T;
 }

--- a/packages/adaptive-ui/src/core/color/recipe.ts
+++ b/packages/adaptive-ui/src/core/color/recipe.ts
@@ -1,7 +1,8 @@
 import { Recipe, RecipeEvaluate, RecipeEvaluateOptional, RecipeOptional } from "../recipes.js";
 import { InteractiveValues } from "../types.js";
+import { Color } from "./color.js";
+import { Paint } from "./paint.js";
 import { Palette } from "./palette.js";
-import { Swatch } from "./swatch.js";
 
 /**
  * Parameters provided to {@link ColorRecipe}.
@@ -12,7 +13,7 @@ export type ColorRecipeParams = {
     /**
      * The reference color, implementation defaults to `fillColor`, but allows for overriding for nested color recipes.
      */
-    reference: Swatch | null,
+    reference: Paint | null,
 };
 
 /**
@@ -20,14 +21,14 @@ export type ColorRecipeParams = {
  *
  * @public
  */
-export type ColorRecipe<T = Swatch> = RecipeOptional<ColorRecipeParams, T>;
+export type ColorRecipe<T = Color> = RecipeOptional<ColorRecipeParams, T>;
 
 /**
  * The type of the `evaluate` function for {@link ColorRecipe}.
  *
  * @public
  */
-export type ColorRecipeEvaluate<T = Swatch> = RecipeEvaluateOptional<ColorRecipeParams, T>;
+export type ColorRecipeEvaluate<T = Color> = RecipeEvaluateOptional<ColorRecipeParams, T>;
 
 /**
  * Parameters provided to {@link ColorRecipePalette}.
@@ -45,49 +46,56 @@ export type ColorRecipePaletteParams = ColorRecipeParams & {
  *
  * @public
  */
-export type ColorRecipePalette<T = Swatch> = Recipe<ColorRecipePaletteParams, T>;
+export type ColorRecipePalette<T = Color> = Recipe<ColorRecipePaletteParams, T>;
 
 /**
  * The type of the `evaluate` function for {@link ColorRecipePalette}.
  *
  * @public
  */
-export type ColorRecipePaletteEvaluate<T = Swatch> = RecipeEvaluate<ColorRecipePaletteParams, T>;
+export type ColorRecipePaletteEvaluate<T = Color> = RecipeEvaluate<ColorRecipePaletteParams, T>;
 
 /**
  * A recipe that evaluates a color value for rest, hover, active, and focus states.
  *
  * @public
  */
-export type InteractiveColorRecipe = ColorRecipe<InteractiveSwatchSet>;
+export type InteractiveColorRecipe = ColorRecipe<InteractivePaintSet>;
 
 /**
  * The type of the `evaluate` function for {@link InteractiveColorRecipe}.
  *
  * @public
  */
-export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipeEvaluate = ColorRecipeEvaluate<InteractivePaintSet>;
 
 /**
  * A recipe that evaluates a color value for rest, hover, active, and focus states using the provided Palette.
  *
  * @public
  */
-export type InteractiveColorRecipePalette = ColorRecipePalette<InteractiveSwatchSet>;
+export type InteractiveColorRecipePalette = ColorRecipePalette<InteractivePaintSet>;
 
 /**
  * The type of the `evaluate` function for {@link InteractiveColorRecipePalette}.
  *
  * @public
  */
-export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipePaletteEvaluate = ColorRecipePaletteEvaluate<InteractivePaintSet>;
 
 /**
- * A set of {@link Swatch}es to use for an interactive control's states.
+ * A set of {@link Paint}s to use for an interactive control's states.
  *
  * @public
  */
-export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {}
+export interface InteractivePaintSet extends InteractiveValues<Paint | null> {}
+
+/**
+ * A set of {@link Color}s to use for an interactive control's states.
+ *
+ * @public
+ */
+export interface InteractiveColorSet extends InteractiveValues<Color | null> {}
 
 /**
  * A recipe that evaluates based on an interactive set of color values.
@@ -97,25 +105,25 @@ export interface InteractiveSwatchSet extends InteractiveValues<Swatch | null> {
  *
  * @public
  */
-export type ColorRecipeBySet<T = Swatch> = Recipe<InteractiveSwatchSet, T>;
+export type ColorRecipeBySet<T = Color> = Recipe<InteractivePaintSet, T>;
 
 /**
  * The type of the `evaluate` function for {@link ColorRecipeBySet}.
  *
  * @public
  */
-export type ColorRecipeBySetEvaluate<T = Swatch> = RecipeEvaluate<InteractiveSwatchSet, T>;
+export type ColorRecipeBySetEvaluate<T = Color> = RecipeEvaluate<InteractivePaintSet, T>;
 
 /**
  * A recipe that evaluates a color value for rest, hover, active, and focus states.
  *
  * @public
  */
-export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractiveSwatchSet>;
+export type InteractiveColorRecipeBySet = ColorRecipeBySet<InteractivePaintSet>;
 
 /**
  * The type of the `evaluate` function for {@link InteractiveColorRecipeBySet}.
  *
  * @public
  */
-export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractiveSwatchSet>;
+export type InteractiveColorRecipeBySetEvaluate = ColorRecipeBySetEvaluate<InteractivePaintSet>;

--- a/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast-set.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast-set.ts
@@ -1,9 +1,10 @@
-import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
+import { InteractiveColorSet, InteractivePaintSet } from "../recipe.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 /**
- * Gets an interactive set of black or white Swatches based on the reference color for each state and minimum contrast.
+ * Gets an interactive set of black or white Colors based on the reference color for each state and minimum contrast.
  *
  * This is commonly used for something like foreground color on an accent-filled Button.
  *
@@ -17,16 +18,16 @@ import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
  * @param focusReference - The focus state reference color
  * @param minContrast - The minimum contrast required for black or white from each reference color
  * @param defaultBlack - True to default to black if both black or white meet contrast
- * @returns The interactive set of black or white Swatches.
+ * @returns The interactive set of black or white Colors.
  *
  * @public
  */
 export function blackOrWhiteByContrastSet(
-    set: InteractiveSwatchSet,
+    set: InteractivePaintSet,
     minContrast: number,
     defaultBlack: boolean
-): InteractiveSwatchSet {
-    const defaultRule: (reference: Swatch | null) => Swatch | null = (reference) =>
+): InteractiveColorSet {
+    const defaultRule: (reference: Paint | null) => Color | null = (reference) =>
         reference ? blackOrWhiteByContrast(reference, minContrast, defaultBlack) : null;
 
     const restForeground = defaultRule(set.rest);
@@ -41,7 +42,7 @@ export function blackOrWhiteByContrastSet(
     const disabled = defaultRule(set.disabled);
     // TODO: Reasonable disabled opacity, but not configurable.
     // Considering replacing these recipes anyway.
-    const disabledForeground = disabled?.toTransparent(0.3) ?? null;
+    const disabledForeground = disabled ? Color.unsafeOpacity(disabled, 0.3) : null;
 
     return {
         rest: restForeground,

--- a/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast.spec.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast.spec.ts
@@ -1,11 +1,11 @@
 import chai from "chai";
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
 import { _black, _white } from "../utilities/color-constants.js";
 import { blackOrWhiteByContrast } from "./black-or-white-by-contrast.js";
 
 const { expect } = chai;
 
-const middleGrey = Swatch.parse("#808080")!;
+const middleGrey = Color.parse("#808080")!;
 
 describe("blackOrWhiteByContrast", (): void => {
     it("should return black when background does not meet contrast ratio with white", (): void => {

--- a/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/black-or-white-by-contrast.ts
@@ -1,8 +1,9 @@
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { _black, _white } from "../utilities/color-constants.js";
 
 /**
- * Gets a black or white Swatch based on the reference color and minimum contrast.
+ * Gets a black or white Color based on the reference color and minimum contrast.
  *
  * @remarks
  * If neither black nor white meet the requested contrast the highest contrasting color is returned.
@@ -10,11 +11,11 @@ import { _black, _white } from "../utilities/color-constants.js";
  * @param reference - The reference color
  * @param minContrast - The minimum contrast required for black or white from `reference`
  * @param defaultBlack - True to default to black if both black and white meet contrast
- * @returns A black or white Swatch
+ * @returns A black or white Color
  *
  * @public
  */
-export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch {
+export function blackOrWhiteByContrast(reference: Paint, minContrast: number, defaultBlack: boolean): Color {
     const defaultColor = defaultBlack ? _black : _white;
     const otherColor = defaultBlack ? _white : _black;
     const defaultContrast = reference.contrast(defaultColor);

--- a/packages/adaptive-ui/src/core/color/recipes/contrast-and-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/contrast-and-delta-swatch-set.ts
@@ -1,10 +1,11 @@
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { Palette, PaletteDirection, PaletteDirectionValue, resolvePaletteDirection } from "../palette.js";
-import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { InteractiveColorSet } from "../recipe.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
- * Gets an interactive set of {@link Swatch}es using contrast from the reference color, then deltas for each state.
+ * Gets an interactive set of {@link Color}s using contrast from the reference color, then deltas for each state.
  *
  * Since this is based on contrast it tries to do the right thing for accessibility. Ideally the `restDelta`
  * and `hoverDelta` should be greater than or equal to zero, because that will ensure those colors meet or
@@ -13,7 +14,7 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * This algorithm will maintain the difference between the rest and hover deltas, but may slide them on the Palette
  * to maintain accessibility.
  *
- * @param palette - The Palette used to find the Swatches
+ * @param palette - The Palette used to find the Colors
  * @param reference - The reference color
  * @param minContrast - The desired minimum contrast from `reference`, which determines the base color
  * @param restDelta - The rest state offset from the base color
@@ -21,16 +22,16 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param activeDelta - The active state offset from the base color
  * @param focusDelta - The focus state offset from the base color
  * @param disabledDelta - The disabled state offset from the base color
- * @param disabledPalette - The Palette for the disabled Swatch
+ * @param disabledPalette - The Palette for the disabled color
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @param zeroAsTransparent - Treat a zero offset as transparent, defaults to true
- * @returns The interactive set of Swatches
+ * @returns The interactive set of Colors
  *
  * @public
  */
 export function contrastAndDeltaSwatchSet(
     palette: Palette,
-    reference: Swatch,
+    reference: Paint,
     minContrast: number,
     restDelta: number,
     hoverDelta: number,
@@ -40,13 +41,13 @@ export function contrastAndDeltaSwatchSet(
     disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference),
     zeroAsTransparent: boolean = false,
-): InteractiveSwatchSet {
+): InteractiveColorSet {
     const dir = resolvePaletteDirection(direction);
 
     const referenceIndex = palette.closestIndexOf(reference);
-    const accessibleSwatch = palette.colorContrast(reference, minContrast, referenceIndex);
+    const accessibleColor = palette.colorContrast(reference, minContrast, referenceIndex);
 
-    const accessibleIndex1 = palette.closestIndexOf(accessibleSwatch);
+    const accessibleIndex1 = palette.closestIndexOf(accessibleColor);
     const accessibleIndex2 = accessibleIndex1 + dir * Math.abs(restDelta - hoverDelta);
     const indexOneIsRestState =
         dir === PaletteDirectionValue.darker ? restDelta < hoverDelta : dir * restDelta > dir * hoverDelta;
@@ -62,20 +63,20 @@ export function contrastAndDeltaSwatchSet(
         hoverIndex = accessibleIndex1;
     }
 
-    function getSwatch(palette: Palette, index: number): Swatch {
-        const swatch = palette.get(index);
+    function getColor(palette: Palette, index: number): Color {
+        const color = palette.get(index);
         if (zeroAsTransparent === true && index === referenceIndex) {
-            return swatch.toTransparent();
+            return Color.asOverlay(color, color);
         } else {
-            return swatch;
+            return color;
         }
     }
 
     return {
-        rest: getSwatch(palette, restIndex),
-        hover: getSwatch(palette, hoverIndex),
-        active: getSwatch(palette, restIndex + dir * activeDelta),
-        focus: getSwatch(palette, restIndex + dir * focusDelta),
-        disabled: getSwatch(disabledPalette, referenceIndex + dir * disabledDelta),
+        rest: getColor(palette, restIndex),
+        hover: getColor(palette, hoverIndex),
+        active: getColor(palette, restIndex + dir * activeDelta),
+        focus: getColor(palette, restIndex + dir * focusDelta),
+        disabled: getColor(disabledPalette, referenceIndex + dir * disabledDelta),
     };
 }

--- a/packages/adaptive-ui/src/core/color/recipes/contrast-swatch.spec.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/contrast-swatch.spec.ts
@@ -1,12 +1,12 @@
 import chai from "chai";
+import { Color } from "../color.js";
 import { PaletteRGB } from "../palette-rgb.js";
-import { Swatch } from "../swatch.js";
 import { contrastSwatch } from "./contrast-swatch.js";
 
 const { expect } = chai;
 
-const neutralBase = Swatch.parse("#808080")!;
-const accentBase = Swatch.parse("#80DEEA")!;
+const neutralBase = Color.parse("#808080")!;
+const accentBase = Color.parse("#80DEEA")!;
 
 describe("contrastSwatch", (): void => {
     const neutralPalette = PaletteRGB.from(neutralBase);

--- a/packages/adaptive-ui/src/core/color/recipes/contrast-swatch.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/contrast-swatch.ts
@@ -1,23 +1,24 @@
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { Palette, PaletteDirection } from "../palette.js";
-import { Swatch } from "../swatch.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
- * Gets a Swatch meeting the minimum contrast from the reference color.
+ * Gets a Color meeting the minimum contrast from the reference color.
  *
- * @param palette - The Palette used to find the Swatch
+ * @param palette - The Palette used to find the Color
  * @param reference - The reference color
  * @param minContrast - The desired minimum contrast
  * @param direction - The direction the delta moves on the `palette`, defaults to {@link directionByIsDark} based on `reference`
- * @returns The Swatch
+ * @returns The Color
  *
  * @public
  */
 export function contrastSwatch(
     palette: Palette,
-    reference: Swatch,
+    reference: Paint,
     minContrast: number,
     direction: PaletteDirection = directionByIsDark(reference)
-): Swatch {
+): Color {
     return palette.colorContrast(reference, minContrast, undefined, direction);
 }

--- a/packages/adaptive-ui/src/core/color/recipes/delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/delta-swatch-set.ts
@@ -1,28 +1,29 @@
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { Palette, PaletteDirection, resolvePaletteDirection } from "../palette.js";
-import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { InteractiveColorSet } from "../recipe.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
- * Gets an interactive set of Swatches the specified positions away from the reference color.
+ * Gets an interactive set of Colors the specified positions away from the reference color.
  *
- * @param palette - The Palette used to find the Swatches
+ * @param palette - The Palette used to find the Colors
  * @param reference - The reference color
  * @param restDelta - The rest state offset from `reference`
  * @param hoverDelta - The hover state offset from `reference`
  * @param activeDelta - The active state offset from `reference`
  * @param focusDelta - The focus state offset from `reference`
  * @param disabledDelta - The disabled state offset from the base color
- * @param disabledPalette - The Palette for the disabled Swatch
+ * @param disabledPalette - The Palette for the disabled color
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @param zeroAsTransparent - Treat a zero offset as transparent, defaults to true
- * @returns The interactive set of Swatches
+ * @returns The interactive set of Colors
  *
  * @public
  */
 export function deltaSwatchSet(
     palette: Palette,
-    reference: Swatch,
+    reference: Paint,
     restDelta: number,
     hoverDelta: number,
     activeDelta: number,
@@ -31,24 +32,24 @@ export function deltaSwatchSet(
     disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference),
     zeroAsTransparent: boolean = false,
-): InteractiveSwatchSet {
+): InteractiveColorSet {
     const referenceIndex = palette.closestIndexOf(reference);
     const dir = resolvePaletteDirection(direction);
 
-    function getSwatch(palette: Palette, delta: number): Swatch {
-        const swatch = palette.get(referenceIndex + dir * delta);
+    function getColor(palette: Palette, delta: number): Color {
+        const color = palette.get(referenceIndex + dir * delta);
         if (zeroAsTransparent === true && delta === 0) {
-            return swatch.toTransparent();
+            return Color.asOverlay(color, color);
         } else {
-            return swatch;
+            return color;
         }
     }
 
     return {
-        rest: getSwatch(palette, restDelta),
-        hover: getSwatch(palette, hoverDelta),
-        active: getSwatch(palette, activeDelta),
-        focus: getSwatch(palette, focusDelta),
-        disabled: getSwatch(disabledPalette, disabledDelta),
+        rest: getColor(palette, restDelta),
+        hover: getColor(palette, hoverDelta),
+        active: getColor(palette, activeDelta),
+        focus: getColor(palette, focusDelta),
+        disabled: getColor(disabledPalette, disabledDelta),
     };
 }

--- a/packages/adaptive-ui/src/core/color/recipes/delta-swatch.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/delta-swatch.ts
@@ -1,23 +1,24 @@
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { Palette, PaletteDirection } from "../palette.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
- * Color algorithm to get the Swatch a specified position away from the reference color.
+ * Color algorithm to get the Color a specified position away from the reference color.
  *
- * @param palette - The Palette used to find the Swatch
+ * @param palette - The Palette used to find the Color
  * @param reference - The reference color
  * @param delta - The offset from the `reference`
  * @param direction - The direction the delta moves on the `palette`, defaults to {@link directionByIsDark} based on `reference`
- * @returns The Swatch
+ * @returns The Color
  *
  * @public
  */
 export function deltaSwatch(
     palette: Palette,
-    reference: Swatch,
+    reference: Paint,
     delta: number,
     direction: PaletteDirection = directionByIsDark(reference)
-): Swatch {
+): Color {
     return palette.delta(reference, delta, direction);
 }

--- a/packages/adaptive-ui/src/core/color/recipes/ideal-color-delta-swatch-set.spec.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/ideal-color-delta-swatch-set.spec.ts
@@ -1,13 +1,13 @@
 import chai from "chai";
+import { Color } from "../color.js";
 import { PaletteRGB } from "../palette-rgb.js";
-import { Swatch } from "../swatch.js";
 import { _black, _white } from "../utilities/color-constants.js";
 import { idealColorDeltaSwatchSet } from "./ideal-color-delta-swatch-set.js";
 
 const { expect } = chai;
 
-const neutralBase = Swatch.parse("#808080")!;
-const accentBase = Swatch.parse("#80DEEA")!;
+const neutralBase = Color.parse("#808080")!;
+const accentBase = Color.parse("#80DEEA")!;
 
 describe("idealColorDeltaSwatchSet", (): void => {
     const neutralPalette = PaletteRGB.from(neutralBase);
@@ -23,11 +23,11 @@ describe("idealColorDeltaSwatchSet", (): void => {
 
     it("should have accessible rest and hover colors against the background color", (): void => {
         const accentColors = [
-            Swatch.parse("#0078D4")!,
-            Swatch.parse("#107C10")!,
-            Swatch.parse("#5C2D91")!,
-            Swatch.parse("#D83B01")!,
-            Swatch.parse("#F2C812")!,
+            Color.parse("#0078D4")!,
+            Color.parse("#107C10")!,
+            Color.parse("#5C2D91")!,
+            Color.parse("#D83B01")!,
+            Color.parse("#F2C812")!,
         ];
 
         accentColors.forEach((accent): void => {

--- a/packages/adaptive-ui/src/core/color/recipes/ideal-color-delta-swatch-set.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/ideal-color-delta-swatch-set.ts
@@ -1,11 +1,11 @@
 import { Color } from "../color.js";
+import { Paint } from "../paint.js";
 import { Palette, PaletteDirection, PaletteDirectionValue, resolvePaletteDirection } from "../palette.js";
-import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { InteractiveColorSet } from "../recipe.js";
 import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
 
 /**
- * Gets an interactive set of {@link Swatch}es using contrast from the reference color. If the ideal color meets contrast it
+ * Gets an interactive set of {@link Color}s using contrast from the reference color. If the ideal color meets contrast it
  * is used for the base color, if not it's adjusted until contrast is met. Then deltas from that color are used for each state.
  *
  * This algorithm is similar to {@link contrastAndDeltaSwatchSet}, with the addition of `idealColor`. This is often preferable
@@ -18,7 +18,7 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * This algorithm will maintain the difference between the rest and hover deltas, but may slide them on the Palette
  * to maintain accessibility.
  *
- * @param palette - The Palette used to find the Swatches
+ * @param palette - The Palette used to find the Colors
  * @param reference - The reference color
  * @param idealColor - The color to use as the base color if it meets `minContrast` from `reference`
  * @param minContrast - The desired minimum contrast from `reference`, which determines the base color
@@ -27,15 +27,15 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param activeDelta - The active state offset from the base color
  * @param focusDelta - The focus state offset from the base color
  * @param disabledDelta - The disabled state offset from the base color
- * @param disabledPalette - The Palette for the disabled Swatch
+ * @param disabledPalette - The Palette for the disabled color
  * @param direction - The direction the deltas move on the `palette`, defaults to {@link directionByIsDark} based on `reference`
- * @returns The interactive set of Swatches
+ * @returns The interactive set of Colors
  *
  * @public
  */
 export function idealColorDeltaSwatchSet(
     palette: Palette,
-    reference: Swatch,
+    reference: Paint,
     minContrast: number,
     idealColor: Color,
     restDelta: number,
@@ -45,7 +45,7 @@ export function idealColorDeltaSwatchSet(
     disabledDelta: number,
     disabledPalette: Palette = palette,
     direction: PaletteDirection = directionByIsDark(reference)
-): InteractiveSwatchSet {
+): InteractiveColorSet {
     const dir = resolvePaletteDirection(direction);
 
     const referenceIndex = palette.closestIndexOf(reference);

--- a/packages/adaptive-ui/src/core/color/swatch.spec.ts
+++ b/packages/adaptive-ui/src/core/color/swatch.spec.ts
@@ -1,7 +1,7 @@
 import chai from "chai";
+import { type Rgb } from "culori/fn";
 import { Color } from "./color.js";
 import { Swatch } from "./swatch.js";
-import { type Rgb } from "culori/fn";
 import { _white } from "./utilities/color-constants.js";
 
 const { expect } = chai;
@@ -24,6 +24,7 @@ describe("Swatch", () => {
         expect(swatch).to.be.instanceof(Swatch);
         expect(swatch.color).to.deep.equal(greyColor);
         expect(swatch.toColorString()).to.equal(greyHex);
+        expect(swatch.toString()).to.equal(greyHex);
     });
 
     it("should create a Swatch from the provided RGB values", () => {

--- a/packages/adaptive-ui/src/core/color/swatch.ts
+++ b/packages/adaptive-ui/src/core/color/swatch.ts
@@ -1,81 +1,21 @@
-import { type Color as CuloriColor, modeRgb, parse, type Rgb, useMode } from "culori/fn";
+import { modeRgb, parse, type Rgb, useMode } from "culori/fn";
 import { Color } from "./color.js";
+import { calculateOverlayColor } from "./utilities/opacity.js";
 
 const rgb = useMode(modeRgb);
 
-const rgbBlack: Rgb = { mode: "rgb", r: 0, g: 0, b: 0 };
-const rgbWhite: Rgb = { mode: "rgb", r: 1, g: 1, b: 1 };
-
-function calcChannelOverlay(match: number, background: number, overlay: number): number {
-    if (overlay - background === 0) {
-        return 0;
-    } else {
-        return (match - background) / (overlay - background);
-    }
-}
-
-function calcRgbOverlay(rgbMatch: Rgb, rgbBackground: Rgb, rgbOverlay: Rgb): number {
-    const rChannel: number = calcChannelOverlay(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
-    const gChannel: number = calcChannelOverlay(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
-    const bChannel: number = calcChannelOverlay(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
-    return (rChannel + gChannel + bChannel) / 3;
-}
-
 /**
- * Calculate an overlay color that uses rgba (rgb + alpha) that matches the appearance of a given solid color
- * when placed on the same background.
- *
- * @param rgbMatch - The solid color the overlay should match in appearance when placed over the rgbBackground
- * @param rgbBackground - The background on which the overlay rests
- * @returns The rgba (rgb + alpha) color of the overlay
- */
-function calculateOverlayColor(rgbMatch: Rgb, rgbBackground: Rgb): Rgb {
-    let overlay = rgbBlack;
-    let alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
-    if (alpha <= 0) {
-        overlay = rgbWhite;
-        alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
-    }
-    alpha = Math.round(alpha * 1000) / 1000;
-
-    return Object.assign({}, overlay, { alpha });
-}
-
-/**
- * Extends {@link Color} adding support for relative opacity.
+ * Legacy equivalent of Color.
  *
  * @public
+ * @deprecated Use {@link Color}.
  */
 export class Swatch extends Color {
-    /**
-     * The opaque value this Swatch represents if opacity is used.
-     */
-    private readonly _intendedColor?: Swatch;
-
-    /**
-     * Creates a new Swatch.
-     *
-     * @param color - The underlying Color value
-     * @param intendedColor - If `color.alpha` &lt; 1 this tracks the intended opaque color value for dependent calculations
-     */
-    protected constructor(color: CuloriColor, intendedColor?: Swatch) {
-        super(color);
-        this._intendedColor = intendedColor;
-    }
-
-    /**
-     * {@inheritdoc RelativeLuminance.relativeLuminance}
-     */
-    public get relativeLuminance(): number {
-        return this._intendedColor
-            ? this._intendedColor.relativeLuminance
-            : super.relativeLuminance;
-    }
-
     /**
      * Gets this color with transparency.
      *
      * @returns The color with full transparency
+     * @deprecated Use Color.unsafeOpacity
      */
     public toTransparent(alpha: number = 0): Swatch {
         const transparentColor = { ...this.color };

--- a/packages/adaptive-ui/src/core/color/utilities/color-constants.ts
+++ b/packages/adaptive-ui/src/core/color/utilities/color-constants.ts
@@ -1,15 +1,15 @@
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
 
 /**
- * A {@link Swatch} convenience for white.
+ * A {@link Color} convenience for white.
  *
  * @internal
  */
-export const _white = Swatch.fromRgb(1, 1, 1);
+export const _white = Color.fromRgb(1, 1, 1);
 
 /**
- * A {@link Swatch} convenience for black.
+ * A {@link Color} convenience for black.
  *
  * @internal
  */
-export const _black = Swatch.fromRgb(0, 0, 0);
+export const _black = Color.fromRgb(0, 0, 0);

--- a/packages/adaptive-ui/src/core/color/utilities/conditional.ts
+++ b/packages/adaptive-ui/src/core/color/utilities/conditional.ts
@@ -1,7 +1,8 @@
-import { InteractiveSwatchSet } from "../recipe.js";
+import { Color } from "../color.js";
+import { InteractiveColorSet } from "../recipe.js";
 import { _white } from "./color-constants.js";
 
-const transparentWhite = _white.toTransparent();
+const _transparentWhite = Color.unsafeOpacity(_white, 0);
 
 /**
  * Return an interactive set of the provided tokens or a no-op "transparent" set of tokens.
@@ -11,18 +12,18 @@ const transparentWhite = _white.toTransparent();
  * @returns The provided swatch set or a "transparent" swatch set.
  */
 export function conditionalSwatchSet(
-    set: InteractiveSwatchSet,
+    set: InteractiveColorSet,
     condition: boolean
-): InteractiveSwatchSet {
+): InteractiveColorSet {
     if (condition) {
         return set;
     }
 
     return {
-        rest: transparentWhite,
-        hover: transparentWhite,
-        active: transparentWhite,
-        focus: transparentWhite,
-        disabled: transparentWhite,
+        rest: _transparentWhite,
+        hover: _transparentWhite,
+        active: _transparentWhite,
+        focus: _transparentWhite,
+        disabled: _transparentWhite,
     };
 }

--- a/packages/adaptive-ui/src/core/color/utilities/luminance-swatch.ts
+++ b/packages/adaptive-ui/src/core/color/utilities/luminance-swatch.ts
@@ -1,13 +1,13 @@
-import { Swatch } from "../swatch.js";
+import { Color } from "../color.js";
 
 /**
- * Create a grey {@link Swatch} for the specified `luminance`. Note this is absolute luminance not 'relative' luminance.
+ * Create a grey {@link Color} for the specified `luminance`. Note this is absolute luminance not 'relative' luminance.
  *
  * @param luminance - A value between 0 and 1 representing the desired luminance, for example, 0.5 for middle grey, 0 = black, 1 = white
  * @returns A swatch for the specified grey value
  *
  * @public
  */
-export function luminanceSwatch(luminance: number): Swatch {
-    return Swatch.fromRgb(luminance, luminance, luminance);
+export function luminanceSwatch(luminance: number): Color {
+    return Color.fromRgb(luminance, luminance, luminance);
 }

--- a/packages/adaptive-ui/src/core/color/utilities/opacity.ts
+++ b/packages/adaptive-ui/src/core/color/utilities/opacity.ts
@@ -1,24 +1,69 @@
-import { InteractiveSwatchSet } from "../recipe.js";
-import { Swatch } from "../swatch.js";
+import { type Color as CuloriColor, modeRgb, type Rgb, useMode } from "culori/fn";
+import { Color } from "../color.js";
+import { InteractiveColorSet } from "../recipe.js";
+
+const rgb = useMode(modeRgb);
+
+const rgbBlack: Rgb = { mode: "rgb", r: 0, g: 0, b: 0 };
+const rgbWhite: Rgb = { mode: "rgb", r: 1, g: 1, b: 1 };
+
+function calcChannelOverlay(match: number, background: number, overlay: number): number {
+    if (overlay - background === 0) {
+        return 0;
+    } else {
+        return (match - background) / (overlay - background);
+    }
+}
+
+function calcRgbOverlay(rgbMatch: Rgb, rgbBackground: Rgb, rgbOverlay: Rgb): number {
+    const rChannel: number = calcChannelOverlay(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
+    const gChannel: number = calcChannelOverlay(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
+    const bChannel: number = calcChannelOverlay(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
+    return (rChannel + gChannel + bChannel) / 3;
+}
 
 /**
- * Returns an opaque {@link Swatch} or a {@link Swatch} with opacity relative to the reference color.
+ * Calculate an overlay color that uses rgba (rgb + alpha) that matches the appearance of a given solid color
+ * when placed on the same background.
  *
- * @param swatch - The opaque intended swatch color.
+ * @param match - The solid color the overlay should match in appearance when placed over the rgbBackground
+ * @param background - The background on which the overlay rests
+ * @returns The rgba (rgb + alpha) color of the overlay
+ *
+ * @public
+ */
+export function calculateOverlayColor(match: CuloriColor, background: CuloriColor): Rgb {
+    const rgbMatch = rgb(match);
+    const rgbBackground = rgb(background);
+    let overlay = rgbBlack;
+    let alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
+    if (alpha <= 0) {
+        overlay = rgbWhite;
+        alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
+    }
+    alpha = Math.round(alpha * 1000) / 1000;
+
+    return Object.assign({}, overlay, { alpha });
+}
+
+/**
+ * Returns an opaque {@link Color} or a {@link Color} with opacity relative to the reference color.
+ *
+ * @param color - The opaque intended swatch color.
  * @param reference - The reference color for a semitransparent swatch.
  * @param asOverlay - True to return a semitransparent representation of `swatch` relative to `reference`.
  * @returns The requested representation of `swatch`.
  *
  * @public
  */
-export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOverlay: boolean): Swatch | null {
-    return swatch && asOverlay
-        ? Swatch.asOverlay(swatch, reference)
-        : swatch;
+export function swatchAsOverlay(color: Color | null, reference: Color, asOverlay: boolean): Color | null {
+    return color && asOverlay
+        ? Color.asOverlay(color, reference)
+        : color;
 }
 
 /**
- * Returns an interactive set of opaque {@link Swatch}es or {@link Swatch}es with opacity relative to the reference color.
+ * Returns an interactive set of opaque {@link Color}s or {@link Color}s with opacity relative to the reference color.
  *
  * @param set - The swatch set for which to make overlay.
  * @param reference - The reference color for a semitransparent swatch.
@@ -28,10 +73,10 @@ export function swatchAsOverlay(swatch: Swatch | null, reference: Swatch, asOver
  * @public
  */
 export function interactiveSwatchSetAsOverlay(
-    set: InteractiveSwatchSet,
-    reference: Swatch,
+    set: InteractiveColorSet,
+    reference: Color,
     asOverlay: boolean
-): InteractiveSwatchSet {
+): InteractiveColorSet {
     if (asOverlay) {
         return {
             rest: swatchAsOverlay(set.rest, reference, asOverlay),

--- a/packages/adaptive-ui/src/core/color/utilities/relative-luminance.ts
+++ b/packages/adaptive-ui/src/core/color/utilities/relative-luminance.ts
@@ -8,6 +8,13 @@ export interface RelativeLuminance {
      * A number between 0 and 1, calculated by {@link https://www.w3.org/WAI/GL/wiki/Relative_luminance}
      */
     readonly relativeLuminance: number;
+
+    /**
+     * Gets the contrast between this relative luminance and another.
+     *
+     * @returns The contrast between the two luminance values, for example, 4.54
+     */
+    contrast: (a: RelativeLuminance) => number;
 }
 
 /**

--- a/packages/adaptive-ui/src/core/modules/styles.ts
+++ b/packages/adaptive-ui/src/core/modules/styles.ts
@@ -1,7 +1,7 @@
 import type { CSSDirective } from "@microsoft/fast-element";
 import { CSSDesignToken } from "@microsoft/fast-foundation";
 import { InteractiveColorRecipe, InteractiveColorRecipeBySet } from "../color/recipe.js";
-import { Swatch } from "../color/swatch.js";
+import { Paint } from "../color/paint.js";
 import { TypedCSSDesignToken, TypedDesignToken } from "../adaptive-design-tokens.js";
 import { InteractiveTokenGroup, InteractiveValues } from "../types.js";
 import { createForegroundSet, createForegroundSetBySet } from "../token-helpers-color.js";
@@ -90,7 +90,7 @@ export type StyleRule = {
  */
 export const Fill = {
     backgroundAndForeground: function(
-        background: InteractiveTokenGroup<Swatch>,
+        background: InteractiveTokenGroup<Paint>,
         foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>
     ): StyleProperties {
         return {
@@ -100,7 +100,7 @@ export const Fill = {
     },
 
     backgroundAndForegroundBySet: function(
-        background: InteractiveTokenGroup<Swatch>,
+        background: InteractiveTokenGroup<Paint>,
         foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>
     ): StyleProperties {
         return {
@@ -110,8 +110,8 @@ export const Fill = {
     },
 
     foregroundNonInteractiveWithDisabled: function(
-        foreground: TypedCSSDesignToken<Swatch>,
-        disabled: TypedCSSDesignToken<Swatch>,
+        foreground: TypedCSSDesignToken<Paint>,
+        disabled: TypedCSSDesignToken<Paint>,
     ): StyleProperties {
         return {
             foregroundFill: {
@@ -121,7 +121,7 @@ export const Fill = {
                 active: foreground,
                 focus: foreground,
                 disabled,
-            } as InteractiveTokenGroup<Swatch>,
+            } as InteractiveTokenGroup<Paint>,
         }
     }
 }

--- a/packages/adaptive-ui/src/core/shadow/index.ts
+++ b/packages/adaptive-ui/src/core/shadow/index.ts
@@ -1,6 +1,6 @@
 import { CSSDirective, cssDirective } from "@microsoft/fast-element";
 import { DesignTokenMultiValue, DesignTokenType } from "../adaptive-design-tokens.js";
-import { Swatch } from "../color/swatch.js";
+import { Color } from "../color/color.js";
 import { StyleProperty } from "../modules/types.js";
 import { createTyped } from "../token-helpers.js";
 
@@ -21,7 +21,7 @@ export class Shadow implements CSSDirective {
      * @param spread - The spread in `px`. This is not supported in all potential uses of Shadow (text or drop).
      */
     constructor(
-        public color: Swatch,
+        public color: Color,
         public xOffset: number,
         public yOffset: number,
         public blurRadius?: number,

--- a/packages/adaptive-ui/src/core/token-helpers-color.ts
+++ b/packages/adaptive-ui/src/core/token-helpers-color.ts
@@ -1,4 +1,5 @@
 import type { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
+import { Paint } from "./color/paint.js";
 import {
     ColorRecipe,
     ColorRecipeBySet,
@@ -10,14 +11,13 @@ import {
     ColorRecipeParams,
     InteractiveColorRecipe,
     InteractiveColorRecipeBySet,
-    InteractiveSwatchSet,
+    InteractivePaintSet,
 } from "./color/recipe.js";
 import { Palette } from "./color/palette.js";
-import { Swatch } from "./color/swatch.js";
 import { StyleProperty } from "./modules/types.js";
 import { DesignTokenRegistry, DesignTokenType, TypedCSSDesignToken, TypedDesignToken } from "./adaptive-design-tokens.js";
 import { Recipe, RecipeOptional } from "./recipes.js";
-import { createTokenNonCss, createTokenSwatch } from "./token-helpers.js";
+import { createTokenNonCss, createTokenPaint } from "./token-helpers.js";
 import { InteractiveState, InteractiveTokenGroup } from "./types.js";
 
 /**
@@ -61,7 +61,7 @@ export function createTokenMinContrast(
  *
  * @public
  */
-export function createTokenColorRecipe<T = Swatch>(
+export function createTokenColorRecipe<T = Paint>(
     baseName: string,
     intendedFor: StyleProperty | StyleProperty[],
     evaluate: ColorRecipeEvaluate<T>,
@@ -80,7 +80,7 @@ export function createTokenColorRecipe<T = Swatch>(
  *
  * @public
  */
-export function createTokenColorRecipeBySet<T = Swatch>(
+export function createTokenColorRecipeBySet<T = Paint>(
     baseName: string,
     intendedFor: StyleProperty | StyleProperty[],
     evaluate: ColorRecipeBySetEvaluate<T>,
@@ -100,7 +100,7 @@ export function createTokenColorRecipeBySet<T = Swatch>(
  *
  * @public
  */
-export function createTokenColorRecipeForPalette<T = Swatch>(
+export function createTokenColorRecipeForPalette<T = Paint>(
     baseName: string,
     intendedFor: StyleProperty | StyleProperty[],
     evaluate: ColorRecipePaletteEvaluate<T>,
@@ -118,7 +118,7 @@ export function createTokenColorRecipeForPalette<T = Swatch>(
  *
  * @public
  */
-export function createTokenColorRecipeWithPalette<T>(
+export function createTokenColorRecipeWithPalette<T = Paint>(
     recipeToken: TypedDesignToken<Recipe<ColorRecipePaletteParams, T>>,
     paletteToken: DesignToken<Palette>,
 ): TypedDesignToken<RecipeOptional<ColorRecipeParams, T>> {
@@ -133,11 +133,11 @@ export function createTokenColorRecipeWithPalette<T>(
     });
 }
 
-function createTokenColorSetState(
-    valueToken: TypedDesignToken<InteractiveSwatchSet>,
+function createTokenPaintSetState(
+    valueToken: TypedDesignToken<InteractivePaintSet>,
     state: InteractiveState,
-): TypedCSSDesignToken<Swatch> {
-    return createTokenSwatch(`${valueToken.name.replace(".value", "")}.${state}`, valueToken.intendedFor).withDefault(
+): TypedCSSDesignToken<Paint> {
+    return createTokenPaint(`${valueToken.name.replace(".value", "")}.${state}`, valueToken.intendedFor).withDefault(
         (resolve: DesignTokenResolver) =>
             resolve(valueToken)[state] as any
     );
@@ -152,9 +152,9 @@ function createTokenColorSetState(
  */
 export function createTokenColorSet(
     recipeToken: TypedDesignToken<InteractiveColorRecipe>
-): InteractiveTokenGroup<Swatch> {
+): InteractiveTokenGroup<Paint> {
     const name = recipeToken.name.replace(".recipe", "");
-    const valueToken = createTokenNonCss<InteractiveSwatchSet>(`${name}.value`, DesignTokenType.color, recipeToken.intendedFor).withDefault(
+    const valueToken = createTokenNonCss<InteractivePaintSet>(`${name}.value`, DesignTokenType.color, recipeToken.intendedFor).withDefault(
         (resolve: DesignTokenResolver) =>
             resolve(recipeToken).evaluate(resolve)
     );
@@ -163,11 +163,11 @@ export function createTokenColorSet(
         name,
         type: DesignTokenType.color,
         intendedFor: valueToken.intendedFor,
-        rest: createTokenColorSetState(valueToken, InteractiveState.rest),
-        hover: createTokenColorSetState(valueToken, InteractiveState.hover),
-        active: createTokenColorSetState(valueToken, InteractiveState.active),
-        focus: createTokenColorSetState(valueToken, InteractiveState.focus),
-        disabled: createTokenColorSetState(valueToken, InteractiveState.disabled),
+        rest: createTokenPaintSetState(valueToken, InteractiveState.rest),
+        hover: createTokenPaintSetState(valueToken, InteractiveState.hover),
+        active: createTokenPaintSetState(valueToken, InteractiveState.active),
+        focus: createTokenPaintSetState(valueToken, InteractiveState.focus),
+        disabled: createTokenPaintSetState(valueToken, InteractiveState.disabled),
     };
     DesignTokenRegistry.Groups.set(name, group);
     return group;
@@ -181,9 +181,9 @@ export function createTokenColorSet(
  * @public
  */
 export function createTokenColorRecipeValue(
-    recipeToken: TypedDesignToken<ColorRecipe<Swatch>>,
-): TypedCSSDesignToken<Swatch> {
-    return createTokenSwatch(`${recipeToken.name.replace(".recipe", "")}.value`, recipeToken.intendedFor).withDefault(
+    recipeToken: TypedDesignToken<ColorRecipe<Paint>>,
+): TypedCSSDesignToken<Paint> {
+    return createTokenPaint(`${recipeToken.name.replace(".recipe", "")}.value`, recipeToken.intendedFor).withDefault(
         (resolve: DesignTokenResolver) =>
             resolve(recipeToken).evaluate(resolve)
     );
@@ -200,16 +200,16 @@ export function createTokenColorRecipeValue(
  */
 export function createForegroundSet(
     foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>,
-    background: InteractiveTokenGroup<Swatch>,
-): InteractiveTokenGroup<Swatch> {
+    background: InteractiveTokenGroup<Paint>,
+): InteractiveTokenGroup<Paint> {
     const foregroundBaseName = `${foregroundRecipe.name.replace(".recipe", "")}`;
     const setName = `${foregroundBaseName}.on.${background.name.replace("color.", "")}`;
 
     function createState(
         foregroundState: InteractiveState,
         state: InteractiveState,
-    ): TypedCSSDesignToken<Swatch> {
-        return createTokenSwatch(`${setName}.${state}`).withDefault(
+    ): TypedCSSDesignToken<Paint> {
+        return createTokenPaint(`${setName}.${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
                 resolve(foregroundRecipe).evaluate(resolve, {
                     reference: resolve(background[state])
@@ -241,15 +241,15 @@ export function createForegroundSet(
  */
 export function createForegroundSetBySet(
     foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>,
-    background: InteractiveTokenGroup<Swatch>,
-): InteractiveTokenGroup<Swatch> {
+    background: InteractiveTokenGroup<Paint>,
+): InteractiveTokenGroup<Paint> {
     const foregroundBaseName = foregroundRecipe.name.replace(".recipe", "");
     const setName = `${foregroundBaseName}.on.${background.name.replace("color.", "")}`;
 
-    const set = createTokenNonCss<InteractiveSwatchSet>(`${setName}.value`, DesignTokenType.color).withDefault(
+    const set = createTokenNonCss<InteractivePaintSet>(`${setName}.value`, DesignTokenType.color).withDefault(
         (resolve: DesignTokenResolver) =>
             {
-                const backgroundSet: InteractiveSwatchSet = {
+                const backgroundSet: InteractivePaintSet = {
                     rest: resolve(background.rest),
                     hover: resolve(background.hover),
                     active: resolve(background.active),
@@ -262,8 +262,8 @@ export function createForegroundSetBySet(
 
     function createState(
         state: InteractiveState,
-    ): TypedCSSDesignToken<Swatch> {
-        return createTokenSwatch(`${setName}.${state}`).withDefault(
+    ): TypedCSSDesignToken<Paint> {
+        return createTokenPaint(`${setName}.${state}`).withDefault(
             (resolve: DesignTokenResolver) =>
                 resolve(set)[state] as any
         );

--- a/packages/adaptive-ui/src/core/token-helpers.ts
+++ b/packages/adaptive-ui/src/core/token-helpers.ts
@@ -1,6 +1,7 @@
 import { DesignToken } from "@microsoft/fast-foundation";
 import { DesignTokenType, TypedCSSDesignToken, TypedDesignToken } from "./adaptive-design-tokens.js";
 import { Color } from "./color/color.js";
+import { Paint } from "./color/paint.js";
 import { Swatch } from "./color/swatch.js";
 import { StyleProperty } from "./modules/types.js";
 import { Recipe, RecipeEvaluate } from "./recipes.js";
@@ -166,7 +167,7 @@ export function createTokenNumberNonStyling(name: string, intendedFor?: StylePro
 }
 
 /**
- * Creates a DesignToken that can be used as a fill in styles.
+ * Creates a DesignToken that can be used as a paint treatment (background, foreground, border, etc.) in styles.
  *
  * @param name - The token name in `css-identifier` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
@@ -176,7 +177,19 @@ export function createTokenNumberNonStyling(name: string, intendedFor?: StylePro
  *
  * @public
  */
+export function createTokenPaint(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Paint> {
+    return TypedCSSDesignToken.createTyped<Paint>(name, DesignTokenType.paint, intendedFor);
+}
+
+/**
+ * Creates a DesignToken that can be used as a color in styles.
+ *
+ * @param name - The token name in `css-identifier` casing.
+ * @param intendedFor - The style properties where this token is intended to be used.
+ *
+ * @public
+ * @deprecated Use createTokenColor or createTokenPaint
+ */
 export function createTokenSwatch(name: string, intendedFor?: StyleProperty | StyleProperty[]): TypedCSSDesignToken<Swatch> {
-    // TODO: Add back `gradient` type support when multiple types are added. (see `adaptive-design-tokens.ts`)
     return TypedCSSDesignToken.createTyped<Swatch>(name, DesignTokenType.color, intendedFor);
 }

--- a/packages/adaptive-ui/src/migration/color.ts
+++ b/packages/adaptive-ui/src/migration/color.ts
@@ -1,9 +1,9 @@
 import type { DesignTokenResolver } from "@microsoft/fast-foundation";
-import { ColorRecipeParams, InteractiveSwatchSet } from "../core/color/recipe.js";
+import { ColorRecipeParams, InteractivePaintSet } from "../core/color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../core/color/recipes/black-or-white-by-contrast-set.js";
 import { deltaSwatchSet } from "../core/color/recipes/delta-swatch-set.js";
 import { deltaSwatch } from "../core/color/recipes/delta-swatch.js";
-import { Swatch } from "../core/color/swatch.js";
+import { Color } from "../core/color/color.js";
 import { interactiveSwatchSetAsOverlay, swatchAsOverlay } from "../core/color/utilities/opacity.js";
 import { StyleProperty, StylePropertyShorthand } from "../core/modules/types.js";
 import {
@@ -112,7 +112,7 @@ const foregroundOnAccentFillReadableName = "foreground-on-accent-fill-readable";
 export const foregroundOnAccentFillReadableRecipe = createTokenColorRecipe(
     foregroundOnAccentFillReadableName,
     StyleProperty.foregroundFill,
-    (resolve: DesignTokenResolver): InteractiveSwatchSet =>
+    (resolve: DesignTokenResolver): InteractivePaintSet =>
         blackOrWhiteByContrastSet(
             {
                 rest: resolve(accentFillReadable.rest),
@@ -433,7 +433,7 @@ export const neutralFillInputRecipe = createTokenColorRecipe(
                 resolve(neutralFillInputFocusDelta),
                 1,
             ),
-            params?.reference || resolve(fillColor),
+            params?.reference as Color || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
@@ -484,7 +484,7 @@ export const neutralFillSecondaryRecipe = createTokenColorRecipe(
                 resolve(neutralFillSecondaryFocusDelta),
                 1,
             ),
-            params?.reference || resolve(fillColor),
+            params?.reference as Color || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );
@@ -569,14 +569,14 @@ export const neutralStrokeDividerRestDelta = createTokenDelta(neutralStrokeDivid
 export const neutralStrokeDividerRecipe = createTokenColorRecipe(
     neutralStrokeDividerName,
     StylePropertyShorthand.borderFill,
-    (resolve: DesignTokenResolver, params?: ColorRecipeParams): Swatch =>
+    (resolve: DesignTokenResolver, params?: ColorRecipeParams): Color =>
         swatchAsOverlay(
             deltaSwatch(
                 resolve(neutralPalette),
                 params?.reference || resolve(fillColor),
                 resolve(neutralStrokeDividerRestDelta)
             ),
-            params?.reference || resolve(fillColor),
+            params?.reference as Color || resolve(fillColor),
             resolve(neutralAsOverlay)
         )!
 );
@@ -615,7 +615,7 @@ export const neutralStrokeInputRecipe = createTokenColorRecipe(
                 resolve(neutralStrokeInputFocusDelta),
                 1,
             ),
-            params?.reference || resolve(fillColor),
+            params?.reference as Color || resolve(fillColor),
             resolve(neutralAsOverlay)
         )
 );

--- a/packages/adaptive-ui/src/reference/color.ts
+++ b/packages/adaptive-ui/src/reference/color.ts
@@ -1,13 +1,13 @@
 import type { DesignTokenResolver, ValuesOf } from "@microsoft/fast-foundation";
 import { Palette } from "../core/color/palette.js";
-import { ColorRecipePaletteParams, ColorRecipeParams, InteractiveSwatchSet } from "../core/color/recipe.js";
+import { ColorRecipePaletteParams, ColorRecipeParams, InteractiveColorSet, InteractivePaintSet } from "../core/color/recipe.js";
 import { blackOrWhiteByContrastSet } from "../core/color/recipes/black-or-white-by-contrast-set.js";
 import { blackOrWhiteByContrast } from "../core/color/recipes/black-or-white-by-contrast.js";
 import { contrastSwatch } from "../core/color/recipes/contrast-swatch.js";
 import { contrastAndDeltaSwatchSet } from "../core/color/recipes/contrast-and-delta-swatch-set.js";
 import { deltaSwatchSet } from "../core/color/recipes/delta-swatch-set.js";
 import { idealColorDeltaSwatchSet } from "../core/color/recipes/ideal-color-delta-swatch-set.js";
-import { Swatch } from "../core/color/swatch.js";
+import { Color } from "../core/color/color.js";
 import { _white } from "../core/color/utilities/color-constants.js";
 import { conditionalSwatchSet } from "../core/color/utilities/conditional.js";
 import { interactiveSwatchSetAsOverlay } from "../core/color/utilities/opacity.js";
@@ -23,7 +23,7 @@ import {
     createTokenDelta,
     createTokenMinContrast,
 } from "../core/token-helpers-color.js";
-import { createTokenNonCss, createTokenSwatch } from "../core/token-helpers.js";
+import { createTokenColor, createTokenNonCss } from "../core/token-helpers.js";
 import { InteractiveState } from "../core/types.js";
 import { DesignTokenType, TypedDesignToken } from "../core/adaptive-design-tokens.js";
 import { accentPalette, criticalPalette, disabledPalette, highlightPalette, infoPalette, neutralPalette, successPalette, warningPalette } from "./palette.js";
@@ -113,7 +113,7 @@ export function createTokenColorRecipeInfo<T>(
  *
  * @public
  */
-export function createTokenColorRecipeNeutral<T extends InteractiveSwatchSet>(
+export function createTokenColorRecipeNeutral<T extends InteractiveColorSet>(
     recipeToken: TypedDesignToken<Recipe<ColorRecipePaletteParams, T>>,
 ): TypedDesignToken<RecipeOptional<ColorRecipeParams, T>> {
     const paletteToken = neutralPalette;
@@ -125,7 +125,7 @@ export function createTokenColorRecipeNeutral<T extends InteractiveSwatchSet>(
             const p = Object.assign({ palette: resolve(paletteToken) }, params);
             return interactiveSwatchSetAsOverlay(
                 resolve(recipeToken).evaluate(resolve, p),
-                p.reference || resolve(fillColor),
+                p.reference as Color || resolve(fillColor),
                 resolve(neutralAsOverlay)
             ) as T;
         }
@@ -179,7 +179,7 @@ export const minContrastReadable = createTokenNonCss<number>("color.wcagContrast
 );
 
 /** @public */
-export const fillColor = createTokenSwatch("color.context").withDefault(_white);
+export const fillColor = createTokenColor("color.context").withDefault(_white);
 
 /** @public */
 export const neutralAsOverlay = createTokenNonCss<boolean>("color.neutral.asOverlay", DesignTokenType.boolean).withDefault(false);
@@ -193,10 +193,10 @@ export const neutralAsOverlay = createTokenNonCss<boolean>("color.neutral.asOver
  *
  * @public
  */
-export const blackOrWhiteDiscernibleRecipe = createTokenColorRecipeBySet<InteractiveSwatchSet>(
+export const blackOrWhiteDiscernibleRecipe = createTokenColorRecipeBySet<InteractivePaintSet>(
     "color.blackOrWhite.discernible",
     StyleProperty.foregroundFill,
-    (resolve: DesignTokenResolver, reference: InteractiveSwatchSet) =>
+    (resolve: DesignTokenResolver, reference: InteractivePaintSet) =>
         blackOrWhiteByContrastSet(
             reference,
             resolve(minContrastDiscernible),
@@ -213,10 +213,10 @@ export const blackOrWhiteDiscernibleRecipe = createTokenColorRecipeBySet<Interac
  *
  * @public
  */
-export const blackOrWhiteReadableRecipe = createTokenColorRecipeBySet<InteractiveSwatchSet>(
+export const blackOrWhiteReadableRecipe = createTokenColorRecipeBySet<InteractivePaintSet>(
     "color.blackOrWhite.readable",
     StyleProperty.foregroundFill,
-    (resolve: DesignTokenResolver, reference: InteractiveSwatchSet) =>
+    (resolve: DesignTokenResolver, reference: InteractivePaintSet) =>
         blackOrWhiteByContrastSet(
             reference,
             resolve(minContrastReadable),
@@ -1754,7 +1754,7 @@ const focusStrokeName = "color.focusStroke";
 export const focusStrokeRecipe = createTokenColorRecipe(
     focusStrokeName,
     [...StylePropertyShorthand.borderFill, StyleProperty.outlineColor],
-    (resolve: DesignTokenResolver, params?: ColorRecipeParams): Swatch =>
+    (resolve: DesignTokenResolver, params?: ColorRecipeParams): Color =>
         contrastSwatch(
             resolve(focusStrokePalette),
             params?.reference || resolve(fillColor),
@@ -1773,7 +1773,7 @@ const focusStrokeOuterName = "color.focusStroke.outer";
 export const focusStrokeOuterRecipe = createTokenColorRecipe(
     focusStrokeOuterName,
     StylePropertyShorthand.borderFill,
-    (resolve: DesignTokenResolver): Swatch =>
+    (resolve: DesignTokenResolver): Color =>
         blackOrWhiteByContrast(resolve(fillColor), resolve(minContrastReadable), true)
 );
 
@@ -1788,7 +1788,7 @@ const focusStrokeInnerName = "color.focusStroke.inner";
 export const focusStrokeInnerRecipe = createTokenColorRecipe(
     focusStrokeInnerName,
     StylePropertyShorthand.borderFill,
-    (resolve: DesignTokenResolver): Swatch =>
+    (resolve: DesignTokenResolver): Color =>
         blackOrWhiteByContrast(resolve(focusStrokeOuter), resolve(minContrastReadable), false)
 );
 

--- a/packages/adaptive-ui/src/reference/elevation.ts
+++ b/packages/adaptive-ui/src/reference/elevation.ts
@@ -1,4 +1,5 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import { Color } from "../core/color/color.js";
 import { StyleProperty } from "../core/modules/types.js";
 import { DesignTokenMultiValue, DesignTokenType } from "../core/adaptive-design-tokens.js";
 import { createTokenNonCss, createTokenRecipe } from "../core/token-helpers.js";
@@ -19,9 +20,9 @@ export const elevationRecipe = createTokenRecipe<number, ShadowValue>("elevation
             directionalOpacity = 0.24;
         }
 
-        const color = resolve(neutralStrokeStrong.rest);
-        const ambient = new Shadow(color.toTransparent(ambientOpacity), 0, 0, 2);
-        const directional = new Shadow(color.toTransparent(directionalOpacity), 0, size * 0.5, size);
+        const color = resolve(neutralStrokeStrong.rest) as Color; // TODO remove type assumption
+        const ambient = new Shadow(Color.unsafeOpacity(color, ambientOpacity), 0, 0, 2);
+        const directional = new Shadow(Color.unsafeOpacity(color, directionalOpacity), 0, size * 0.5, size);
         return new DesignTokenMultiValue(ambient, directional);
     },
 );

--- a/packages/adaptive-ui/src/reference/layer.ts
+++ b/packages/adaptive-ui/src/reference/layer.ts
@@ -1,12 +1,12 @@
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
 import { DesignTokenType } from "../core/adaptive-design-tokens.js";
 import { Palette, PaletteDirectionValue } from "../core/color/palette.js";
-import { ColorRecipeParams, InteractiveSwatchSet } from "../core/color/recipe.js";
+import { ColorRecipeParams, InteractivePaintSet } from "../core/color/recipe.js";
 import { deltaSwatch, deltaSwatchSet } from "../core/color/recipes/index.js";
-import { Swatch } from "../core/color/swatch.js";
+import { Color } from "../core/color/color.js";
 import { luminanceSwatch } from "../core/color/utilities/luminance-swatch.js";
 import { StyleProperty } from "../core/modules/types.js";
-import { createTokenNonCss, createTokenRecipe, createTokenSwatch } from "../core/token-helpers.js";
+import { createTokenColor, createTokenNonCss, createTokenRecipe } from "../core/token-helpers.js";
 import { createTokenColorRecipe, createTokenColorSet, createTokenDelta } from "../core/token-helpers-color.js";
 import { InteractiveState } from "../core/types.js";
 import { fillColor } from "./color.js";
@@ -78,7 +78,7 @@ export const layerFillBaseLuminance = createTokenNonCss<number>(`${layerFillFixe
  *
  * @public
  */
-export const layerFillFixedRecipe = createTokenRecipe<number, Swatch>(
+export const layerFillFixedRecipe = createTokenRecipe<number, Color>(
     layerFillFixedName,
     StyleProperty.backgroundFill,
     (resolve: DesignTokenResolver, index: number) =>
@@ -98,7 +98,7 @@ export const layerFillFixedRecipe = createTokenRecipe<number, Swatch>(
  *
  * @public
  */
-export const layerFillFixedBase = createTokenSwatch(`${layerFillFixedName}.base`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedBase = createTokenColor(`${layerFillFixedName}.base`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, 0)
 );
@@ -111,7 +111,7 @@ export const layerFillFixedBase = createTokenSwatch(`${layerFillFixedName}.base`
  *
  * @public
  */
-export const layerFillFixedMinus1 = createTokenSwatch(`${layerFillFixedName}.minus1`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedMinus1 = createTokenColor(`${layerFillFixedName}.minus1`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, -1)
 );
@@ -124,7 +124,7 @@ export const layerFillFixedMinus1 = createTokenSwatch(`${layerFillFixedName}.min
  *
  * @public
  */
-export const layerFillFixedMinus2 = createTokenSwatch(`${layerFillFixedName}.minus2`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedMinus2 = createTokenColor(`${layerFillFixedName}.minus2`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, -2)
 );
@@ -137,7 +137,7 @@ export const layerFillFixedMinus2 = createTokenSwatch(`${layerFillFixedName}.min
  *
  * @public
  */
-export const layerFillFixedMinus3 = createTokenSwatch(`${layerFillFixedName}.minus3`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedMinus3 = createTokenColor(`${layerFillFixedName}.minus3`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, -3)
 );
@@ -150,7 +150,7 @@ export const layerFillFixedMinus3 = createTokenSwatch(`${layerFillFixedName}.min
  *
  * @public
  */
-export const layerFillFixedMinus4 = createTokenSwatch(`${layerFillFixedName}.minus4`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedMinus4 = createTokenColor(`${layerFillFixedName}.minus4`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, -4)
 );
@@ -163,7 +163,7 @@ export const layerFillFixedMinus4 = createTokenSwatch(`${layerFillFixedName}.min
  *
  * @public
  */
-export const layerFillFixedPlus1 = createTokenSwatch(`${layerFillFixedName}.plus1`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedPlus1 = createTokenColor(`${layerFillFixedName}.plus1`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, 1)
 );
@@ -176,7 +176,7 @@ export const layerFillFixedPlus1 = createTokenSwatch(`${layerFillFixedName}.plus
  *
  * @public
  */
-export const layerFillFixedPlus2 = createTokenSwatch(`${layerFillFixedName}.plus2`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedPlus2 = createTokenColor(`${layerFillFixedName}.plus2`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, 2)
 );
@@ -189,7 +189,7 @@ export const layerFillFixedPlus2 = createTokenSwatch(`${layerFillFixedName}.plus
  *
  * @public
  */
-export const layerFillFixedPlus3 = createTokenSwatch(`${layerFillFixedName}.plus3`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedPlus3 = createTokenColor(`${layerFillFixedName}.plus3`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, 3)
 );
@@ -202,7 +202,7 @@ export const layerFillFixedPlus3 = createTokenSwatch(`${layerFillFixedName}.plus
  *
  * @public
  */
-export const layerFillFixedPlus4 = createTokenSwatch(`${layerFillFixedName}.plus4`, StyleProperty.backgroundFill).withDefault(
+export const layerFillFixedPlus4 = createTokenColor(`${layerFillFixedName}.plus4`, StyleProperty.backgroundFill).withDefault(
     (resolve: DesignTokenResolver) =>
         resolve(layerFillFixedRecipe).evaluate(resolve, 4)
 );
@@ -245,8 +245,8 @@ export const layerFillDisabledDelta = createTokenDelta(layerFillInteractiveName,
  *
  * @public
  */
-export const layerFillInteractiveRecipe = createTokenColorRecipe<InteractiveSwatchSet>(layerFillInteractiveName, StyleProperty.backgroundFill,
-    (resolve: DesignTokenResolver, params?: ColorRecipeParams): InteractiveSwatchSet =>
+export const layerFillInteractiveRecipe = createTokenColorRecipe<InteractivePaintSet>(layerFillInteractiveName, StyleProperty.backgroundFill,
+    (resolve: DesignTokenResolver, params?: ColorRecipeParams): InteractivePaintSet =>
         deltaSwatchSet(
             resolve(layerPalette),
             params?.reference || resolve(fillColor),

--- a/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
+++ b/packages/adaptive-web-components/src/components/tree-item/tree-item.styles.ts
@@ -1,4 +1,4 @@
-import { Swatch } from"@adaptive-web/adaptive-ui";
+import { Color } from"@adaptive-web/adaptive-ui";
 import {
     cornerRadiusControl,
     focusStrokeThickness,
@@ -11,14 +11,14 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 import { DesignToken, DesignTokenResolver } from "@microsoft/fast-foundation";
 import { heightNumber } from "../../styles/index.js";
 
-const expandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collapse-hover").withDefault(
+const expandCollapseHover = DesignToken.create<Color>("tree-item-expand-collapse-hover").withDefault(
     (resolve: DesignTokenResolver) => {
         const recipe = resolve(neutralFillStealthRecipe);
         return recipe.evaluate(resolve, { reference: recipe.evaluate(resolve).hover }).hover as any;
     }
 );
 
-const selectedExpandCollapseHover = DesignToken.create<Swatch>("tree-item-expand-collapse-selected-hover").withDefault(
+const selectedExpandCollapseHover = DesignToken.create<Color>("tree-item-expand-collapse-selected-hover").withDefault(
     (resolve: DesignTokenResolver) => {
         const baseRecipe = resolve(neutralFillSubtleRecipe);
         const buttonRecipe = resolve(neutralFillStealthRecipe);


### PR DESCRIPTION
# Pull Request

## Description

The primary goal here is to refactor color-type design tokens to support gradients.

The secondary goal was to align design token terminology around "Color" and to subsume the opacity capability that was in "Swatch".

The "Swatch" term has been around for a while and the original meaning comes from the collection of colors (swatches) in a Palette. From a token perspective this was more confusing.

## Reviewer Notes

The bulk of the change is a rename from `Swatch` to `Color`. The `Paint` class is introduced as the parent of `Color` and eventually the parent of `Gradient`. The design token working group is missing the abstraction that both a solid color and a gradient can often be used in the same ways. This resolves that.

## Test Plan

Tested in the Designer plugin and all web apps in this project.

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.

## ⏭ Next Steps

As mentioned, the immediate next step is to add Gradient support.

Also I will rename some of the color recipes including the file name, but that felt difficult with the changes that were already in place.

There are probably some migrations to `Color` which will be further generalized to `Paint`, but I want to revisit that when the need arises to make sure I don't over index on everything being `Paint`.