### PR TITLE
Add gradient recipes

### DIFF
--- a/change/@adaptive-web-adaptive-ui-designer-core-24f1f38c-f5db-496d-9543-e3c36a258a89.json
+++ b/change/@adaptive-web-adaptive-ui-designer-core-24f1f38c-f5db-496d-9543-e3c36a258a89.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add gradient recipes",
+  "packageName": "@adaptive-web/adaptive-ui-designer-core",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@adaptive-web-adaptive-ui-f6c9b518-1e77-49ab-b7ad-6b634ac0189c.json
+++ b/change/@adaptive-web-adaptive-ui-f6c9b518-1e77-49ab-b7ad-6b634ac0189c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add gradient recipes",
+  "packageName": "@adaptive-web/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30776,6 +30776,14 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
         },
+        "node_modules/transformation-matrix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-3.0.0.tgz",
+            "integrity": "sha512-C6NlNnD6T8JqDeY4BpGznuve4d8/JlLDZLcJbnnx7gQKoyk01+uk2XYVFjBGqvNsVxJUpUwb3WZpjpdPr+05FQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/chrvadala"
+            }
+        },
         "node_modules/tree-kill": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -33345,11 +33353,13 @@
                 "@csstools/css-parser-algorithms": "^2.2.0",
                 "@csstools/css-tokenizer": "^2.1.1",
                 "change-case": "^5.4.4",
-                "culori": "^3.2.0"
+                "culori": "^3.2.0",
+                "transformation-matrix": "^3.0.0"
             },
             "devDependencies": {
                 "@figma/eslint-plugin-figma-plugins": "^0.15.0",
                 "@figma/plugin-typings": "^1.103.0",
+                "@types/culori": "^2.0.0",
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
                 "@typescript-eslint/parser": "^6.21.0",
                 "concurrently": "^7.6.0",
@@ -35235,6 +35245,7 @@
                 "@csstools/css-tokenizer": "^2.1.1",
                 "@figma/eslint-plugin-figma-plugins": "^0.15.0",
                 "@figma/plugin-typings": "^1.103.0",
+                "@types/culori": "^2.0.0",
                 "@typescript-eslint/eslint-plugin": "^6.21.0",
                 "@typescript-eslint/parser": "^6.21.0",
                 "change-case": "^5.4.4",
@@ -35243,6 +35254,7 @@
                 "esbuild": "^0.17.10",
                 "eslint": "^8.57.0",
                 "rimraf": "^3.0.2",
+                "transformation-matrix": "^3.0.0",
                 "typescript": "^4.7.0",
                 "typescript-eslint": "^7.14.1",
                 "vite": "^4.5.13",
@@ -58959,6 +58971,11 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true
+        },
+        "transformation-matrix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-3.0.0.tgz",
+            "integrity": "sha512-C6NlNnD6T8JqDeY4BpGznuve4d8/JlLDZLcJbnnx7gQKoyk01+uk2XYVFjBGqvNsVxJUpUwb3WZpjpdPr+05FQ=="
         },
         "tree-kill": {
             "version": "1.2.2",

--- a/packages/adaptive-ui-designer-core/src/registry/recipes.ts
+++ b/packages/adaptive-ui-designer-core/src/registry/recipes.ts
@@ -7,11 +7,13 @@ import {
     accentFillStealth,
     accentFillSubtle,
     accentFillSubtleInverse,
+    accentHueShiftGradientFillSubtleRest,
     accentStrokeDiscernible,
     accentStrokeReadable,
     accentStrokeSafety,
     accentStrokeStrong,
     accentStrokeSubtle,
+    accentToHighlightGradientFillSubtleRest,
     bodyFontFamily,
     bodyFontStyle,
     bodyFontWeight,
@@ -50,6 +52,9 @@ import {
     fontFamily,
     fontStyle,
     fontWeight,
+    gradientAngle,
+    gradientEndShift,
+    gradientStartShift,
     highlightBaseColor,
     highlightFillDiscernible,
     highlightFillIdeal,
@@ -212,6 +217,9 @@ const designTokens: DesignTokenStore = [
     strokeDiscernibleRestDelta,
     strokeReadableRestDelta,
     strokeStrongRestDelta,
+    gradientAngle,
+    gradientStartShift,
+    gradientEndShift,
 ];
 
 const colorTokens: DesignTokenOrGroupStore = [
@@ -276,6 +284,8 @@ const colorTokens: DesignTokenOrGroupStore = [
     neutralFillIdeal,
     neutralFillDiscernible,
     neutralFillReadable,
+    accentHueShiftGradientFillSubtleRest,
+    accentToHighlightGradientFillSubtleRest,
     // Stroke
     focusStroke,
     focusStrokeOuter,

--- a/packages/adaptive-ui-designer-figma-plugin/package.json
+++ b/packages/adaptive-ui-designer-figma-plugin/package.json
@@ -42,7 +42,8 @@
     "@csstools/css-parser-algorithms": "^2.2.0",
     "@csstools/css-tokenizer": "^2.1.1",
     "change-case": "^5.4.4",
-    "culori": "^3.2.0"
+    "culori": "^3.2.0",
+    "transformation-matrix": "^3.0.0"
   },
   "peerDependencies": {
     "@adaptive-web/adaptive-ui": "0.12.0",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@figma/eslint-plugin-figma-plugins": "^0.15.0",
     "@figma/plugin-typings": "^1.103.0",
+    "@types/culori": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "concurrently": "^7.6.0",

--- a/packages/adaptive-ui-designer-figma-plugin/src/figma/gradient.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/figma/gradient.ts
@@ -1,0 +1,179 @@
+import { Gradient, GradientStop, GradientType, LinearGradient } from "@adaptive-web/adaptive-ui";
+import { Rgb } from "culori/fn";
+import { compose, rotate, scale, translate } from "transformation-matrix";
+import { colorToRgba } from "./utility.js";
+
+// Big thanks here to Michael Yagudaev, https://github.com/yagudaev/css-gradient-to-figma
+
+export function gradientToGradientPaint(gradient: Gradient, width = 1, height = 1): GradientPaint {
+    const gradientLength = calculateLength(gradient, width, height);
+    const [sx, sy] = calculateScale(gradient);
+    const rotationAngle = calculateRotationAngle(gradient);
+    const [tx, ty] = calculateTranslationToCenter(gradient);
+    const gradientTransform = compose(
+        translate(0, 0.5),
+        scale(sx, sy),
+        rotate(rotationAngle),
+        translate(tx, ty)
+    );
+
+    let previousPosition: number | undefined = undefined;
+    const gradientPaint: GradientPaint = {
+        type: convertType(gradient.type),
+        gradientStops: gradient.stops.map((stop, index) => {
+            const position = getPosition(stop, index, gradient.stops.length, gradientLength, previousPosition);
+            previousPosition = position;
+            return {
+                position,
+                color: colorToRgba(stop.color.color as Rgb),
+            };
+        }),
+        gradientTransform: [
+            [gradientTransform.a, gradientTransform.c, gradientTransform.e],
+            [gradientTransform.b, gradientTransform.d, gradientTransform.f],
+        ],
+    };
+
+    return gradientPaint;
+}
+
+function getPosition(
+    stop: GradientStop,
+    index: number,
+    total: number,
+    gradientLength: number,
+    previousPosition = 0
+): number {
+    if (total <= 1) return 0;
+    // browsers will enforce increasing positions (red 50%, blue 0px) becomes (red 50%, blue 50%)
+    const normalize = (v: number) => Math.max(previousPosition, Math.min(1, v));
+    if (stop.position) {
+        if (stop.position.value <= 0) {
+            // TODO: add support for negative color stops, figma doesn't support it, instead we will
+            // have to scale the transform to fit the negative color stops
+            return normalize(0);
+        }
+        switch (stop.position.unit) {
+            case "%":
+                return normalize(stop.position.value);
+            case "px":
+                return normalize(stop.position.value / gradientLength);
+            default:
+                console.warn("Unsupported stop position unit: ", stop.position.unit);
+        }
+    }
+    return normalize(index / (total - 1));
+}
+
+function convertType(
+    type: GradientType
+): "GRADIENT_LINEAR" | "GRADIENT_RADIAL" | "GRADIENT_ANGULAR" {
+    switch (type) {
+        case "conic":
+            return "GRADIENT_ANGULAR";
+        case "linear":
+            return "GRADIENT_LINEAR";
+        case "radial":
+            return "GRADIENT_RADIAL";
+        default:
+            throw "unsupported gradient type";
+    }
+}
+
+function calculateRotationAngle(gradient: Gradient): number {
+    // CSS has a top-down default, figma has a right-left default when no angle is specified
+    // CSS has a default unspecified angle of 180deg, figma has a default unspecified angle of 0deg
+    const initialRotation = -Math.PI / 2.0; // math rotation with css 180deg default
+    let additionalRotation = 0.0;
+
+    // linear gradients
+    if (gradient.type === "linear") {
+        // css angle is clockwise from the y-axis, figma angles are counter-clockwise from the x-axis
+        additionalRotation = (convertCssAngle((gradient as LinearGradient).angle) + 90) % 360;
+        return degreesToRadians(additionalRotation);
+    } else if (gradient.type === "radial") {
+        // if size is 'furthers-corner' which is the default, then the rotation is 45 to reach corner
+        // any corner will do, but we will use the bottom right corner
+        // since the parser is not smart enough to know that, we just assume that for now
+        additionalRotation = 45;
+    }
+
+    return initialRotation + degreesToRadians(additionalRotation);
+}
+
+type FigmaAngle = number; // 0-360, CCW from x-axis
+type CssAngle = number; // 0-360, CW from y-axis
+
+function convertCssAngle(angle: CssAngle): FigmaAngle {
+    // positive angles only
+    angle = angle < 0 ? 360 + angle : angle;
+    // convert to CCW angle use by figma
+    angle = 360 - angle;
+    return angle % 360;
+}
+
+function calculateLength(gradient: Gradient, width: number, height: number): number {
+    if (gradient.type === "linear") {
+        // from w3c: abs(W * sin(A)) + abs(H * cos(A))
+        // https://w3c.github.io/csswg-drafts/css-images-3/#linears
+        const rads = degreesToRadians(convertCssAngle((gradient as LinearGradient).angle));
+        return Math.abs(width * Math.sin(rads)) + Math.abs(height * Math.cos(rads));
+    } else if (gradient.type === "radial") {
+        // if size is 'furthers-corner' which is the default, then the scale is sqrt(2)
+        // since the parser is not smart enough to know that, we just assume that for now
+        return Math.sqrt(2);
+    }
+    throw "unsupported gradient type";
+}
+
+function calculateScale(gradient: Gradient): [number, number] {
+    if (gradient.type === "linear") {
+        // from w3c: abs(W * sin(A)) + abs(H * cos(A))
+        // https://w3c.github.io/csswg-drafts/css-images-3/#linears
+        // W and H are unit vectors, so we can just use 1
+        const angleRad = degreesToRadians(convertCssAngle((gradient as LinearGradient).angle));
+        const scale =
+            Math.abs(Math.sin(angleRad)) +
+            Math.abs(Math.cos(angleRad));
+
+        return [1.0 / scale, 1.0 / scale];
+    } else if (gradient.type === "radial") {
+        // if size is 'furthers-corner' which is the default, then the scale is sqrt(2)
+        // since the parser is not smart enough to know that, we just assume that for now
+        const scale = 1 / Math.sqrt(2);
+        return [scale, scale];
+    }
+
+    return [1.0, 1.0];
+}
+
+function calculateTranslationToCenter(gradient: Gradient): [number, number] {
+    if (gradient.type === "linear") {
+        const angle = convertCssAngle((gradient as LinearGradient).angle);
+        if (angle === 0) {
+            return [-0.5, -1];
+        } else if (angle === 90) {
+            return [-1, -0.5];
+        } else if (angle === 180) {
+            return [-0.5, 0];
+        } else if (angle === 270) {
+            return [0, -0.5];
+        } else if (angle > 0 && angle < 90) {
+            return [-1, -1];
+        } else if (angle > 90 && angle < 180) {
+            return [-1, 0];
+        } else if (angle > 180 && angle < 270) {
+            return [0, 0];
+        } else if (angle > 270 && angle < 360) {
+            return [0, -1];
+        }
+    } else if (gradient.type === "radial") {
+        return [0, 0];
+    }
+
+    return [0, 0];
+}
+
+function degreesToRadians(degrees: number) {
+    return degrees * (Math.PI / 180);
+}

--- a/packages/adaptive-ui-designer-figma-plugin/src/figma/utility.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/figma/utility.ts
@@ -32,18 +32,18 @@ export const variantBooleanHelper = (booleanFormat: string, isTrue: boolean): st
 
 export const colorToRgb = (color: Rgb): RGB => {
     return {
-        r: color.r,
-        g: color.g,
-        b: color.b,
+        r: roundToDecimals(color.r, 6),
+        g: roundToDecimals(color.g, 6),
+        b: roundToDecimals(color.b, 6),
     };
 }
 
 export const colorToRgba = (color: Rgb): RGBA => {
     return {
-        r: color.r,
-        g: color.g,
-        b: color.b,
-        a: color.alpha || 1,
+        r: roundToDecimals(color.r, 6),
+        g: roundToDecimals(color.g, 6),
+        b: roundToDecimals(color.b, 6),
+        a: color.alpha !== undefined ? roundToDecimals(color.alpha!, 6) : 1,
     };
 }
 

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller-elements.ts
@@ -59,8 +59,8 @@ export class ElementsController {
                 let color: Color | null = null;
                 if (value instanceof Color) {
                     color = value;
-                } else {
-                    color = Color.parse((value as unknown) as string);
+                } else if (typeof value === "string" && value.startsWith("#")) {
+                    color = Color.parse(value);
                 }
                 if (color) {
                     // TODO fix this logic

--- a/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
+++ b/packages/adaptive-ui-designer-figma-plugin/src/ui/ui-controller.ts
@@ -3,7 +3,6 @@ import { FASTElement, observable } from "@microsoft/fast-element";
 import { CSSDesignToken, DesignToken, type ValuesOf } from "@microsoft/fast-foundation";
 import { Color, InteractiveState, InteractiveTokenGroup, StyleProperty, Styles } from "@adaptive-web/adaptive-ui";
 import { fillColor } from "@adaptive-web/adaptive-ui/reference";
-import { formatHex8 } from 'culori';
 import {
     AdaptiveDesignToken,
     AdaptiveDesignTokenOrGroup,
@@ -413,9 +412,7 @@ export class UIController {
             let value: any = valueOriginal;
             // let valueDebug: any;
             if (valueOriginal instanceof Color) {
-                const color = valueOriginal;
-                value = formatHex8(color.color);
-                // valueDebug = swatch.toColorString();
+                // valueDebug = valueOriginal.toString();
             } else if (typeof valueOriginal === "string") {
                 if (valueOriginal.startsWith("calc")) {
                     const ret = calc(valueOriginal as string);

--- a/packages/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/adaptive-ui-explorer/src/components/color-block.ts
@@ -7,7 +7,9 @@ import {
     accentFillSubtleControlStyles,
     accentFillSubtleInverseControlStyles,
     accentForegroundReadableControlStyles,
+    accentHueShiftGradientFillSubtleElementStyles,
     accentOutlineDiscernibleControlStyles,
+    accentToHighlightGradientFillSubtleElementStyles,
     fillColor,
     highlightFillDiscernibleControlStyles,
     highlightFillIdealControlStyles,
@@ -52,6 +54,14 @@ StyleExample;
 AppSwatch;
 
 const backplateComponents = html<ColorBlock>`
+    <app-style-example :disabledState=${x => x.disabledState} :showSwatches=${x => x.showSwatches} :styles="${x => accentHueShiftGradientFillSubtleElementStyles}">
+        Accent hue shift
+    </app-style-example>
+
+    <app-style-example :disabledState=${x => x.disabledState} :showSwatches=${x => x.showSwatches} :styles="${x => accentToHighlightGradientFillSubtleElementStyles}">
+        Accent to Highlight
+    </app-style-example>
+
     <app-style-example :disabledState=${x => x.disabledState} :showSwatches=${x => x.showSwatches} :styles="${x => accentFillIdealControlStyles}">
         Accent ideal
     </app-style-example>

--- a/packages/adaptive-ui/.mocha-jsdom.js
+++ b/packages/adaptive-ui/.mocha-jsdom.js
@@ -1,0 +1,7 @@
+// Fill in some gaps required by fast-element for testing in JSDOM
+
+import "jsdom-global/register.js";
+
+global.MutationObserver = window.MutationObserver;
+
+window.matchMedia = function() {}

--- a/packages/adaptive-ui/.mocharc.json
+++ b/packages/adaptive-ui/.mocharc.json
@@ -4,6 +4,6 @@
     "timeout": 5000,
     "spec": "dist/**/*.spec.js",
     "require": [
-        "jsdom-global/register"
+        "./.mocha-jsdom.js"
     ]
 }

--- a/packages/adaptive-ui/docs/api-report.md
+++ b/packages/adaptive-ui/docs/api-report.md
@@ -61,7 +61,7 @@ export const BorderThickness: {
 export function calculateOverlayColor(match: Color_2, background: Color_2): Rgb;
 
 // @public
-export class Color extends Paint {
+export class Color extends PaintBase {
     constructor(color: Color_2, intendedColor?: Color);
     static asOverlay(intendedColor: Color, reference: Color): Color;
     readonly color: Color_2;
@@ -127,6 +127,16 @@ export type ComponentParts = Record<string, string>;
 
 // @public
 export type Condition = BooleanCondition | StringCondition;
+
+// @public
+export class ConicGradient extends Gradient {
+    constructor(stops: GradientStop[], angle?: number);
+    readonly angle: number;
+    // (undocumented)
+    toString(): string;
+    // (undocumented)
+    readonly type: GradientType;
+}
 
 // @public
 export function contrast(a: RelativeLuminance, b: RelativeLuminance): number;
@@ -273,6 +283,12 @@ export class DesignTokenMultiValue<T extends CSSDirective | string> extends Arra
 }
 
 // @public
+export class DesignTokenMultiValuePaint extends DesignTokenMultiValue<PaintBase> implements RelativeLuminance {
+    contrast(b: RelativeLuminance): number;
+    get relativeLuminance(): number;
+}
+
+// @public
 export abstract class DesignTokenRegistry {
     static Groups: Map<string, InteractiveTokenGroup<any>>;
     static Shared: Map<string, DesignToken<any>>;
@@ -333,7 +349,8 @@ export type ElevationRecipeEvaluate = RecipeEvaluate<number, string>;
 export const Fill: {
     backgroundAndForeground: (background: InteractiveTokenGroup<Paint>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipe>) => StyleProperties;
     backgroundAndForegroundBySet: (background: InteractiveTokenGroup<Paint>, foregroundRecipe: TypedDesignToken<InteractiveColorRecipeBySet>) => StyleProperties;
-    foregroundNonInteractiveWithDisabled: (foreground: TypedCSSDesignToken<Paint>, disabled: TypedCSSDesignToken<Paint>) => StyleProperties;
+    backgroundNonInteractive: (background: TypedCSSDesignToken<Paint>, disabled?: TypedCSSDesignToken<Paint>) => StyleProperties;
+    foregroundNonInteractive: (foreground: TypedCSSDesignToken<Paint>, disabled?: TypedCSSDesignToken<Paint>) => StyleProperties;
 };
 
 // @public
@@ -349,6 +366,36 @@ export interface FocusDefinition<TParts> {
     focusTarget: StyleModuleTarget;
     resetTarget?: StyleModuleTarget;
 }
+
+// @public
+export abstract class Gradient extends PaintBase {
+    constructor(stops: GradientStop[]);
+    createCSS: () => string;
+    readonly stops: GradientStop[];
+    // (undocumented)
+    protected get stopsListCSS(): string;
+    abstract toString(): string;
+    abstract readonly type: GradientType;
+}
+
+// @public
+export type GradientStop = {
+    color: Color;
+    position: GradientStopPosition;
+    endPosition?: GradientStopPosition;
+};
+
+// @public
+export type GradientStopPosition = {
+    value: number;
+    unit: "%" | "px" | "deg";
+};
+
+// @public
+export type GradientType = "conic" | "linear" | "radial";
+
+// @beta
+export function hueShiftGradient(palette: Palette, reference: Paint, delta: number, angle?: number, startShift?: number, endShift?: number, direction?: PaletteDirection): Gradient;
 
 // @public
 export function idealColorDeltaSwatchSet(palette: Palette, reference: Paint, minContrast: number, idealColor: Color, restDelta: number, hoverDelta: number, activeDelta: number, focusDelta: number, disabledDelta: number, disabledPalette?: Palette, direction?: PaletteDirection): InteractiveColorSet;
@@ -420,6 +467,15 @@ export type InteractivityDefinition = {
 export function isDark(color: RelativeLuminance): boolean;
 
 // @public
+export class LinearGradient extends Gradient {
+    constructor(stops: GradientStop[], angle?: number);
+    readonly angle: number;
+    toString(): string;
+    // (undocumented)
+    readonly type: GradientType;
+}
+
+// @public
 export function luminanceSwatch(luminance: number): Color;
 
 // @public (undocumented)
@@ -440,9 +496,11 @@ export const Padding: {
 };
 
 // @public
-export abstract class Paint implements RelativeLuminance, CSSDirective {
+export type Paint = PaintBase | DesignTokenMultiValuePaint;
+
+// @public
+export abstract class PaintBase implements RelativeLuminance, CSSDirective {
     protected constructor(relativeLuminance: number);
-    // (undocumented)
     contrast(b: RelativeLuminance): number;
     createCSS(add: AddBehavior): ComposableStyles;
     get relativeLuminance(): number;
@@ -493,6 +551,14 @@ export interface PaletteRGBOptions {
     preserveSource: boolean;
     stepContrast: number;
     stepContrastRamp: number;
+}
+
+// @public
+export class RadialGradient extends Gradient {
+    constructor(stops: GradientStop[]);
+    toString(): string;
+    // (undocumented)
+    readonly type: GradientType;
 }
 
 // @public
@@ -766,6 +832,9 @@ export interface TokenGroup extends MakePropertyOptional<DesignTokenMetadata, "t
     name: string;
     type?: DesignTokenType;
 }
+
+// @beta
+export function twoPaletteGradient(startPalette: Palette, endPalette: Palette, reference: Paint, delta: number, angle?: number, direction?: PaletteDirection): Gradient;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TypedCSSDesignToken" because one of its declarations is marked as @internal

--- a/packages/adaptive-ui/src/core/color/color.ts
+++ b/packages/adaptive-ui/src/core/color/color.ts
@@ -1,6 +1,6 @@
 import { cssDirective } from "@microsoft/fast-element";
 import { type Color as CuloriColor, formatHex, formatRgb, modeLrgb, modeRgb, parse, type Rgb, useMode, wcagLuminance } from "culori/fn";
-import { Paint } from "./paint.js";
+import { PaintBase } from "./paint.js";
 import { calculateOverlayColor } from "./utilities/opacity.js";
 
 useMode(modeRgb);
@@ -13,7 +13,7 @@ useMode(modeLrgb);
  * @public
  */
 @cssDirective()
-export class Color extends Paint {
+export class Color extends PaintBase {
     /**
      * The underlying Color value.
      */

--- a/packages/adaptive-ui/src/core/color/gradient.spec.ts
+++ b/packages/adaptive-ui/src/core/color/gradient.spec.ts
@@ -1,0 +1,79 @@
+import chai from "chai";
+import { Color } from "./color.js";
+import { ConicGradient, GradientStop, LinearGradient, RadialGradient } from "./gradient.js";
+
+const { expect } = chai;
+
+const colorRed = Color.fromRgb(1, 0, 0);
+const colorGreen = Color.fromRgb(0, 1, 0);
+const colorBlue = Color.fromRgb(0, 0, 1);
+
+describe("Gradient", () => {
+    it("should create a ConicGradient", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "deg" } },
+            { color: colorBlue, position: { value: 360, unit: "deg" } },
+        ];
+        const gradient = new ConicGradient(stops, 44);
+
+        expect(gradient).to.be.instanceof(ConicGradient);
+        expect(gradient.toString()).to.equal("conic-gradient(from 44deg, #ff0000 0deg, #0000ff 360deg)");
+    });
+
+    it("should create a LinearGradient", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "%" } },
+            { color: colorBlue, position: { value: 1, unit: "%" } },
+        ];
+        const gradient = new LinearGradient(stops, 44);
+
+        expect(gradient).to.be.instanceof(LinearGradient);
+        expect(gradient.toString()).to.equal("linear-gradient(44deg, #ff0000 0%, #0000ff 100%)");
+    });
+
+    it("should create a RadialGradient", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "%" } },
+            { color: colorBlue, position: { value: 1, unit: "%" } },
+        ];
+        const gradient = new RadialGradient(stops);
+
+        expect(gradient).to.be.instanceof(RadialGradient);
+        expect(gradient.toString()).to.equal("radial-gradient(#ff0000 0%, #0000ff 100%)");
+    });
+
+    it("should throw an error for a Gradient with one stop", () => {
+        const stops: GradientStop[] = [
+            { color: colorGreen, position: { value: 0, unit: "%" } },
+        ];
+
+        expect(() => new LinearGradient(stops, 44)).to.throw(Error, "A Gradient must have at least two stops");
+    });
+
+    it("should throw an error for a ConicGradient with invalid positions", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "%" } },
+            { color: colorBlue, position: { value: 360, unit: "px" } },
+        ];
+
+        expect(() => new ConicGradient(stops, 44)).to.throw(Error, "All stop positions must have a unit of 'deg'");
+    });
+
+    it("should throw an error for a LinearGradient with invalid positions", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "deg" } },
+            { color: colorBlue, position: { value: 360, unit: "deg" } },
+        ];
+
+        expect(() => new LinearGradient(stops, 44)).to.throw(Error, "All stop positions must have a unit of '%' or 'px'");
+    });
+
+    it("should throw an error for a RadialGradient with invalid positions", () => {
+        const stops: GradientStop[] = [
+            { color: colorRed, position: { value: 0, unit: "deg" } },
+            { color: colorBlue, position: { value: 360, unit: "deg" } },
+        ];
+
+        expect(() => new RadialGradient(stops)).to.throw(Error, "All stop positions must have a unit of '%' or 'px'");
+    });
+});

--- a/packages/adaptive-ui/src/core/color/gradient.ts
+++ b/packages/adaptive-ui/src/core/color/gradient.ts
@@ -1,0 +1,216 @@
+import { cssDirective } from "@microsoft/fast-element";
+import { PaintBase } from "./paint.js";
+import { Color } from "./color.js";
+
+/**
+ * Represents the position of a single {@link GradientStop}.
+ *
+ * @public
+ */
+export type GradientStopPosition = {
+    /**
+     * The value of the gradient stop position.
+     */
+    value: number;
+
+    /**
+     * The unit of the gradient stop position.
+     *
+     * @remarks
+     * Percentage values are represented as a decimal value between 0 and 1.
+     * "deg" is valid for conic gradient stops only.
+     */
+    unit: "%" | "px" | "deg";
+};
+
+/**
+ * Represents a single {@link Color} stop on a {@link Gradient}.
+ *
+ * @public
+ */
+export type GradientStop = {
+    /**
+     * The {@link Color} at this gradient stop.
+     */
+    color: Color,
+
+    /**
+     * The position of the start of the gradient stop.
+     */
+    position: GradientStopPosition,
+
+    /**
+     * The position of the end of the gradient stop.
+     */
+    endPosition?: GradientStopPosition,
+};
+
+/**
+ * Supported gradient types.
+ *
+ * @public
+ */
+export type GradientType = "conic" | "linear" | "radial";
+
+/**
+ * Represents a gradient.
+ *
+ * @public
+ */
+export abstract class Gradient extends PaintBase {
+    /**
+     * The type of gradient.
+     */
+    public abstract readonly type: GradientType;
+
+    /**
+     * The stops on the gradient.
+     */
+    public readonly stops: GradientStop[];
+
+    /**
+     * Creates a new Gradient.
+     */
+    constructor(stops: GradientStop[]) {
+        if (stops.length < 2) {
+            throw new Error("A Gradient must have at least two stops");
+        }
+
+        // TODO, assumes the stops are equivalent luminance
+        super(stops[0].color.relativeLuminance);
+
+        this.stops = stops;
+    }
+
+    protected get stopsListCSS() {
+        function getPosition(position: GradientStopPosition): string {
+            if (position.unit === "%") {
+                return (position.value * 100).toFixed(0) + "%";
+            } else {
+                return position.value + position.unit;
+            }
+        }
+
+        return this.stops.map(stop => 
+            `${stop.color.toString()} ${getPosition(stop.position)} ${stop.endPosition ? getPosition(stop.endPosition) : ""}`.trim()
+        ).join(", ");
+    }
+
+    /**
+     * Gets this gradient value as a string.
+     *
+     * @returns The gradient value in string format
+     */
+    public abstract toString(): string;
+
+    /**
+     * Gets this gradient value as a string for use in css.
+     *
+     * @returns The gradient value in a valid css string format
+     */
+    public createCSS = this.toString;
+}
+
+/**
+ * Represents a conic gradient.
+ *
+ * @public
+ */
+@cssDirective()
+export class ConicGradient extends Gradient {
+    public readonly type: GradientType = "conic";
+
+    /**
+     * The angle of the gradient in degrees.
+     */
+    public readonly angle: number;
+
+    /**
+     *
+     */
+    constructor(stops: GradientStop[], angle: number = 0) {
+        const invalidStops = stops.filter(stop => stop.position.unit !== "deg" || (stop.endPosition && stop.endPosition?.unit !== "deg"));
+        if (invalidStops.length > 0) {
+            throw new Error("All stop positions must have a unit of 'deg'");
+        }
+
+        super(stops);
+        this.angle = angle;
+    }
+
+    public toString(): string {
+        return `conic-gradient(from ${this.angle}deg, ${this.stopsListCSS})`;
+    }
+}
+
+/**
+ * Represents a linear gradient.
+ *
+ * @public
+ */
+@cssDirective()
+export class LinearGradient extends Gradient {
+    public readonly type: GradientType = "linear";
+
+    /**
+     * The angle of the gradient in degrees.
+     */
+    public readonly angle: number;
+
+    /**
+     *
+     */
+    constructor(stops: GradientStop[], angle: number = 0) {
+        const invalidStops = stops.filter(stop => 
+            (stop.position.unit !== "%" && stop.position.unit !== "px") ||
+            (stop.endPosition && stop.endPosition?.unit !== "%" && stop.endPosition?.unit !== "px"));
+        if (invalidStops.length > 0) {
+            throw new Error("All stop positions must have a unit of '%' or 'px'");
+        }
+
+        super(stops);
+        this.angle = angle;
+    }
+
+    /**
+     * Gets this gradient value as a string.
+     *
+     * @returns The gradient value in string format
+     */
+    public toString(): string {
+        return `linear-gradient(${this.angle}deg, ${this.stopsListCSS})`;
+    }
+}
+
+/**
+ * Represents a radial gradient.
+ *
+ * @public
+ */
+@cssDirective()
+export class RadialGradient extends Gradient {
+    public readonly type: GradientType = "radial";
+
+    /**
+     *
+     */
+    constructor(stops: GradientStop[]) {
+        const invalidStops = stops.filter(stop => 
+            (stop.position.unit !== "%" && stop.position.unit !== "px") ||
+            (stop.endPosition && stop.endPosition?.unit !== "%" && stop.endPosition?.unit !== "px"));
+        if (invalidStops.length > 0) {
+            throw new Error("All stop positions must have a unit of '%' or 'px'");
+        }
+
+        super(stops);
+    }
+
+    /**
+     * Gets this gradient value as a string.
+     *
+     * @returns The gradient value in string format
+     */
+    public toString(): string {
+        return `radial-gradient(${this.stopsListCSS})`;
+    }
+}

--- a/packages/adaptive-ui/src/core/color/index.ts
+++ b/packages/adaptive-ui/src/core/color/index.ts
@@ -1,6 +1,7 @@
 export * from "./recipes/index.js";
 export * from "./utilities/index.js";
 export * from "./color.js";
+export * from "./gradient.js";
 export * from "./paint.js";
 export * from "./palette-base.js";
 export * from "./palette-okhsl.js";

--- a/packages/adaptive-ui/src/core/color/paint.ts
+++ b/packages/adaptive-ui/src/core/color/paint.ts
@@ -1,14 +1,15 @@
 import { AddBehavior, ComposableStyles, CSSDirective } from "@microsoft/fast-element";
+import { DesignTokenMultiValue } from "../adaptive-design-tokens.js";
 import { contrast, RelativeLuminance } from "./utilities/relative-luminance.js";
 
 /**
  * Abstract representation of a value which can be used to paint a style like a fill or border.
  *
- * See {@link Color} for concrete implementation.
+ * See {@link Color} of {@link Gradient} for concrete implementations.
  *
  * @public
  */
-export abstract class Paint implements RelativeLuminance, CSSDirective {
+export abstract class PaintBase implements RelativeLuminance, CSSDirective {
     readonly #relativeLuminance: number;
 
     /**
@@ -36,7 +37,38 @@ export abstract class Paint implements RelativeLuminance, CSSDirective {
         return this.#relativeLuminance;
     }
 
+    /**
+     * {@inheritdoc RelativeLuminance.contrast}
+     */
     public contrast(b: RelativeLuminance): number {
         return contrast(this, b);
     }
 }
+
+/**
+ * A design token value for paint purposes which can have multiple values, like `background`.
+ *
+ * @public
+ */
+export class DesignTokenMultiValuePaint extends DesignTokenMultiValue<PaintBase> implements RelativeLuminance {
+    /**
+     * {@inheritdoc RelativeLuminance.relativeLuminance}
+     */
+    public get relativeLuminance(): number {
+        return this[0].relativeLuminance;
+    }
+
+    /**
+     * {@inheritdoc RelativeLuminance.contrast}
+     */
+    public contrast(b: RelativeLuminance): number {
+        return contrast(this, b);
+    }
+}
+
+/**
+ * The type of a Paint token value.
+ *
+ * @public
+ */
+export type Paint = PaintBase | DesignTokenMultiValuePaint;

--- a/packages/adaptive-ui/src/core/color/recipes/hue-shift-gradient.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/hue-shift-gradient.ts
@@ -1,0 +1,58 @@
+import { clampChroma, modeOkhsl, modeRgb, useMode} from "culori/fn";
+import { Gradient, GradientStop, LinearGradient } from "../gradient.js";
+import { Paint } from "../paint.js";
+import { Palette, PaletteDirection } from "../palette.js";
+import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
+import { Color } from "../color.js";
+
+const okhsl = useMode(modeOkhsl);
+const rgb = useMode(modeRgb);
+
+/**
+ * Color algorithm for a gradient with the source palette in the middle and the hue shifted for the start and end.
+ *
+ * @param palette - The Palette used for the base of the hue shift
+ * @param reference - The reference color
+ * @param delta - The offset from the `reference`
+ * @param angle - The angle of the gradient
+ * @param startShift - The amount and direction of the hue shift at the start
+ * @param endShift - The amount and direction of the hue shift at the end
+ * @param direction - The direction the delta moves on the palettes, defaults to {@link directionByIsDark} based on `reference`
+ * @returns The Gradient
+ * 
+ * @beta
+ */
+export function hueShiftGradient(
+    palette: Palette,
+    reference: Paint,
+    delta: number,
+    angle?: number,
+    startShift: number = -15,
+    endShift: number = 15,
+    direction: PaletteDirection = directionByIsDark(reference)
+): Gradient {
+    const centerColor = palette.delta(reference, delta, direction);
+    const centerHsl = okhsl(centerColor.color);
+    const startAdjust = centerHsl.h! + startShift;
+    const startHsl = Object.assign({}, centerHsl, {h: startAdjust < 0 ? 360 + startAdjust : startAdjust});
+    const startColor = Color.from(rgb(clampChroma(startHsl, "okhsl")));
+    const endAdjust = centerHsl.h! + endShift;
+    const endHsl = Object.assign({}, centerHsl, {h: endAdjust > 360 ? endAdjust - 360 : endAdjust});
+    const endColor = Color.from(rgb(clampChroma(endHsl, "okhsl")));
+
+    const stops: GradientStop[] = [
+        {
+            color: startColor,
+            position: { value: 0, unit: "%" },
+        },
+        {
+            color: centerColor,
+            position: { value: 0.5, unit: "%" },
+        },
+        {
+            color: endColor,
+            position: { value: 1, unit: "%" },
+        },
+    ];
+    return new LinearGradient(stops, angle);
+}

--- a/packages/adaptive-ui/src/core/color/recipes/index.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/index.ts
@@ -4,4 +4,6 @@ export * from "./contrast-and-delta-swatch-set.js";
 export * from "./contrast-swatch.js";
 export * from "./delta-swatch-set.js";
 export * from "./delta-swatch.js";
+export * from "./hue-shift-gradient.js";
 export * from "./ideal-color-delta-swatch-set.js";
+export * from "./two-palette-gradient.js";

--- a/packages/adaptive-ui/src/core/color/recipes/two-palette-gradient.ts
+++ b/packages/adaptive-ui/src/core/color/recipes/two-palette-gradient.ts
@@ -1,0 +1,41 @@
+import { Gradient, GradientStop, LinearGradient } from "../gradient.js";
+import { Paint } from "../paint.js";
+import { Palette, PaletteDirection } from "../palette.js";
+import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
+
+/**
+ * Color algorithm for a gradient between two colors.
+ *
+ * @param startPalette - The Palette used for the start of the gradient
+ * @param endPalette - The Palette used for the end of the gradient
+ * @param reference - The reference color
+ * @param delta - The offset from the `reference`
+ * @param angle - The angle of the gradient
+ * @param direction - The direction the delta moves on the palettes, defaults to {@link directionByIsDark} based on `reference`
+ * @returns The Gradient
+ * 
+ * @beta
+ */
+export function twoPaletteGradient(
+    startPalette: Palette,
+    endPalette: Palette,
+    reference: Paint,
+    delta: number,
+    angle?: number,
+    direction: PaletteDirection = directionByIsDark(reference)
+): Gradient {
+    const startColor = startPalette.delta(reference, delta, direction);
+    const endColor = endPalette.delta(reference, delta, direction);
+
+    const stops: GradientStop[] = [
+        {
+            color: startColor,
+            position: { value: 0, unit: "%" },
+        },
+        {
+            color: endColor,
+            position: { value: 1, unit: "%" },
+        },
+    ];
+    return new LinearGradient(stops, angle);
+}

--- a/packages/adaptive-ui/src/core/modules/css.ts
+++ b/packages/adaptive-ui/src/core/modules/css.ts
@@ -10,7 +10,7 @@ import { StyleProperty } from "./types.js";
 export const stylePropertyToCssProperty = (usage: StyleProperty): string => {
     switch (usage) {
         case StyleProperty.backgroundFill:
-            return "background-color";
+            return "background";
         case StyleProperty.foregroundFill:
             return "color";
         case StyleProperty.borderFillTop:

--- a/packages/adaptive-ui/src/core/modules/styles.ts
+++ b/packages/adaptive-ui/src/core/modules/styles.ts
@@ -109,9 +109,25 @@ export const Fill = {
         };
     },
 
-    foregroundNonInteractiveWithDisabled: function(
+    backgroundNonInteractive: function(
+        background: TypedCSSDesignToken<Paint>,
+        disabled?: TypedCSSDesignToken<Paint>,
+    ): StyleProperties {
+        return {
+            backgroundFill: {
+                name: `${background.name}-value`,
+                rest: background,
+                hover: background,
+                active: background,
+                focus: background,
+                disabled: disabled || background,
+            } as InteractiveTokenGroup<Paint>,
+        }
+    },
+
+    foregroundNonInteractive: function(
         foreground: TypedCSSDesignToken<Paint>,
-        disabled: TypedCSSDesignToken<Paint>,
+        disabled?: TypedCSSDesignToken<Paint>,
     ): StyleProperties {
         return {
             foregroundFill: {
@@ -120,7 +136,7 @@ export const Fill = {
                 hover: foreground,
                 active: foreground,
                 focus: foreground,
-                disabled,
+                disabled : disabled || foreground,
             } as InteractiveTokenGroup<Paint>,
         }
     }

--- a/packages/adaptive-ui/src/core/shadow/index.ts
+++ b/packages/adaptive-ui/src/core/shadow/index.ts
@@ -58,7 +58,7 @@ export type ShadowValue = Shadow | DesignTokenMultiValue<Shadow> | string;
 /**
  * Creates a DesignToken that can be used for Shadow value.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */

--- a/packages/adaptive-ui/src/core/token-helpers-color.ts
+++ b/packages/adaptive-ui/src/core/token-helpers-color.ts
@@ -23,7 +23,7 @@ import { InteractiveState, InteractiveTokenGroup } from "./types.js";
 /**
  * Creates a DesignToken that can be used for interactive color recipe deltas.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param state - The state for the recipe delta value, or a custom identifier in camelCase.
  * @param value - The value for the recipe delta.
  *
@@ -40,7 +40,7 @@ export function createTokenDelta(
 /**
  * Creates a DesignToken that can be used for color recipe minimum contrast.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param value - The value for the recipe minimum contrast.
  *
  * @public
@@ -55,7 +55,7 @@ export function createTokenMinContrast(
 /**
  * Creates a DesignToken that can be used for a color recipe, optionally referencing a context color.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  * @param evaluate - The function to call when the derived token needs to be evaluated.
  *
@@ -74,7 +74,7 @@ export function createTokenColorRecipe<T = Paint>(
 /**
  * Creates a DesignToken that can be used for a color recipe, referencing an interactive color set for context.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  * @param evaluate - The function to call when the derived token needs to be evaluated.
  *
@@ -94,7 +94,7 @@ export function createTokenColorRecipeBySet<T = Paint>(
  * Creates a DesignToken that can be used for a color recipe that works with different {@link Palette}s.
  * Use in conjunction with {@link createTokenColorRecipeWithPalette}.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  * @param evaluate - The function to call when the derived token needs to be evaluated.
  *

--- a/packages/adaptive-ui/src/core/token-helpers.ts
+++ b/packages/adaptive-ui/src/core/token-helpers.ts
@@ -24,7 +24,7 @@ export const { createTyped } = TypedCSSDesignToken;
 /**
  * Creates a DesignToken that can be used for color value.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @public
@@ -36,7 +36,7 @@ export function createTokenColor(name: string, intendedFor?: StyleProperty | Sty
 /**
  * Creates a DesignToken that can be used by other DesignTokens, but not directly in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param type - The allowed types for the token value.
  *
  * @public
@@ -48,7 +48,7 @@ export function createTokenNonCss<T>(name: string, type: DesignTokenType, intend
 /**
  * Creates a DesignToken that can be used for a recipe.
  *
- * @param baseName - The base token name in `css-identifier` casing.
+ * @param baseName - The base token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  * @param evaluate - The function to call when the derived token needs to be evaluated.
  *
@@ -67,7 +67,7 @@ export function createTokenRecipe<TParam, TResult>(
 /**
  * Creates a DesignToken that can be used for thickness, sizes, and other dimension values in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @public
@@ -79,7 +79,7 @@ export function createTokenDimension(name: string, intendedFor?: StyleProperty |
 /**
  * Creates a DesignToken that can be used for typography font family in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -90,7 +90,7 @@ export function createTokenFontFamily(name: string): TypedCSSDesignToken<string>
 /**
  * Creates a DesignToken that can be used for typography font size in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -101,7 +101,7 @@ export function createTokenFontSize(name: string): TypedCSSDesignToken<string> {
 /**
  * Creates a DesignToken that can be used for typography font style (normal, italic) in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -112,7 +112,7 @@ export function createTokenFontStyle(name: string): TypedCSSDesignToken<string> 
 /**
  * Creates a DesignToken that can be used for typography font variations in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -123,7 +123,7 @@ export function createTokenFontVariations(name: string): TypedCSSDesignToken<str
 /**
  * Creates a DesignToken that can be used for typography font weight in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -134,7 +134,7 @@ export function createTokenFontWeight(name: string): TypedCSSDesignToken<number>
 /**
  * Creates a DesignToken that can be used for typography line height in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  *
  * @public
  */
@@ -145,7 +145,7 @@ export function createTokenLineHeight(name: string): TypedCSSDesignToken<string>
 /**
  * Creates a DesignToken that can be used for number value.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @public
@@ -157,7 +157,7 @@ export function createTokenNumber(name: string, intendedFor?: StyleProperty | St
 /**
  * Creates a DesignToken for number values that can be used by other DesignTokens, but not directly in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @public
@@ -169,7 +169,7 @@ export function createTokenNumberNonStyling(name: string, intendedFor?: StylePro
 /**
  * Creates a DesignToken that can be used as a paint treatment (background, foreground, border, etc.) in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @remarks
@@ -184,7 +184,7 @@ export function createTokenPaint(name: string, intendedFor?: StyleProperty | Sty
 /**
  * Creates a DesignToken that can be used as a color in styles.
  *
- * @param name - The token name in `css-identifier` casing.
+ * @param name - The token name in `dotted.camelCase` casing.
  * @param intendedFor - The style properties where this token is intended to be used.
  *
  * @public

--- a/packages/adaptive-ui/src/core/types.ts
+++ b/packages/adaptive-ui/src/core/types.ts
@@ -1,8 +1,14 @@
 import type { DesignTokenMetadata, DesignTokenType, TypedCSSDesignToken } from "./adaptive-design-tokens.js";
 import { StyleProperty } from "./modules/types.js";
 
+/**
+ * @public
+ */
 export type MakePropertyOptional<T, K extends keyof T> = Omit<T, K> & { [P in K]?: T[P] };
 
+/**
+ * @public
+ */
 export type MakePropertyRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 /**

--- a/packages/adaptive-ui/src/reference/experimental.ts
+++ b/packages/adaptive-ui/src/reference/experimental.ts
@@ -1,0 +1,77 @@
+import { DesignTokenResolver } from "@microsoft/fast-foundation";
+import { createTokenNumber, createTokenPaint } from "../core/token-helpers.js";
+import { hueShiftGradient } from "../core/color/recipes/hue-shift-gradient.js";
+import { twoPaletteGradient } from "../core/color/recipes/two-palette-gradient.js";
+import { Fill, Styles } from "../core/modules/styles.js";
+import { StyleProperty } from "../core/modules/types.js";
+import { accentStrokeSafety, fillColor, fillSubtleRestDelta, neutralFillSubtle } from "./color.js";
+import { accentPalette, highlightPalette } from "./palette.js";
+import { densityBorderStyles } from "./util.js";
+
+/**
+ * @beta
+ */
+export const gradientAngle = createTokenNumber("color.gradient.angle").withDefault(180);
+// css is strange, if you provide the rotation, 180deg is the same as if it was not provided (not 0).
+
+/**
+ * @beta
+ */
+export const gradientStartShift = createTokenNumber("color.gradient.startShift").withDefault(15);
+
+/**
+ * @beta
+ */
+export const gradientEndShift = createTokenNumber("color.gradient.endShift").withDefault(15);
+
+/**
+ * @beta
+ */
+export const accentHueShiftGradientFillSubtleRest = createTokenPaint("color.accentHueShiftGradient.fill.subtle.rest", StyleProperty.backgroundFill).withDefault(
+    (resolve: DesignTokenResolver) => {
+        const palette = resolve(accentPalette);
+        const reference = resolve(fillColor);
+        const delta = resolve(fillSubtleRestDelta);
+        const angle = resolve(gradientAngle);
+        const startShift = resolve(gradientStartShift);
+        const endShift = resolve(gradientEndShift);
+        return hueShiftGradient(palette, reference, delta, angle, startShift, endShift);
+    }
+);
+
+/**
+ * @beta
+ */
+export const accentToHighlightGradientFillSubtleRest = createTokenPaint("color.accentToHighlightGradient.fill.subtle.rest", StyleProperty.backgroundFill).withDefault(
+    (resolve: DesignTokenResolver) => {
+        const startPalette = resolve(accentPalette);
+        const endPalette = resolve(highlightPalette);
+        const reference = resolve(fillColor);
+        const delta = resolve(fillSubtleRestDelta);
+        const angle = resolve(gradientAngle);
+        console.log("twoPaletteGradient", delta, angle);
+        return twoPaletteGradient(startPalette, endPalette, reference, delta, angle);
+    }
+);
+
+/**
+ * @beta
+ */
+export const accentHueShiftGradientFillSubtleElementStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundNonInteractive(accentHueShiftGradientFillSubtleRest, neutralFillSubtle.rest),
+        ...densityBorderStyles(accentStrokeSafety),
+    },
+    "color.accent-hue-shift-gradient-fill-subtle-element",
+);
+
+/**
+ * @beta
+ */
+export const accentToHighlightGradientFillSubtleElementStyles: Styles = Styles.fromProperties(
+    {
+        ...Fill.backgroundNonInteractive(accentToHighlightGradientFillSubtleRest, neutralFillSubtle.rest),
+        ...densityBorderStyles(accentStrokeSafety),
+    },
+    "color.accent-to-highlight-gradient-fill-subtle-element",
+);

--- a/packages/adaptive-ui/src/reference/index.ts
+++ b/packages/adaptive-ui/src/reference/index.ts
@@ -2,6 +2,7 @@ export * from "./appearance.js";
 export * from "./color.js";
 export * from "./density.js";
 export * from "./elevation.js";
+export * from "./experimental.js";
 export * from "./layer.js";
 export * from "./modules.js";
 export * from "./palette.js";

--- a/packages/adaptive-ui/src/reference/modules.ts
+++ b/packages/adaptive-ui/src/reference/modules.ts
@@ -1,6 +1,6 @@
 import { ValuesOf } from "@microsoft/fast-foundation";
-import { Fill, Styles, StyleValue } from "../core/modules/styles.js";
-import { cornerRadiusControl, cornerRadiusLayer, focusStrokeThickness, strokeThickness } from "./appearance.js";
+import { Fill, Styles } from "../core/modules/styles.js";
+import { cornerRadiusControl, cornerRadiusLayer, focusStrokeThickness } from "./appearance.js";
 import {
     accentFillDiscernible,
     accentFillIdeal,
@@ -116,6 +116,7 @@ import {
     typeRampPlus6FontVariations,
     typeRampPlus6LineHeight,
 } from "./type.js";
+import { densityBorderStyles, transparent } from "./util.js";
 
 /**
  * Style module for the shape of a control.
@@ -297,18 +298,6 @@ export const layerDensityStyles: Styles = Styles.fromProperties(
     },
     "density.layer",
 );
-
-const transparent = "transparent";
-
-// TODO: There's a bit of an overlap right now where density calculations assume a border thickness,
-// but setting the color is done elsewhere or not at all, producing inconsistent and unpredictable styling.
-const densityBorderStyles = (fillValue: StyleValue) => {
-    return {
-        borderThickness: strokeThickness,
-        borderStyle: "solid",
-        borderFill: fillValue,
-    }
-};
 
 /**
  * Convenience style module for an accent-filled stealth control (interactive).
@@ -1295,7 +1284,7 @@ export const neutralFillReadableControlStyles: Styles = Styles.fromProperties(
 export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromProperties(
     {
         ...densityBorderStyles(neutralStrokeDiscernible),
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractive(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
         backgroundFill: fillColor,
     },
     "color.neutral-outline-discernible-control",
@@ -1313,7 +1302,7 @@ export const neutralOutlineDiscernibleControlStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundReadableElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeReadable.rest, neutralStrokeReadable.disabled),
+        ...Fill.foregroundNonInteractive(neutralStrokeReadable.rest, neutralStrokeReadable.disabled),
     },
     "color.neutral-foreground-readable-element",
 );
@@ -1330,7 +1319,7 @@ export const neutralForegroundReadableElementStyles: Styles = Styles.fromPropert
  */
 export const neutralForegroundStrongElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractive(neutralStrokeStrong.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-foreground-strong-element",
 );
@@ -1347,7 +1336,7 @@ export const neutralForegroundStrongElementStyles: Styles = Styles.fromPropertie
  */
 export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeSubtle.rest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractive(neutralStrokeSubtle.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-subtle-element",
 );
@@ -1364,7 +1353,7 @@ export const neutralDividerSubtleElementStyles: Styles = Styles.fromProperties(
  */
 export const neutralDividerDiscernibleElementStyles: Styles = Styles.fromProperties(
     {
-        ...Fill.foregroundNonInteractiveWithDisabled(neutralStrokeDiscernible.rest, neutralStrokeStrong.disabled),
+        ...Fill.foregroundNonInteractive(neutralStrokeDiscernible.rest, neutralStrokeStrong.disabled),
     },
     "color.neutral-divider-discernible-element",
 );

--- a/packages/adaptive-ui/src/reference/util.ts
+++ b/packages/adaptive-ui/src/reference/util.ts
@@ -1,0 +1,23 @@
+import { StyleValue } from "../core/modules/styles.js";
+import { strokeThickness } from "./appearance.js";
+
+// Note that this file is not exported from the package.
+
+/**
+ * @internal
+ */
+export const transparent = "transparent";
+
+// TODO: There's a bit of an overlap right now where density calculations assume a border thickness,
+// but setting the color is done elsewhere or not at all, producing inconsistent and unpredictable styling.
+
+/**
+ * @internal
+ */
+export const densityBorderStyles = (fillValue: StyleValue) => {
+    return {
+        borderThickness: strokeThickness,
+        borderStyle: "solid",
+        borderFill: fillValue,
+    }
+};


### PR DESCRIPTION
I'll merge the color changes first and then rebase this.

# Pull Request

## Description

- Added Gradient token type support
- Added a couple basic gradient recipes
- Added experimental tokens and styles to the reference implementation

## Reviewer Notes

It looks large but a lot of it is just plumbing things through or for examples. I broke out a few commits to simplify somewhat.

## Test Plan

Tested in Explorer and Figma plugin

## Checklist

### General
<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using $ npm run change
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/adaptive-web/adaptive-web-components/blob/master/CONTRIBUTING.md) documentation for this project.